### PR TITLE
[CE] Installer program: merge handoff, profile fixtures, and rematerialize drift heal

### DIFF
--- a/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
+++ b/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
@@ -8,6 +8,8 @@ body:
       value: |
         This form is opened by the ChaosEngine installer when install verification fails.
         Keep the prefilled fields and add anything that is missing.
+        Attach `.chaos-engine-state/install-trace.json` as a GitHub file attachment.
+        Do not paste a machine-local absolute path as the only evidence.
   - type: input
     id: error_code
     attributes:
@@ -53,12 +55,13 @@ body:
   - type: input
     id: install_trace
     attributes:
-      label: Install trace path
+      label: Install trace (repo-relative)
+      description: Use `.chaos-engine-state/install-trace.json`. Attach that file to this issue; a private absolute path is not useful.
   - type: textarea
     id: install_trace_snippet
     attributes:
       label: Install trace snippet
-      description: Last lines from install-trace.json when present
+      description: Short redacted excerpt only. Attach the full install-trace.json file.
   - type: input
     id: status_command
     attributes:

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -611,6 +611,23 @@ class InstallReporter:
         if client_names:
             self.stream.write(f"Clients: {', '.join(client_names)}\n")
         self.stream.write(format_first_session_brief(clients=clients if isinstance(clients, dict) else {}))
+        handoff = project / ".chaos-engine-state" / "merge-handoff.md"
+        if handoff.is_file() and not handoff.is_symlink():
+            doctor = "py -3" if os.name == "nt" else "python3"
+            doctor_command = f"{doctor} .chaos-engine/install.py doctor --project ."
+            prompt = (
+                "Merge ChaosEngine host configuration using "
+                ".chaos-engine-state/merge-handoff.md. Follow "
+                "chaos-engine/references/installer-program.md deterministic merge. "
+                "Preserve every foreign handler and MCP server. Apply only the listed "
+                f"owned blocks. Then run {doctor_command} and follow each fix-next."
+            )
+            self.stream.write(self._paint("  Merge handoff", "36") + "\n")
+            self.stream.write(
+                "Core is installed. Some host files were left unchanged. Details: "
+                f"{handoff.as_posix()}\n"
+            )
+            self.stream.write(f"`{prompt}`\n")
         self.stream.write(
             format_host_onboarding_cards(
                 detected=detect_install_hosts(),

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -1430,7 +1430,14 @@ def emit_install_failure(
             )
             trace = root / ".chaos-engine-state" / "install-trace.json"
             if trace.is_file():
-                print(f"Install trace: {trace}", file=sys.stderr)
+                print(
+                    "Install trace: .chaos-engine-state/install-trace.json",
+                    file=sys.stderr,
+                )
+                print(
+                    "Attach .chaos-engine-state/install-trace.json to the GitHub issue.",
+                    file=sys.stderr,
+                )
         except OSError:
             # Best-effort diagnostics only; path resolution/stat failures must not hide the install error.
             pass
@@ -1506,7 +1513,7 @@ def emit_install_failure(
                 )
                 trace = install_trace_path(root)
                 if trace.is_file():
-                    install_trace = trace.as_posix()
+                    install_trace = ".chaos-engine-state/install-trace.json"
                     raw = trace.read_text(encoding="utf-8")
                     lines = [line.strip() for line in raw.splitlines() if line.strip()]
                     snippet = " | ".join(lines[-6:])[:400]
@@ -1545,6 +1552,7 @@ def emit_install_failure(
                 f"Core dir: {core_dir}",
                 f"install.py: {install_py}",
                 f"Install trace: {install_trace}",
+                "Attach: .chaos-engine-state/install-trace.json (GitHub file attachment)",
                 f"Install trace snippet: {install_trace_snippet}",
                 f"Platform: {sys.platform}",
                 f"Status command: {status_command}",

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -2982,7 +2982,7 @@ def merge_instruction(
     if recognized is None or interior != recognized:
         _note_merge_handoff(
             relative,
-            "markers exist but the interior is not the current or a recognized legacy owned block",
+            "markers exist but the interior is not the current owned block",
             instruction,
         )
         return original
@@ -3586,12 +3586,9 @@ def _merge_or_preserve(relative: str, original: bytes | None, builder):
             raise
         if "UTF-8" in detail or detail.startswith("invalid "):
             reason = "file is not valid UTF-8 or does not parse"
-        elif (
-            "MCP" in detail
-            or "hook" in detail
-            or "plugin" in detail
-            or "marketplace" in detail
-        ):
+        elif "plugin" in detail or "marketplace" in detail:
+            reason = "plugin marketplace entry exists with unknown ownership"
+        elif "MCP" in detail or "hook" in detail:
             reason = "same-name MCP server or hook exists with unknown ownership"
         else:
             reason = "marker count is not a single matching start and end"
@@ -4024,7 +4021,7 @@ def replace_owned_text_block(
     if recognized is None or interior != recognized:
         _note_merge_handoff(
             path,
-            "markers exist but the interior is not the current or a recognized legacy owned block",
+            "markers exist but the interior is not the current owned block",
             block,
         )
         return preserved
@@ -4252,14 +4249,6 @@ def desired_content(
             raise ValueError("invalid plugin marketplace configuration") from error
         if not isinstance(marketplace, dict) or not isinstance(marketplace.get("plugins"), list):
             raise ValueError("invalid plugin marketplace configuration")
-    existing_plugin = next(
-        (item for item in marketplace["plugins"] if isinstance(item, dict) and item.get("name") == "chaos-engine"),
-        None,
-    )
-    if existing_plugin is not None and existing_plugin != plugin_entry:
-        raise ValueError("ChaosEngine plugin marketplace collision")
-    if existing_plugin is None:
-        marketplace["plugins"].append(plugin_entry)
     caveman_entry = {
         "name": CAVEMAN_PLUGIN_NAME,
         "source": {"source": "local", "path": "./plugins/caveman"},
@@ -4269,18 +4258,6 @@ def desired_content(
         },
         "category": "Productivity",
     }
-    existing_caveman = next(
-        (
-            item
-            for item in marketplace["plugins"]
-            if isinstance(item, dict) and item.get("name") == CAVEMAN_PLUGIN_NAME
-        ),
-        None,
-    )
-    if existing_caveman is not None and existing_caveman != caveman_entry:
-        raise ValueError("Caveman plugin marketplace collision")
-    if existing_caveman is None:
-        marketplace["plugins"].append(caveman_entry)
     ponytail_entry = {
         "name": PONYTAIL_PLUGIN_NAME,
         "source": {"source": "local", "path": "./plugins/ponytail"},
@@ -4290,6 +4267,18 @@ def desired_content(
         },
         "category": "Productivity",
     }
+    existing_plugin = next(
+        (item for item in marketplace["plugins"] if isinstance(item, dict) and item.get("name") == "chaos-engine"),
+        None,
+    )
+    existing_caveman = next(
+        (
+            item
+            for item in marketplace["plugins"]
+            if isinstance(item, dict) and item.get("name") == CAVEMAN_PLUGIN_NAME
+        ),
+        None,
+    )
     existing_ponytail = next(
         (
             item
@@ -4298,13 +4287,36 @@ def desired_content(
         ),
         None,
     )
-    if existing_ponytail is not None and existing_ponytail != ponytail_entry:
-        raise ValueError("Ponytail plugin marketplace collision")
-    if existing_ponytail is None:
-        marketplace["plugins"].append(ponytail_entry)
-    after[".agents/plugins/marketplace.json"] = (
-        json.dumps(marketplace, indent=2, sort_keys=True) + "\n"
-    ).encode()
+    agents_collision = (
+        (existing_plugin is not None and existing_plugin != plugin_entry)
+        or (existing_caveman is not None and existing_caveman != caveman_entry)
+        or (existing_ponytail is not None and existing_ponytail != ponytail_entry)
+    )
+    desired_agents_marketplace = {
+        "name": marketplace.get("name", "chaos-engine-project"),
+        "plugins": [plugin_entry, caveman_entry, ponytail_entry],
+    }
+    if "interface" in marketplace:
+        desired_agents_marketplace["interface"] = marketplace["interface"]
+    if agents_collision:
+        _note_merge_handoff(
+            ".agents/plugins/marketplace.json",
+            "plugin marketplace entry exists with unknown ownership",
+            json.dumps(desired_agents_marketplace, indent=2, sort_keys=True) + "\n",
+        )
+        after[".agents/plugins/marketplace.json"] = (
+            b"" if marketplace_before is None else marketplace_before
+        )
+    else:
+        if existing_plugin is None:
+            marketplace["plugins"].append(plugin_entry)
+        if existing_caveman is None:
+            marketplace["plugins"].append(caveman_entry)
+        if existing_ponytail is None:
+            marketplace["plugins"].append(ponytail_entry)
+        after[".agents/plugins/marketplace.json"] = (
+            json.dumps(marketplace, indent=2, sort_keys=True) + "\n"
+        ).encode()
     claude_plugin_entry = {
         "name": "chaos-engine",
         "source": "./plugins/chaos-engine",
@@ -4359,7 +4371,7 @@ def desired_content(
         if existing_claude_plugin != claude_plugin_entry:
             _note_merge_handoff(
                 ".claude-plugin/marketplace.json",
-                "same-name MCP server or hook exists with unknown ownership",
+                "plugin marketplace entry exists with unknown ownership",
                 json.dumps(claude_plugin_entry, indent=2, sort_keys=True) + "\n",
             )
             after[".claude-plugin/marketplace.json"] = (
@@ -4387,10 +4399,6 @@ def desired_content(
         if existing_caveman is not None and existing_caveman != caveman_claude_entry:
             if existing_caveman.get("skills") in (None, []):
                 existing_caveman["skills"] = caveman_claude_entry["skills"]
-            if existing_caveman != caveman_claude_entry:
-                raise ValueError("Caveman Claude plugin collision")
-        if existing_caveman is None:
-            claude_marketplace["plugins"].append(caveman_claude_entry)
         ponytail_claude_entry = {
             "name": PONYTAIL_PLUGIN_NAME,
             "source": "./plugins/ponytail",
@@ -4409,13 +4417,42 @@ def desired_content(
         if existing_ponytail is not None and existing_ponytail != ponytail_claude_entry:
             if existing_ponytail.get("skills") in (None, []):
                 existing_ponytail["skills"] = ponytail_claude_entry["skills"]
-            if existing_ponytail != ponytail_claude_entry:
-                raise ValueError("Ponytail Claude plugin collision")
-        if existing_ponytail is None:
-            claude_marketplace["plugins"].append(ponytail_claude_entry)
-        after[".claude-plugin/marketplace.json"] = (
-            json.dumps(claude_marketplace, indent=2, sort_keys=True) + "\n"
-        ).encode()
+        companion_collision = (
+            (existing_caveman is not None and existing_caveman != caveman_claude_entry)
+            or (
+                existing_ponytail is not None
+                and existing_ponytail != ponytail_claude_entry
+            )
+        )
+        if companion_collision:
+            _note_merge_handoff(
+                ".claude-plugin/marketplace.json",
+                "plugin marketplace entry exists with unknown ownership",
+                json.dumps(
+                    {
+                        "plugins": [
+                            claude_plugin_entry,
+                            caveman_claude_entry,
+                            ponytail_claude_entry,
+                        ]
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+            )
+            after[".claude-plugin/marketplace.json"] = (
+                b"" if claude_marketplace_before is None else claude_marketplace_before
+            )
+            claude_marketplace = None
+        else:
+            if existing_caveman is None:
+                claude_marketplace["plugins"].append(caveman_claude_entry)
+            if existing_ponytail is None:
+                claude_marketplace["plugins"].append(ponytail_claude_entry)
+            after[".claude-plugin/marketplace.json"] = (
+                json.dumps(claude_marketplace, indent=2, sort_keys=True) + "\n"
+            ).encode()
     plugin_manifest = {
         "name": "chaos-engine",
         "version": plugin_version,
@@ -4531,23 +4568,33 @@ def desired_content(
         desired_marketplace = {
             "source": {"source": "directory", "path": "."}
         }
-        if plugin_id in enabled and enabled[plugin_id] is not True:
-            _note_merge_handoff(
-                ".claude/settings.json",
-                "same-name MCP server or hook exists with unknown ownership",
-                "",
-            )
-            after[".claude/settings.json"] = (
-                b"" if before[".claude/settings.json"] is None else before[".claude/settings.json"]
-            )
-        elif (
+        desired_settings = json.dumps(
+            {
+                **settings,
+                "enabledPlugins": {
+                    **enabled,
+                    plugin_id: True,
+                    f"caveman@{claude_marketplace_name}": True,
+                    f"ponytail@{claude_marketplace_name}": True,
+                },
+                "extraKnownMarketplaces": {
+                    **marketplaces,
+                    claude_marketplace_name: desired_marketplace,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+        settings_collision = plugin_id in enabled and enabled[plugin_id] is not True
+        marketplace_collision = (
             claude_marketplace_name in marketplaces
             and marketplaces[claude_marketplace_name] != desired_marketplace
-        ):
+        )
+        if settings_collision or marketplace_collision:
             _note_merge_handoff(
                 ".claude/settings.json",
-                "same-name MCP server or hook exists with unknown ownership",
-                "",
+                "Claude plugin enablement is not the current owned state",
+                desired_settings,
             )
             after[".claude/settings.json"] = (
                 b"" if before[".claude/settings.json"] is None else before[".claude/settings.json"]
@@ -5318,16 +5365,6 @@ def strip_known_json_ownership(
         owned_shape = replaceable_owned_server(name, servers[name], {}) or legacy_server or (
             name == "maven-tools-mcp" and servers[name] == LEGACY_MAVEN_TOOLS_SERVER
         )
-        if not owned_shape and isinstance(servers[name], dict):
-            args = servers[name].get("args")
-            if name == "chaosengine-memory" and isinstance(args, list):
-                owned_shape = args[:2] == [".chaos-engine/tool.py", "memory-mcp"]
-            elif name == "chaosengine-mempalace" and isinstance(args, list):
-                owned_shape = (
-                    ".chaos-engine/tool.py" in args and "mempalace-mcp" in args
-                )
-            elif name == "maven-tools-mcp" and isinstance(args, list):
-                owned_shape = bool(args) and args[0] == "-jar"
         wrote_entry = (
             name in recorded_servers
             and recorded_servers[name] != original_servers.get(name)

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -2919,17 +2919,136 @@ def read_file(project: Path, path: Path) -> bytes | None:
         return stream.read()
 
 
-def instruction_content(before: bytes | None, instruction: str) -> bytes:
+MERGE_HANDOFF_RELATIVE = ".chaos-engine-state/merge-handoff.md"
+_merge_handoffs: list[dict[str, str]] = []
+
+
+def consume_merge_handoffs() -> list[dict[str, str]]:
+    items = list(_merge_handoffs)
+    _merge_handoffs.clear()
+    return items
+
+
+def _note_merge_handoff(relative: str, reason: str, desired: str) -> None:
+    _merge_handoffs.append(
+        {"path": relative, "reason": reason, "desired": desired}
+    )
+
+
+def _normalized_owned_span(block: str, start: str, end: str) -> str | None:
+    if block.count(start) != 1 or block.count(end) != 1:
+        return None
+    begin = block.index(start)
+    finish = block.index(end, begin)
+    if finish < begin:
+        return None
+    return block[begin : finish + len(end)].replace("\r\n", "\n")
+
+
+def merge_instruction(
+    before: bytes | None, instruction: str, *, relative: str
+) -> bytes:
+    """Merge one marker-owned instruction file, or leave it and record a handoff."""
+    original = b"" if before is None else before
     try:
         existing = before.decode("utf-8") if before is not None else ""
-    except UnicodeDecodeError as error:
-        raise ValueError("invalid host instruction file") from error
-    if START in existing or END in existing:
-        if instruction not in existing:
-            raise ValueError("ChaosEngine instruction collision")
-        return before  # type: ignore[return-value]
-    separator = "\n" if existing and not existing.endswith("\n") else ""
-    return (existing + separator + instruction).encode()
+    except UnicodeDecodeError:
+        _note_merge_handoff(relative, "file is not valid UTF-8", instruction)
+        return original
+    start_count = existing.count(START)
+    end_count = existing.count(END)
+    if start_count == end_count == 0:
+        separator = "\n" if existing and not existing.endswith("\n") else ""
+        return (existing + separator + instruction).encode()
+    if start_count != 1 or end_count != 1:
+        _note_merge_handoff(
+            relative,
+            "marker count is not a single matching start and end",
+            instruction,
+        )
+        return original
+    begin = existing.index(START)
+    finish = existing.index(END, begin)
+    if finish < begin:
+        _note_merge_handoff(
+            relative,
+            "marker count is not a single matching start and end",
+            instruction,
+        )
+        return original
+    span_end = finish + len(END)
+    interior = existing[begin:span_end].replace("\r\n", "\n")
+    recognized = _normalized_owned_span(instruction, START, END)
+    if recognized is None or interior != recognized:
+        _note_merge_handoff(
+            relative,
+            "markers exist but the interior is not the current or a recognized legacy owned block",
+            instruction,
+        )
+        return original
+    if span_end < len(existing) and existing[span_end] == "\r":
+        span_end += 1
+    if span_end < len(existing) and existing[span_end] == "\n":
+        span_end += 1
+    block = instruction if instruction.endswith("\n") else instruction + "\n"
+    return (existing[:begin] + block + existing[span_end:]).encode()
+
+
+def instruction_content(before: bytes | None, instruction: str) -> bytes:
+    return merge_instruction(before, instruction, relative="instruction")
+
+
+
+def _handoff_doctor_command() -> str:
+    command = "py -3" if os.name == "nt" else "python3"
+    return f"{command} .chaos-engine/install.py doctor --project ."
+
+
+def write_merge_handoff(project: Path, doctor_command: str) -> Path | None:
+    """Overwrite the handoff markdown, or remove a stale one after a clean merge."""
+    target = project / MERGE_HANDOFF_RELATIVE
+    items = consume_merge_handoffs()
+    if not items:
+        if target.exists() and target.is_file() and not is_link_or_reparse(target):
+            target.unlink()
+        return None
+    lines = [
+        "# Merge handoff",
+        "",
+        "The portable core is installed. These files were left byte-identical",
+        "because deterministic merge was impossible.",
+        "",
+    ]
+    for item in items:
+        lines.extend(
+            [
+                f"## {item['path']}",
+                "",
+                f"Reason: {item['reason']}",
+                "",
+                "Desired owned block:",
+                "",
+                "```",
+                item["desired"].rstrip("\n"),
+                "```",
+                "",
+            ]
+        )
+    lines.extend(["Doctor:", "", f"`{doctor_command}`", ""])
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = ("\n".join(lines)).encode("utf-8")
+    target.write_bytes(payload)
+    return target
+
+
+def merge_handoff_prompt(doctor_command: str) -> str:
+    return (
+        "Merge ChaosEngine host configuration using "
+        ".chaos-engine-state/merge-handoff.md. Follow "
+        "chaos-engine/references/installer-program.md deterministic merge. "
+        "Preserve every foreign handler and MCP server. Apply only the listed "
+        f"owned blocks. Then run {doctor_command} and follow each fix-next."
+    )
 
 
 def legacy_owned_python_server(name: str, platform_name: str) -> dict[str, object]:
@@ -4456,10 +4575,14 @@ def desired_content(
         after["mempalace.yaml"] = mempalace_before
     after[".gitignore"] = gitignore_content(before[".gitignore"])
     for relative in ("AGENTS.md", "CLAUDE.md", "GEMINI.md"):
-        after[relative] = instruction_content(before[relative], INSTRUCTION)
-    after[".github/copilot-instructions.md"] = instruction_content(
+        after[relative] = merge_instruction(
+            before[relative], INSTRUCTION, relative=relative
+        )
+    copilot_instruction = INSTRUCTION.replace(".chaos-engine/", "../.chaos-engine/")
+    after[".github/copilot-instructions.md"] = merge_instruction(
         before[".github/copilot-instructions.md"],
-        INSTRUCTION.replace(".chaos-engine/", "../.chaos-engine/"),
+        copilot_instruction,
+        relative=".github/copilot-instructions.md",
     )
     after[".mcp.json"] = json_content(
         before[".mcp.json"], maven_runtime, managed_python, account_commands,
@@ -5308,6 +5431,7 @@ def install(
     upgrade_snapshot: dict[str, object] | None = None,
 ) -> dict[str, object]:
     project = project.resolve()
+    consume_merge_handoffs()
     if capability_policy_digest is not None and re.fullmatch(r"[0-9a-f]{64}", capability_policy_digest) is None:
         raise ValueError("ChaosEngine capability policy digest is invalid")
     receipt_path = project / RECEIPT_NAME
@@ -5372,6 +5496,7 @@ def install(
             ):
                 apply_hook_receipt(receipt, after, receipt_after)
                 write_receipt(project, receipt, raw)
+                write_merge_handoff(project, _handoff_doctor_command())
                 return receipt
             next_receipt = dict(receipt)
             next_receipt[ROLLBACK_PREVIOUS_RECEIPT] = base64.b64encode(
@@ -5414,6 +5539,7 @@ def install(
                 reconcile(project, wanted, (current, wanted))
                 next_receipt["phase"] = "installed"
                 write_receipt(project, next_receipt, next_raw)
+                write_merge_handoff(project, _handoff_doctor_command())
                 return next_receipt
             except BaseException:
                 reconcile(project, current, (current, wanted))
@@ -5427,6 +5553,7 @@ def install(
         reconcile(project, after, (before, after))
         receipt["phase"] = "installed"
         write_receipt(project, receipt, raw)
+        write_merge_handoff(project, _handoff_doctor_command())
         return receipt
 
     before = current_images(project)
@@ -5461,8 +5588,10 @@ def install(
         reconcile(project, after, (before, after))
         receipt["phase"] = "installed"
         write_receipt(project, receipt, raw)
+        write_merge_handoff(project, _handoff_doctor_command())
         return receipt
     except BaseException:
+        consume_merge_handoffs()
         reconcile(project, before, (before, after))
         remove_created_directories(project, receipt)
         if read_file(project, receipt_path) is not None:

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -3586,7 +3586,12 @@ def _merge_or_preserve(relative: str, original: bytes | None, builder):
             raise
         if "UTF-8" in detail or detail.startswith("invalid "):
             reason = "file is not valid UTF-8 or does not parse"
-        elif "MCP" in detail or "hook" in detail:
+        elif (
+            "MCP" in detail
+            or "hook" in detail
+            or "plugin" in detail
+            or "marketplace" in detail
+        ):
             reason = "same-name MCP server or hook exists with unknown ownership"
         else:
             reason = "marker count is not a single matching start and end"
@@ -4014,6 +4019,15 @@ def replace_owned_text_block(
             path, "marker count is not a single matching start and end", block
         )
         return preserved
+    interior = existing[begin:finish].replace("\r\n", "\n")
+    recognized = _normalized_owned_span(block, start, end)
+    if recognized is None or interior != recognized:
+        _note_merge_handoff(
+            path,
+            "markers exist but the interior is not the current or a recognized legacy owned block",
+            block,
+        )
+        return preserved
     if finish < len(existing) and existing[finish] == "\r":
         finish += 1
     if finish < len(existing) and existing[finish] == "\n":
@@ -4343,56 +4357,65 @@ def desired_content(
         ):
             existing_claude_plugin["version"] = plugin_version
         if existing_claude_plugin != claude_plugin_entry:
-            raise ValueError("ChaosEngine Claude marketplace collision")
-    if existing_claude_plugin is None:
+            _note_merge_handoff(
+                ".claude-plugin/marketplace.json",
+                "same-name MCP server or hook exists with unknown ownership",
+                json.dumps(claude_plugin_entry, indent=2, sort_keys=True) + "\n",
+            )
+            after[".claude-plugin/marketplace.json"] = (
+                b"" if claude_marketplace_before is None else claude_marketplace_before
+            )
+            claude_marketplace = None
+    if claude_marketplace is not None and existing_claude_plugin is None:
         claude_marketplace["plugins"].append(claude_plugin_entry)
-    caveman_claude_entry = {
-        "name": CAVEMAN_PLUGIN_NAME,
-        "source": "./plugins/caveman",
-        "description": "Ultra-compressed communication mode.",
-        "version": CAVEMAN_PLUGIN_VERSION,
-        "skills": ["./caveman"],
-    }
-    existing_caveman = next(
-        (
-            item
-            for item in claude_marketplace["plugins"]
-            if isinstance(item, dict) and item.get("name") == CAVEMAN_PLUGIN_NAME
-        ),
-        None,
-    )
-    if existing_caveman is not None and existing_caveman != caveman_claude_entry:
-        if existing_caveman.get("skills") in (None, []):
-            existing_caveman["skills"] = caveman_claude_entry["skills"]
-        if existing_caveman != caveman_claude_entry:
-            raise ValueError("Caveman Claude plugin collision")
-    if existing_caveman is None:
-        claude_marketplace["plugins"].append(caveman_claude_entry)
-    ponytail_claude_entry = {
-        "name": PONYTAIL_PLUGIN_NAME,
-        "source": "./plugins/ponytail",
-        "description": "Laziest solution that actually works.",
-        "version": PONYTAIL_PLUGIN_VERSION,
-        "skills": ["./ponytail"],
-    }
-    existing_ponytail = next(
-        (
-            item
-            for item in claude_marketplace["plugins"]
-            if isinstance(item, dict) and item.get("name") == PONYTAIL_PLUGIN_NAME
-        ),
-        None,
-    )
-    if existing_ponytail is not None and existing_ponytail != ponytail_claude_entry:
-        if existing_ponytail.get("skills") in (None, []):
-            existing_ponytail["skills"] = ponytail_claude_entry["skills"]
-        if existing_ponytail != ponytail_claude_entry:
-            raise ValueError("Ponytail Claude plugin collision")
-    if existing_ponytail is None:
-        claude_marketplace["plugins"].append(ponytail_claude_entry)
-    after[".claude-plugin/marketplace.json"] = (
-        json.dumps(claude_marketplace, indent=2, sort_keys=True) + "\n"
-    ).encode()
+    if claude_marketplace is not None:
+        caveman_claude_entry = {
+            "name": CAVEMAN_PLUGIN_NAME,
+            "source": "./plugins/caveman",
+            "description": "Ultra-compressed communication mode.",
+            "version": CAVEMAN_PLUGIN_VERSION,
+            "skills": ["./caveman"],
+        }
+        existing_caveman = next(
+            (
+                item
+                for item in claude_marketplace["plugins"]
+                if isinstance(item, dict) and item.get("name") == CAVEMAN_PLUGIN_NAME
+            ),
+            None,
+        )
+        if existing_caveman is not None and existing_caveman != caveman_claude_entry:
+            if existing_caveman.get("skills") in (None, []):
+                existing_caveman["skills"] = caveman_claude_entry["skills"]
+            if existing_caveman != caveman_claude_entry:
+                raise ValueError("Caveman Claude plugin collision")
+        if existing_caveman is None:
+            claude_marketplace["plugins"].append(caveman_claude_entry)
+        ponytail_claude_entry = {
+            "name": PONYTAIL_PLUGIN_NAME,
+            "source": "./plugins/ponytail",
+            "description": "Laziest solution that actually works.",
+            "version": PONYTAIL_PLUGIN_VERSION,
+            "skills": ["./ponytail"],
+        }
+        existing_ponytail = next(
+            (
+                item
+                for item in claude_marketplace["plugins"]
+                if isinstance(item, dict) and item.get("name") == PONYTAIL_PLUGIN_NAME
+            ),
+            None,
+        )
+        if existing_ponytail is not None and existing_ponytail != ponytail_claude_entry:
+            if existing_ponytail.get("skills") in (None, []):
+                existing_ponytail["skills"] = ponytail_claude_entry["skills"]
+            if existing_ponytail != ponytail_claude_entry:
+                raise ValueError("Ponytail Claude plugin collision")
+        if existing_ponytail is None:
+            claude_marketplace["plugins"].append(ponytail_claude_entry)
+        after[".claude-plugin/marketplace.json"] = (
+            json.dumps(claude_marketplace, indent=2, sort_keys=True) + "\n"
+        ).encode()
     plugin_manifest = {
         "name": "chaos-engine",
         "version": plugin_version,
@@ -4499,25 +4522,44 @@ def desired_content(
         marketplaces = settings.setdefault("extraKnownMarketplaces", {})
         if not isinstance(enabled, dict) or not isinstance(marketplaces, dict):
             raise ValueError("invalid Claude settings")
-        claude_marketplace_name = claude_marketplace["name"]
+        claude_marketplace_name = (
+            claude_marketplace["name"]
+            if claude_marketplace is not None
+            else "chaos-engine-project"
+        )
         plugin_id = f"chaos-engine@{claude_marketplace_name}"
-        if plugin_id in enabled and enabled[plugin_id] is not True:
-            raise ValueError("ChaosEngine Claude plugin collision")
         desired_marketplace = {
             "source": {"source": "directory", "path": "."}
         }
-        if (
+        if plugin_id in enabled and enabled[plugin_id] is not True:
+            _note_merge_handoff(
+                ".claude/settings.json",
+                "same-name MCP server or hook exists with unknown ownership",
+                "",
+            )
+            after[".claude/settings.json"] = (
+                b"" if before[".claude/settings.json"] is None else before[".claude/settings.json"]
+            )
+        elif (
             claude_marketplace_name in marketplaces
             and marketplaces[claude_marketplace_name] != desired_marketplace
         ):
-            raise ValueError("ChaosEngine Claude marketplace collision")
-        enabled[plugin_id] = True
-        enabled[f"caveman@{claude_marketplace_name}"] = True
-        enabled[f"ponytail@{claude_marketplace_name}"] = True
-        marketplaces[claude_marketplace_name] = desired_marketplace
-        after[".claude/settings.json"] = (
-            json.dumps(settings, indent=2, sort_keys=True) + "\n"
-        ).encode()
+            _note_merge_handoff(
+                ".claude/settings.json",
+                "same-name MCP server or hook exists with unknown ownership",
+                "",
+            )
+            after[".claude/settings.json"] = (
+                b"" if before[".claude/settings.json"] is None else before[".claude/settings.json"]
+            )
+        else:
+            enabled[plugin_id] = True
+            enabled[f"caveman@{claude_marketplace_name}"] = True
+            enabled[f"ponytail@{claude_marketplace_name}"] = True
+            marketplaces[claude_marketplace_name] = desired_marketplace
+            after[".claude/settings.json"] = (
+                json.dumps(settings, indent=2, sort_keys=True) + "\n"
+            ).encode()
     caveman_manifest = {
         "name": CAVEMAN_PLUGIN_NAME,
         "version": CAVEMAN_PLUGIN_VERSION,
@@ -5273,10 +5315,27 @@ def strip_known_json_ownership(
             legacy_owned_python_server(name, "nt"),
             legacy_owned_python_server(name, "posix"),
         )
-        if servers[name] in expected or legacy_server or (
+        owned_shape = replaceable_owned_server(name, servers[name], {}) or legacy_server or (
             name == "maven-tools-mcp" and servers[name] == LEGACY_MAVEN_TOOLS_SERVER
-        ):
-            del servers[name]
+        )
+        if not owned_shape and isinstance(servers[name], dict):
+            args = servers[name].get("args")
+            if name == "chaosengine-memory" and isinstance(args, list):
+                owned_shape = args[:2] == [".chaos-engine/tool.py", "memory-mcp"]
+            elif name == "chaosengine-mempalace" and isinstance(args, list):
+                owned_shape = (
+                    ".chaos-engine/tool.py" in args and "mempalace-mcp" in args
+                )
+            elif name == "maven-tools-mcp" and isinstance(args, list):
+                owned_shape = bool(args) and args[0] == "-jar"
+        wrote_entry = (
+            name in recorded_servers
+            and recorded_servers[name] != original_servers.get(name)
+            and servers[name] == recorded_servers[name]
+        )
+        if servers[name] in expected:
+            if owned_shape or wrote_entry:
+                del servers[name]
             continue
         raise ValueError(f"ChaosEngine MCP server collision: {name}")
     for name in ("sha" + "ft-memory", "mempalace"):

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -5440,7 +5440,7 @@ def upgrade_before_images(
                 project, relative, observed
             ):
                 raise ValueError(
-                    f"ChaosEngine host adapter drift detected: {project / relative}"
+                    f"ChaosEngine host adapter drift detected: {relative}"
                 )
             continue
         if relative in ROLE_ADAPTER_PATHS:
@@ -5448,7 +5448,7 @@ def upgrade_before_images(
             if isinstance(observed, bytes) and desired is not None and observed == desired:
                 continue
             raise ValueError(
-                f"ChaosEngine host adapter drift detected: {project / relative}"
+                f"ChaosEngine host adapter drift detected: {relative}"
             )
         if relative in {
             ".codex/hooks.json",
@@ -5462,7 +5462,7 @@ def upgrade_before_images(
             }[relative]
             restored[relative] = without_chaos_hooks(observed, label)
             continue
-        raise ValueError(f"ChaosEngine host adapter drift detected: {project / relative}")
+        raise ValueError(f"ChaosEngine host adapter drift detected: {relative}")
     return restored
 
 
@@ -5494,7 +5494,7 @@ def reconcile(  # noqa: MC0001 - one ordered pass retains rollback images for ev
         if relative in LIVE_PERSISTENT_PATHS:
             continue
         if not any(current == candidate[relative] for candidate in allowed):
-            raise ValueError(f"ChaosEngine host adapter drift detected: {project / relative}")
+            raise ValueError(f"ChaosEngine host adapter drift detected: {relative}")
     changed: list[tuple[str, bytes | None, bytes | None]] = []
     try:
         for relative in managed_paths():
@@ -5572,7 +5572,7 @@ def install(
                     snapshot = preflight(project)
                 except ValueError as error:
                     raise ValueError(
-                        f"ChaosEngine host adapter drift detected: {project}"
+                        "ChaosEngine host adapter drift detected"
                     ) from error
             else:
                 snapshot = upgrade_snapshot
@@ -5738,7 +5738,7 @@ def verify(
     validate_live_persistent_images(current)
     for relative in receipt_owned_paths():
         if current[relative] != after[relative]:
-            raise ValueError(f"ChaosEngine host adapter drift detected: {project / relative}")
+            raise ValueError(f"ChaosEngine host adapter drift detected: {relative}")
     return {
         "status": "healthy",
         "hookSourceCommit": receipt.get("coreCommit"),

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -3391,16 +3391,27 @@ def json_content(
     managed_python: Path | None = None,
     account_commands: dict[str, str] | None = None,
     maven_docker: tuple[str, str] | None = None,
+    relative: str = ".mcp.json",
 ) -> bytes:
+    original = b"" if before is None else before
+    desired = owned_servers(
+        maven_runtime=maven_runtime, managed_python=managed_python,
+        account_commands=account_commands,
+        maven_docker=maven_docker,
+    )
+    snippet = json.dumps({"mcpServers": desired}, indent=2, sort_keys=True) + "\n"
     try:
         value = json.loads(before.decode("utf-8")) if before is not None else {}
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise ValueError("invalid host JSON configuration") from error
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _note_merge_handoff(relative, "file is not valid UTF-8 or does not parse", snippet)
+        return original
     if not isinstance(value, dict):
-        raise ValueError("invalid host JSON configuration")
+        _note_merge_handoff(relative, "file is not valid UTF-8 or does not parse", snippet)
+        return original
     servers = value.setdefault("mcpServers", {})
     if not isinstance(servers, dict):
-        raise ValueError("invalid MCP server configuration")
+        _note_merge_handoff(relative, "file is not valid UTF-8 or does not parse", snippet)
+        return original
     if servers.get("maven-tools-mcp") == LEGACY_MAVEN_TOOLS_SERVER:
         del servers["maven-tools-mcp"]
     for legacy_name in ("sha" + "ft-memory", "mempalace"):
@@ -3408,14 +3419,15 @@ def json_content(
             legacy_name, servers[legacy_name]
         ):
             del servers[legacy_name]
-    for name, desired in owned_servers(
-        maven_runtime=maven_runtime, managed_python=managed_python,
-        account_commands=account_commands,
-        maven_docker=maven_docker,
-    ).items():
-        if name in servers and not replaceable_owned_server(name, servers[name], desired):
-            raise ValueError(f"ChaosEngine MCP server collision: {name}")
-        servers[name] = desired
+    for name, server in desired.items():
+        if name in servers and not replaceable_owned_server(name, servers[name], server):
+            _note_merge_handoff(
+                relative,
+                "same-name MCP server exists with unknown ownership",
+                snippet,
+            )
+            return original
+        servers[name] = server
     return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
 
 
@@ -3559,6 +3571,29 @@ def remove_exact_legacy_native_maven_codex_block(existing: str) -> str:
     return existing[:match.start()] + existing[match.end():]
 
 
+def _path_handed_off(relative: str) -> bool:
+    return any(item["path"] == relative for item in _merge_handoffs)
+
+
+def _merge_or_preserve(relative: str, original: bytes | None, builder):
+    """Apply a host merge; impossible files stay byte-identical and record a handoff."""
+    preserved = b"" if original is None else original
+    try:
+        return builder()
+    except ValueError as error:
+        detail = str(error)
+        if "collision" not in detail and not detail.startswith("invalid "):
+            raise
+        if "UTF-8" in detail or detail.startswith("invalid "):
+            reason = "file is not valid UTF-8 or does not parse"
+        elif "MCP" in detail or "hook" in detail:
+            reason = "same-name MCP server or hook exists with unknown ownership"
+        else:
+            reason = "marker count is not a single matching start and end"
+        _note_merge_handoff(relative, reason, "")
+        return preserved
+
+
 def codex_content(
     before: bytes | None,
     platform_name: str | None = None,
@@ -3567,10 +3602,16 @@ def codex_content(
     account_commands: dict[str, str] | None = None,
     maven_docker: tuple[str, str] | None = None,
 ) -> bytes:
+    original = b"" if before is None else before
     try:
-        existing = before.decode("utf-8") if before is not None else ""
-    except UnicodeDecodeError as error:
-        raise ValueError("invalid Codex configuration") from error
+        existing = original.decode("utf-8") if before is not None else ""
+    except UnicodeDecodeError:
+        _note_merge_handoff(
+            ".codex/config.toml",
+            "file is not valid UTF-8 or does not parse",
+            "",
+        )
+        return original
     existing = remove_known_codex_orphans(existing)
     legacy_blocks = (
         '[mcp_servers.maven-tools-mcp]\ncommand = "docker"\n'
@@ -3668,7 +3709,17 @@ def codex_content(
             if candidate in existing:
                 return existing.replace(candidate, block).encode()
         # Drifted managed block / markers wrapping non-owned keys: replace stanza (#5630).
-        return heal_replace_codex_managed_block(existing, block).encode()
+        try:
+            return heal_replace_codex_managed_block(existing, block).encode()
+        except ValueError as error:
+            if "collision" not in str(error):
+                raise
+            _note_merge_handoff(
+                ".codex/config.toml",
+                "marker count is not a single matching start and end",
+                block,
+            )
+            return original
     # Orphan CE-owned sections outside markers (esp. context7): strip then append.
     existing = strip_owned_codex_server_sections(existing)
     separator = "\n" if existing and not existing.endswith("\n") else ""
@@ -3934,7 +3985,14 @@ def without_chaos_hooks(before: bytes | None, label: str) -> bytes:
 
 
 def replace_owned_text_block(
-    existing: str, start: str, end: str, block: str, label: str
+    existing: str,
+    start: str,
+    end: str,
+    block: str,
+    label: str,
+    *,
+    relative: str | None = None,
+    original: bytes | None = None,
 ) -> bytes:
     """Upgrade one marker-owned block while preserving all foreign text."""
     start_count = existing.count(start)
@@ -3942,12 +4000,20 @@ def replace_owned_text_block(
     if start_count == end_count == 0:
         separator = "\n" if existing and not existing.endswith("\n") else ""
         return (existing + separator + block).encode()
+    preserved = original if original is not None else existing.encode()
+    path = relative or label
     if start_count != 1 or end_count != 1:
-        raise ValueError(f"ChaosEngine {label} collision")
+        _note_merge_handoff(
+            path, "marker count is not a single matching start and end", block
+        )
+        return preserved
     begin = existing.index(start)
     finish = existing.index(end, begin) + len(end)
     if finish < begin:
-        raise ValueError(f"ChaosEngine {label} collision")
+        _note_merge_handoff(
+            path, "marker count is not a single matching start and end", block
+        )
+        return preserved
     if finish < len(existing) and existing[finish] == "\r":
         finish += 1
     if finish < len(existing) and existing[finish] == "\n":
@@ -3996,10 +4062,11 @@ def strip_owned_text_block(
 
 
 def gitignore_content(before: bytes | None) -> bytes:
+    original = b"" if before is None else before
     try:
-        existing = before.decode("utf-8") if before is not None else ""
-    except UnicodeDecodeError as error:
-        raise ValueError("invalid gitignore configuration") from error
+        existing = original.decode("utf-8") if before is not None else ""
+    except UnicodeDecodeError:
+        existing = None
     block = (
         f"{GITIGNORE_START}\n"
         ".chaos-engine-runtime/\n.chaos-engine-runtime.lock\n.chaos-engine-runtime.*\n.chaos-engine-state/\n"
@@ -4039,16 +4106,28 @@ def gitignore_content(before: bytes | None) -> bytes:
         ".chaos-engine-owned-directory\n"
         f"{GITIGNORE_END}\n"
     )
+    if existing is None:
+        _note_merge_handoff(
+            ".gitignore", "file is not valid UTF-8 or does not parse", block
+        )
+        return original
     return replace_owned_text_block(
-        existing, GITIGNORE_START, GITIGNORE_END, block, "gitignore"
+        existing,
+        GITIGNORE_START,
+        GITIGNORE_END,
+        block,
+        "gitignore",
+        relative=".gitignore",
+        original=original,
     )
 
 
 def gitattributes_content(before: bytes | None) -> bytes:
+    original = b"" if before is None else before
     try:
-        existing = before.decode("utf-8") if before is not None else ""
-    except UnicodeDecodeError as error:
-        raise ValueError("invalid gitattributes configuration") from error
+        existing = original.decode("utf-8") if before is not None else ""
+    except UnicodeDecodeError:
+        existing = None
     repository_root_anchor = "/"
     block = (
         f"{GITATTRIBUTES_START}\n"
@@ -4075,8 +4154,19 @@ def gitattributes_content(before: bytes | None) -> bytes:
         f"{repository_root_anchor}.gitattributes text eol=lf\n"
         f"{GITATTRIBUTES_END}\n"
     )
+    if existing is None:
+        _note_merge_handoff(
+            ".gitattributes", "file is not valid UTF-8 or does not parse", block
+        )
+        return original
     return replace_owned_text_block(
-        existing, GITATTRIBUTES_START, GITATTRIBUTES_END, block, "gitattributes"
+        existing,
+        GITATTRIBUTES_START,
+        GITATTRIBUTES_END,
+        block,
+        "gitattributes",
+        relative=".gitattributes",
+        original=original,
     )
 
 
@@ -4339,18 +4429,30 @@ def desired_content(
     after["plugins/chaos-engine/hooks/hooks.json"] = (
         json.dumps({"hooks": {}}, indent=2, sort_keys=True) + "\n"
     ).encode()
-    after[".codex/hooks.json"] = hook_content(
-        without_chaos_hooks(before[".codex/hooks.json"], "Codex"),
-        desired_hooks,
-        "Codex",
+    after[".codex/hooks.json"] = _merge_or_preserve(
+        ".codex/hooks.json",
+        before[".codex/hooks.json"],
+        lambda: hook_content(
+            without_chaos_hooks(before[".codex/hooks.json"], "Codex"),
+            desired_hooks,
+            "Codex",
+        ),
     )
-    after[".grok/hooks/lifecycle.json"] = hook_content(
-        without_chaos_hooks(before[".grok/hooks/lifecycle.json"], "Grok"),
-        lifecycle_hooks_document("grok", managed_python=managed_python),
-        "Grok",
+    after[".grok/hooks/lifecycle.json"] = _merge_or_preserve(
+        ".grok/hooks/lifecycle.json",
+        before[".grok/hooks/lifecycle.json"],
+        lambda: hook_content(
+            without_chaos_hooks(before[".grok/hooks/lifecycle.json"], "Grok"),
+            lifecycle_hooks_document("grok", managed_python=managed_python),
+            "Grok",
+        ),
     )
-    after[".github/hooks/chaos-engine.json"] = copilot_hook_content(
-        before[".github/hooks/chaos-engine.json"], managed_node
+    after[".github/hooks/chaos-engine.json"] = _merge_or_preserve(
+        ".github/hooks/chaos-engine.json",
+        before[".github/hooks/chaos-engine.json"],
+        lambda: copilot_hook_content(
+            before[".github/hooks/chaos-engine.json"], managed_node
+        ),
     )
     after["plugins/chaos-engine/hooks/guard.py"] = (
         Path(__file__).resolve().parent / "hooks/guard.py"
@@ -4375,37 +4477,47 @@ def desired_content(
         "From the active project root, load `.chaos-engine/skills/chaos-engine/SKILL.md` before every task.\n"
         "That router decides whether to load the bundled Caveman and Ponytail companions.\n"
     ).encode()
-    claude_settings = hook_content(
-        without_chaos_hooks(before[".claude/settings.json"], "Claude"),
-        lifecycle_hooks_document("claude", managed_python=managed_python),
-        "Claude",
+    claude_settings = _merge_or_preserve(
+        ".claude/settings.json",
+        before[".claude/settings.json"],
+        lambda: hook_content(
+            without_chaos_hooks(before[".claude/settings.json"], "Claude"),
+            lifecycle_hooks_document("claude", managed_python=managed_python),
+            "Claude",
+        ),
     )
-    try:
-        settings = json.loads(claude_settings) if claude_settings is not None else {}
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise ValueError("invalid Claude settings") from error
-    if not isinstance(settings, dict):
-        raise ValueError("invalid Claude settings")
-    enabled = settings.setdefault("enabledPlugins", {})
-    marketplaces = settings.setdefault("extraKnownMarketplaces", {})
-    if not isinstance(enabled, dict) or not isinstance(marketplaces, dict):
-        raise ValueError("invalid Claude settings")
-    claude_marketplace_name = claude_marketplace["name"]
-    plugin_id = f"chaos-engine@{claude_marketplace_name}"
-    if plugin_id in enabled and enabled[plugin_id] is not True:
-        raise ValueError("ChaosEngine Claude plugin collision")
-    desired_marketplace = {
-        "source": {"source": "directory", "path": "."}
-    }
-    if claude_marketplace_name in marketplaces and marketplaces[claude_marketplace_name] != desired_marketplace:
-        raise ValueError("ChaosEngine Claude marketplace collision")
-    enabled[plugin_id] = True
-    enabled[f"caveman@{claude_marketplace_name}"] = True
-    enabled[f"ponytail@{claude_marketplace_name}"] = True
-    marketplaces[claude_marketplace_name] = desired_marketplace
-    after[".claude/settings.json"] = (
-        json.dumps(settings, indent=2, sort_keys=True) + "\n"
-    ).encode()
+    if _path_handed_off(".claude/settings.json"):
+        after[".claude/settings.json"] = claude_settings
+    else:
+        try:
+            settings = json.loads(claude_settings) if claude_settings is not None else {}
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError("invalid Claude settings") from error
+        if not isinstance(settings, dict):
+            raise ValueError("invalid Claude settings")
+        enabled = settings.setdefault("enabledPlugins", {})
+        marketplaces = settings.setdefault("extraKnownMarketplaces", {})
+        if not isinstance(enabled, dict) or not isinstance(marketplaces, dict):
+            raise ValueError("invalid Claude settings")
+        claude_marketplace_name = claude_marketplace["name"]
+        plugin_id = f"chaos-engine@{claude_marketplace_name}"
+        if plugin_id in enabled and enabled[plugin_id] is not True:
+            raise ValueError("ChaosEngine Claude plugin collision")
+        desired_marketplace = {
+            "source": {"source": "directory", "path": "."}
+        }
+        if (
+            claude_marketplace_name in marketplaces
+            and marketplaces[claude_marketplace_name] != desired_marketplace
+        ):
+            raise ValueError("ChaosEngine Claude marketplace collision")
+        enabled[plugin_id] = True
+        enabled[f"caveman@{claude_marketplace_name}"] = True
+        enabled[f"ponytail@{claude_marketplace_name}"] = True
+        marketplaces[claude_marketplace_name] = desired_marketplace
+        after[".claude/settings.json"] = (
+            json.dumps(settings, indent=2, sort_keys=True) + "\n"
+        ).encode()
     caveman_manifest = {
         "name": CAVEMAN_PLUGIN_NAME,
         "version": CAVEMAN_PLUGIN_VERSION,
@@ -4586,18 +4698,25 @@ def desired_content(
     )
     after[".mcp.json"] = json_content(
         before[".mcp.json"], maven_runtime, managed_python, account_commands,
-        maven_docker,
+        maven_docker, relative=".mcp.json",
     )
     gemini_settings = json_content(
         before[".gemini/settings.json"], maven_runtime, managed_python,
         account_commands,
-        maven_docker,
+        maven_docker, relative=".gemini/settings.json",
     )
-    after[".gemini/settings.json"] = hook_content(
-        without_chaos_hooks(gemini_settings, "Gemini"),
-        gemini_hooks_document(managed_node),
-        "Gemini",
-    )
+    if _path_handed_off(".gemini/settings.json"):
+        after[".gemini/settings.json"] = gemini_settings
+    else:
+        after[".gemini/settings.json"] = _merge_or_preserve(
+            ".gemini/settings.json",
+            before[".gemini/settings.json"],
+            lambda: hook_content(
+                without_chaos_hooks(gemini_settings, "Gemini"),
+                gemini_hooks_document(managed_node),
+                "Gemini",
+            ),
+        )
     after[".codex/config.toml"] = codex_content(
         before[".codex/config.toml"], maven_runtime=maven_runtime,
         managed_python=managed_python, account_commands=account_commands,

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -729,7 +729,6 @@ def upgrade_host_receipt_drift_needed(project: Path) -> bool:
             for token in (
                 "host adapter drift",
                 "host receipt does not match the installed core",
-                "receipt integrity drift",
                 "host receipt is missing or invalid",
                 "host anchor collision",
                 "MCP server collision",
@@ -773,7 +772,6 @@ def _is_healable_host_drift(error: BaseException) -> bool:
         token in blob
         for token in (
             "host adapter drift",
-            "receipt integrity drift",
             "host receipt does not match the installed core",
             "MCP server collision",
             "Codex configuration collision",

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -717,8 +717,13 @@ def upgrade_host_receipt_drift_needed(project: Path) -> bool:
     try:
         host_controller = load_installed_controller(target, "hosts")
         host_controller.verify(project, core_commit=core_commit)
+        preflight = getattr(host_controller, "preflight", None)
+        if callable(preflight):
+            preflight(project)
     except (OSError, RuntimeError, ValueError) as error:
         message = str(error)
+        if error.__cause__ is not None:
+            message = f"{message} {error.__cause__}"
         return any(
             token in message
             for token in (
@@ -727,6 +732,8 @@ def upgrade_host_receipt_drift_needed(project: Path) -> bool:
                 "receipt integrity drift",
                 "host receipt is missing or invalid",
                 "host anchor collision",
+                "MCP server collision",
+                "Codex configuration collision",
             )
         )
     return False
@@ -755,7 +762,28 @@ def _quarantine_state_path(state: Path, preferred: str) -> Path:
     return destination
 
 
-def quarantine_orphaned_host_receipt(project: Path, reporter=None) -> Path | None:
+def _is_healable_host_drift(error: BaseException) -> bool:
+    """True when host preflight/verify drift should quarantine and rebind (#5685)."""
+    texts = [str(error)]
+    cause = error.__cause__
+    if cause is not None:
+        texts.append(str(cause))
+    blob = " ".join(texts)
+    return any(
+        token in blob
+        for token in (
+            "host adapter drift",
+            "receipt integrity drift",
+            "host receipt does not match the installed core",
+            "MCP server collision",
+            "Codex configuration collision",
+        )
+    )
+
+
+def quarantine_orphaned_host_receipt(
+    project: Path, reporter=None, *, force: bool = False
+) -> Path | None:
     """Move orphaned/stale host receipt (+ anchors) aside for safe reinstall.
 
     Covers (#5606): phase=installed host receipt with wiped `.chaos-engine`.
@@ -763,10 +791,12 @@ def quarantine_orphaned_host_receipt(project: Path, reporter=None) -> Path | Non
     stale host receipt/anchor (coreCommit or hostToken drift / verify failure).
     Extends (#5633): deps+core present with drifted receipt/adapters (upgrade
     host-adapter drift); quarantine then rebind preserves foreign user MCP.
+    Extends (#5685): force=True after a live preflight drift so rematerialize+
+    provision can rebind instead of CE-INSTALL-FAILED.
     Quarantining lets install rematerialize core and rebind hosts without
     undocumented file surgery.
     """
-    if not wiped_runtime_recovery_needed(project):
+    if not force and not wiped_runtime_recovery_needed(project):
         return None
     receipt = project / ".chaos-engine-hosts.json"
     state = project / ".chaos-engine-state"
@@ -2917,9 +2947,15 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
                         try:
                             host_snapshot = candidate_host_controller.preflight(project)
                         except ValueError as error:
-                            raise ValueError(
-                                f"ChaosEngine host adapter drift detected (receipt integrity drift): {project}"
-                            ) from error
+                            if not _is_healable_host_drift(error):
+                                raise ValueError(
+                                    "ChaosEngine host adapter drift detected "
+                                    "(receipt integrity drift)"
+                                ) from error
+                            quarantine_orphaned_host_receipt(
+                                project, reporter=reporter, force=True
+                            )
+                            host_snapshot = None
                 if generation_mode:
                     try:
                         old_dependencies = load_dependency_controller(current)
@@ -3083,24 +3119,28 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
                     rollback_mempalace_state = mempalace_rollback_image(
                         mempalace_state_before, mempalace_state_after
                     )
-            host_controller.install(
-                project,
-                core_commit=commit,
-                capability_policy_digest=installed_manifest.get("capabilityPolicySha256"),
-                dependency_runtime=dependency_generation,
-                account_commands=account_commands,
-                maven_docker=maven_docker,
-                **(
-                    {"rollback_account_receipt": account_receipt_before}
-                    if account_mode and account_receipt_before is not None
-                    else {}
-                ),
-                **(
-                    {"rollback_mempalace_state": rollback_mempalace_state}
-                    if rollback_mempalace_state is not None else {}
-                ),
-                **({"upgrade_snapshot": host_snapshot} if host_snapshot is not None else {}),
-            )
+            host_bind = {
+                "core_commit": commit,
+                "capability_policy_digest": installed_manifest.get("capabilityPolicySha256"),
+                "dependency_runtime": dependency_generation,
+                "account_commands": account_commands,
+                "maven_docker": maven_docker,
+            }
+            if account_mode and account_receipt_before is not None:
+                host_bind["rollback_account_receipt"] = account_receipt_before
+            if rollback_mempalace_state is not None:
+                host_bind["rollback_mempalace_state"] = rollback_mempalace_state
+            try:
+                host_controller.install(
+                    project,
+                    **host_bind,
+                    **({"upgrade_snapshot": host_snapshot} if host_snapshot is not None else {}),
+                )
+            except ValueError as error:
+                if not _is_healable_host_drift(error):
+                    raise
+                quarantine_orphaned_host_receipt(project, reporter=reporter, force=True)
+                host_controller.install(project, **host_bind)
             if account_rollback_journal is not None:
                 recover_account_rollback_journal(project)
                 if account_rollback_journal.exists():

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -3581,6 +3581,8 @@ def attach_component_status(
         **cache_state,
         **capabilities["maven-tools-mcp"],
     }
+    if result.get("distribution") == "repository":
+        components["maven-tools-mcp"]["taskImpact"] = "required"
     bundle = read_bundle_options(project)
     for name in ("memory", "mempalace", "graphify"):
         if not bundle.get(name, True) and name in components:
@@ -3599,6 +3601,7 @@ def attach_component_status(
             "cliPresent": False,
         }
     result["components"] = components
+    apply_merge_handoff_fix_next(project, components)
     if any(
         item["status"] != "healthy" and item["taskImpact"] != "optional"
         for item in components.values()
@@ -4023,6 +4026,7 @@ def doctor_with_dependencies(
         )
         if not host_controller.hook_runtime_healthy(project.resolve(), managed_python):
             apply_hooks_probe_failure(result, components)
+    apply_merge_handoff_fix_next(project.resolve(), components)
     if not verify_clients:
         # Still attach activationProof from receipt when available (no live CLI probe).
         result.setdefault("activationProof", {})
@@ -4616,6 +4620,25 @@ def _component_severity(item: dict[str, object]) -> str:
     if impact == "optional":
         return "info"
     return "error"
+
+
+def apply_merge_handoff_fix_next(project: Path, components: object) -> None:
+    """Point doctor fix-next at the merge handoff instead of a blind reinstall."""
+    if not isinstance(components, dict):
+        return
+    handoff = Path(project) / ".chaos-engine-state" / "merge-handoff.md"
+    if not handoff.is_file() or is_link_or_reparse(handoff):
+        return
+    message = (
+        "Complete the agent merge using .chaos-engine-state/merge-handoff.md, "
+        "then rerun doctor."
+    )
+    for item in components.values():
+        if not isinstance(item, dict):
+            continue
+        if _component_severity(item) == "ok":
+            continue
+        item["fixNext"] = message
 
 
 def _looks_like_fix_next(detail: object) -> bool:

--- a/scripts/ci/chaos_engine_empty_project_smoke.py
+++ b/scripts/ci/chaos_engine_empty_project_smoke.py
@@ -112,6 +112,8 @@ def main(argv: list[str] | None = None) -> int:
         evidence["doctorReport"] = doctor_text
         core_ok = (project / ".chaos-engine/skills/chaos-engine/SKILL.md").is_file()
         evidence["corePresent"] = core_ok
+        evidence["distribution"] = installer.detect_distribution(project, source)
+        evidence["mergeHandoff"] = (project / ".chaos-engine-state/merge-handoff.md").is_file()
         healthy = doctor.get("status") == "healthy"
         if args.skip_tools:
             if not core_ok:

--- a/scripts/ci/chaos_gauge/agent.py
+++ b/scripts/ci/chaos_gauge/agent.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import re
 import shlex
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -17,37 +17,15 @@ _COMMIT = re.compile(r"[0-9a-f]{40}")
 
 
 def _tree_sha256(root: Path) -> str:
-    digest = hashlib.sha256()
-    root = root.resolve()
-    files = None
-    try:
-        top = subprocess.check_output(
-            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-        prefix = root.relative_to(Path(top).resolve()).as_posix()
-        spec = prefix if prefix != "." else "."
-        raw = subprocess.check_output(
-            ["git", "-C", top, "ls-files", "-z", "--", spec],
-            stderr=subprocess.DEVNULL,
-        )
-        files = [
-            Path(top) / item.decode()
-            for item in raw.split(b"\0")
-            if item
-        ]
-        files = [path for path in files if path.is_file() and not path.is_symlink()]
-    except (OSError, subprocess.CalledProcessError, ValueError):
-        files = None
-    if files is None:
-        files = [item for item in root.rglob("*") if item.is_file() and not item.is_symlink()]
-    for path in sorted(files, key=lambda item: item.relative_to(root).as_posix()):
-        relative = path.relative_to(root).as_posix()
-        if "__pycache__" in path.parts or path.suffix in {".pyc", ".pyo", ".so"}:
-            continue
-        digest.update(f"{relative}\0{hashlib.sha256(path.read_bytes()).hexdigest()}\n".encode())
-    return digest.hexdigest()
+    spec = importlib.util.spec_from_file_location(
+        "chaos_gauge_validate_experiment_tree",
+        Path(__file__).resolve().with_name("validate_experiment.py"),
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError("ChaosGauge validator could not be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._tree_sha256(root)
 
 
 class ChaosEngineCodex(Codex):

--- a/scripts/ci/chaos_gauge/agent.py
+++ b/scripts/ci/chaos_gauge/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import re
 import shlex
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -17,9 +18,33 @@ _COMMIT = re.compile(r"[0-9a-f]{40}")
 
 def _tree_sha256(root: Path) -> str:
     digest = hashlib.sha256()
-    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+    root = root.resolve()
+    files = None
+    try:
+        top = subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        prefix = root.relative_to(Path(top).resolve()).as_posix()
+        spec = prefix if prefix != "." else "."
+        raw = subprocess.check_output(
+            ["git", "-C", top, "ls-files", "-z", "--", spec],
+            stderr=subprocess.DEVNULL,
+        )
+        files = [
+            Path(top) / item.decode()
+            for item in raw.split(b"\0")
+            if item
+        ]
+        files = [path for path in files if path.is_file() and not path.is_symlink()]
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        files = None
+    if files is None:
+        files = [item for item in root.rglob("*") if item.is_file() and not item.is_symlink()]
+    for path in sorted(files, key=lambda item: item.relative_to(root).as_posix()):
         relative = path.relative_to(root).as_posix()
-        if "__pycache__" in path.parts or path.suffix == ".pyc":
+        if "__pycache__" in path.parts or path.suffix in {".pyc", ".pyo", ".so"}:
             continue
         digest.update(f"{relative}\0{hashlib.sha256(path.read_bytes()).hexdigest()}\n".encode())
     return digest.hexdigest()

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db",
+      "harnessSha256": "96335cc084cb85427f8cec8f8a443c47391d485d49f76445cca839e270d8423e",
       "treatmentSha256": {
-        "calibration": "e2dc49bbebe7d309e908815a19950c26f58e52b5ef3832c17dbae754265089df",
-        "full-pilot": "cf2e60b2d164fa1ceee084b219effc3465ae78fb54763d336ab1c62b6327f2db"
+        "calibration": "12825b457a74dec70eb750a2123cac9fbc6717fe47b25e61d54d52a979c07f6d",
+        "full-pilot": "54f8f65e467c5f260cfcc560e02858ec4a949e3e5df4aa356d8a4b837dd9d620"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "5c5b0ac306d310c35c3b4e55d657111dcd735c25b13cab2a3283ed6ab2d00e00",
+      "harnessSha256": "88ed2fa0ad83b6b13c5fe749fa56ddb6d6cc143eacf070cca2f0b8434f80e66b",
       "treatmentSha256": {
-        "calibration": "6f0310c0f65cfc31b90b25ecae0fd5d3b32d334654f4b3e4dfee46086e718679",
-        "full-pilot": "f7a387e420b6faee12ef63f2ec6009e6c2ec258b0f5489d6bf35b1786fbb5acb"
+        "calibration": "8dc83fa2879dd59f2c908d81dd87209a6c2b566c6aacc7c1c82c1b98953004cb",
+        "full-pilot": "3bd0e8ca640ba055c1087343f29daa4855b743996282fff051f69058456380dd"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "99927dc5f6fc9efd239c3eaf63ec7419983f674a16da877fc4be5e7ebb5c98b2",
+      "harnessSha256": "e7f47beca895e4d581d02d94ebc4166dd933f4be36ab78ce33b9438c2669170d",
       "treatmentSha256": {
-        "calibration": "6f2963f957523d65b9362093c51bb0f207c3e6a0cf859be792f0af59fe9ee20e",
-        "full-pilot": "d52bdd745ed263bbc7250dd51e59103fd2c84205de7a5c79c6a8c5696779ab99"
+        "calibration": "6eb7da4adeea021a0bcbd5378289c8943416d6b5d3a2be24e421648158f52dc1",
+        "full-pilot": "8958e25dc88557aed749f4caef4278a121be005599be5ca9dbbaeece6459eaa1"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "96335cc084cb85427f8cec8f8a443c47391d485d49f76445cca839e270d8423e",
+      "harnessSha256": "cfec63614a4587364520dafec27d1f4c7955826f645fdecfb12183b8d0490a4c",
       "treatmentSha256": {
-        "calibration": "12825b457a74dec70eb750a2123cac9fbc6717fe47b25e61d54d52a979c07f6d",
-        "full-pilot": "54f8f65e467c5f260cfcc560e02858ec4a949e3e5df4aa356d8a4b837dd9d620"
+        "calibration": "64fc87087c0dc4f84a168e84f08df3a91c9d0b030cd770181054914b5d851c41",
+        "full-pilot": "3b27c292c936555c9f2fbc4129fc46df5465358da2d04c4d65189ca48aad0822"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -70,8 +70,8 @@
       "harness": "chaos-engine",
       "harnessSha256": "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db",
       "treatmentSha256": {
-        "calibration": "ebd1224a842d176fc16bede548f482b556c73d1ca7202ee28275d2762e794ade",
-        "full-pilot": "0db0eedbb4385b68b48b4cf3489e3a77993635cbf381f88943cc0609b6323a99"
+        "calibration": "e2dc49bbebe7d309e908815a19950c26f58e52b5ef3832c17dbae754265089df",
+        "full-pilot": "cf2e60b2d164fa1ceee084b219effc3465ae78fb54763d336ab1c62b6327f2db"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "bccde7a66efc652e39d85a2a89c6bb2429137a78c8345a2a4a13148b203cdcee",
+      "harnessSha256": "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db",
       "treatmentSha256": {
-        "calibration": "aa325f931396e4951aaa7f5eadc0e52a6bd2f56b0d07a63347d4df965fbb9969",
-        "full-pilot": "a90c9253d0bb0c962d0876e4cca46bc6b495872ad601814103732bf7d91a7153"
+        "calibration": "ebd1224a842d176fc16bede548f482b556c73d1ca7202ee28275d2762e794ade",
+        "full-pilot": "0db0eedbb4385b68b48b4cf3489e3a77993635cbf381f88943cc0609b6323a99"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "cfec63614a4587364520dafec27d1f4c7955826f645fdecfb12183b8d0490a4c",
+      "harnessSha256": "99927dc5f6fc9efd239c3eaf63ec7419983f674a16da877fc4be5e7ebb5c98b2",
       "treatmentSha256": {
-        "calibration": "64fc87087c0dc4f84a168e84f08df3a91c9d0b030cd770181054914b5d851c41",
-        "full-pilot": "3b27c292c936555c9f2fbc4129fc46df5465358da2d04c4d65189ca48aad0822"
+        "calibration": "6f2963f957523d65b9362093c51bb0f207c3e6a0cf859be792f0af59fe9ee20e",
+        "full-pilot": "d52bdd745ed263bbc7250dd51e59103fd2c84205de7a5c79c6a8c5696779ab99"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "88ed2fa0ad83b6b13c5fe749fa56ddb6d6cc143eacf070cca2f0b8434f80e66b",
+      "harnessSha256": "bccde7a66efc652e39d85a2a89c6bb2429137a78c8345a2a4a13148b203cdcee",
       "treatmentSha256": {
-        "calibration": "8dc83fa2879dd59f2c908d81dd87209a6c2b566c6aacc7c1c82c1b98953004cb",
-        "full-pilot": "3bd0e8ca640ba055c1087343f29daa4855b743996282fff051f69058456380dd"
+        "calibration": "aa325f931396e4951aaa7f5eadc0e52a6bd2f56b0d07a63347d4df965fbb9969",
+        "full-pilot": "a90c9253d0bb0c962d0876e4cca46bc6b495872ad601814103732bf7d91a7153"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "5c5b0ac306d310c35c3b4e55d657111dcd735c25b13cab2a3283ed6ab2d00e00"
+      harness_sha256: "88ed2fa0ad83b6b13c5fe749fa56ddb6d6cc143eacf070cca2f0b8434f80e66b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "88ed2fa0ad83b6b13c5fe749fa56ddb6d6cc143eacf070cca2f0b8434f80e66b"
+      harness_sha256: "bccde7a66efc652e39d85a2a89c6bb2429137a78c8345a2a4a13148b203cdcee"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db"
-      adapter_sha256: "d309d9b17afd1145e4a6f0b2ac57f1224afa6a1f74e8015eb1429d1e93b46181"
+      harness_sha256: "96335cc084cb85427f8cec8f8a443c47391d485d49f76445cca839e270d8423e"
+      adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "bccde7a66efc652e39d85a2a89c6bb2429137a78c8345a2a4a13148b203cdcee"
+      harness_sha256: "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "99927dc5f6fc9efd239c3eaf63ec7419983f674a16da877fc4be5e7ebb5c98b2"
+      harness_sha256: "e7f47beca895e4d581d02d94ebc4166dd933f4be36ab78ce33b9438c2669170d"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -24,6 +24,6 @@ agents:
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
       harness_sha256: "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db"
-      adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
+      adapter_sha256: "d309d9b17afd1145e4a6f0b2ac57f1224afa6a1f74e8015eb1429d1e93b46181"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "cfec63614a4587364520dafec27d1f4c7955826f645fdecfb12183b8d0490a4c"
+      harness_sha256: "99927dc5f6fc9efd239c3eaf63ec7419983f674a16da877fc4be5e7ebb5c98b2"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "96335cc084cb85427f8cec8f8a443c47391d485d49f76445cca839e270d8423e"
+      harness_sha256: "cfec63614a4587364520dafec27d1f4c7955826f645fdecfb12183b8d0490a4c"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "88ed2fa0ad83b6b13c5fe749fa56ddb6d6cc143eacf070cca2f0b8434f80e66b"
+      harness_sha256: "bccde7a66efc652e39d85a2a89c6bb2429137a78c8345a2a4a13148b203cdcee"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "5c5b0ac306d310c35c3b4e55d657111dcd735c25b13cab2a3283ed6ab2d00e00"
+      harness_sha256: "88ed2fa0ad83b6b13c5fe749fa56ddb6d6cc143eacf070cca2f0b8434f80e66b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "99927dc5f6fc9efd239c3eaf63ec7419983f674a16da877fc4be5e7ebb5c98b2"
+      harness_sha256: "e7f47beca895e4d581d02d94ebc4166dd933f4be36ab78ce33b9438c2669170d"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "bccde7a66efc652e39d85a2a89c6bb2429137a78c8345a2a4a13148b203cdcee"
+      harness_sha256: "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,8 +22,8 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db"
-      adapter_sha256: "d309d9b17afd1145e4a6f0b2ac57f1224afa6a1f74e8015eb1429d1e93b46181"
+      harness_sha256: "96335cc084cb85427f8cec8f8a443c47391d485d49f76445cca839e270d8423e"
+      adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset
   - name: ShaftHQ/chaosgauge-private

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "96335cc084cb85427f8cec8f8a443c47391d485d49f76445cca839e270d8423e"
+      harness_sha256: "cfec63614a4587364520dafec27d1f4c7955826f645fdecfb12183b8d0490a4c"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "cfec63614a4587364520dafec27d1f4c7955826f645fdecfb12183b8d0490a4c"
+      harness_sha256: "99927dc5f6fc9efd239c3eaf63ec7419983f674a16da877fc4be5e7ebb5c98b2"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
       harness_sha256: "1e99853bd499b617d12b20c535de08d3f80a7aac99e3f2390cebc7db659d62db"
-      adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
+      adapter_sha256: "d309d9b17afd1145e4a6f0b2ac57f1224afa6a1f74e8015eb1429d1e93b46181"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset
   - name: ShaftHQ/chaosgauge-private

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -54,8 +54,8 @@ def _skip_tree_path(path: Path, root: Path) -> bool:
     return path.suffix in _SKIP_TREE_SUFFIXES
 
 
-def _git_tracked_files(root: Path) -> list[Path] | None:
-    """Return tracked files under root, or None when root is not this git worktree."""
+def _git_head_blobs(root: Path) -> list[tuple[str, bytes]] | None:
+    """Return HEAD blob bytes under root, independent of worktree smudge/EOL."""
     root = root.resolve()
     try:
         top = subprocess.check_output(
@@ -73,27 +73,72 @@ def _git_tracked_files(root: Path) -> list[Path] | None:
     spec = prefix if prefix != "." else "."
     try:
         raw = subprocess.check_output(
-            ["git", "-C", str(top_path), "ls-files", "-z", "--", spec],
+            ["git", "-C", str(top_path), "ls-tree", "-r", "-z", "HEAD", "--", spec],
             stderr=subprocess.DEVNULL,
         )
     except (OSError, subprocess.CalledProcessError):
         return None
-    files: list[Path] = []
+    entries: list[tuple[str, str]] = []
     for item in raw.split(b"\0"):
-        if not item:
+        if not item or b"\t" not in item:
             continue
-        path = top_path / item.decode()
-        if path.is_file() and not path.is_symlink():
-            files.append(path)
-    return files
+        meta, path_b = item.split(b"\t", 1)
+        parts = meta.split(b" ")
+        if len(parts) != 3 or parts[1] != b"blob":
+            continue
+        posix = path_b.decode()
+        if prefix != "." and posix.startswith(prefix + "/"):
+            rel = posix[len(prefix) + 1 :]
+        else:
+            rel = posix
+        entries.append((rel, parts[2].decode()))
+    if not entries:
+        return []
+    payload = b"".join(f"{sha}\n".encode() for _rel, sha in entries)
+    try:
+        dumped = subprocess.check_output(
+            ["git", "-C", str(top_path), "cat-file", "--batch"],
+            input=payload,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    blobs: list[tuple[str, bytes]] = []
+    offset = 0
+    for rel, _sha in entries:
+        newline = dumped.find(b"\n", offset)
+        if newline < 0:
+            return None
+        header = dumped[offset:newline].decode()
+        fields = header.split(" ")
+        if len(fields) < 3 or fields[1] != "blob":
+            return None
+        size = int(fields[2])
+        start = newline + 1
+        finish = start + size
+        blobs.append((rel, dumped[start:finish]))
+        offset = finish + 1
+    return blobs
 
 
 def _tree_sha256(root: Path, *, task_package: bool = False) -> str:
     digest = hashlib.sha256()
     root = root.resolve()
-    files = _git_tracked_files(root)
-    if files is None:
-        files = [path for path in root.rglob("*") if path.is_file() and not path.is_symlink()]
+    blobs = _git_head_blobs(root)
+    if blobs is not None:
+        items = blobs
+        if task_package:
+            items = [
+                (rel, data)
+                for rel, data in items
+                if Path(rel).name not in {"README.md", "trajectory.json"}
+            ]
+        for rel, data in sorted(items, key=lambda item: item[0]):
+            if _skip_tree_path(root / rel, root):
+                continue
+            digest.update(f"{rel}\0{hashlib.sha256(data).hexdigest()}\n".encode())
+        return digest.hexdigest()
+    files = [path for path in root.rglob("*") if path.is_file() and not path.is_symlink()]
     if task_package:
         files = [path for path in files if path.name not in {"README.md", "trajectory.json"}]
     for path in sorted(files, key=lambda item: item.relative_to(root).as_posix()):

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import re
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -42,13 +43,61 @@ def _file_sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+_SKIP_TREE_PARTS = frozenset({"__pycache__", ".pytest_cache"})
+_SKIP_TREE_SUFFIXES = frozenset({".pyc", ".pyo", ".so"})
+
+
+def _skip_tree_path(path: Path, root: Path) -> bool:
+    relative = path.relative_to(root)
+    if any(part in _SKIP_TREE_PARTS or part.endswith(".egg-info") for part in relative.parts):
+        return True
+    return path.suffix in _SKIP_TREE_SUFFIXES
+
+
+def _git_tracked_files(root: Path) -> list[Path] | None:
+    """Return tracked files under root, or None when root is not this git worktree."""
+    root = root.resolve()
+    try:
+        top = subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    top_path = Path(top).resolve()
+    try:
+        prefix = root.relative_to(top_path).as_posix()
+    except ValueError:
+        return None
+    spec = prefix if prefix != "." else "."
+    try:
+        raw = subprocess.check_output(
+            ["git", "-C", str(top_path), "ls-files", "-z", "--", spec],
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    files: list[Path] = []
+    for item in raw.split(b"\0"):
+        if not item:
+            continue
+        path = top_path / item.decode()
+        if path.is_file() and not path.is_symlink():
+            files.append(path)
+    return files
+
+
 def _tree_sha256(root: Path, *, task_package: bool = False) -> str:
     digest = hashlib.sha256()
-    files = [path for path in root.rglob("*") if path.is_file()]
+    root = root.resolve()
+    files = _git_tracked_files(root)
+    if files is None:
+        files = [path for path in root.rglob("*") if path.is_file() and not path.is_symlink()]
     if task_package:
         files = [path for path in files if path.name not in {"README.md", "trajectory.json"}]
     for path in sorted(files, key=lambda item: item.relative_to(root).as_posix()):
-        if "__pycache__" in path.parts or path.suffix == ".pyc":
+        if _skip_tree_path(path, root):
             continue
         digest.update(
             f"{path.relative_to(root).as_posix()}\0{_file_sha256(path)}\n".encode()
@@ -87,7 +136,10 @@ def validate_live_evidence(
     lock = _file_sha256(gauge / "requirements.lock")
     candidate_kwargs = jobs["chaos-engine"]["agents"][0]["kwargs"]
     if candidate_kwargs.get("harness_sha256") != harness:
-        raise ValueError("live harness tree digest mismatch")
+        raise ValueError(
+            "live harness tree digest mismatch "
+            f"(live {harness} != job {candidate_kwargs.get('harness_sha256')})"
+        )
     if manifest["arms"][1].get("harnessSha256") != harness:
         raise ValueError("manifest harness source digest mismatch")
     if candidate_kwargs.get("adapter_sha256") != adapter:

--- a/tests/scripts/test_chaos_engine_empty_project_smoke.py
+++ b/tests/scripts/test_chaos_engine_empty_project_smoke.py
@@ -45,6 +45,8 @@ class EmptyProjectSmokeTests(unittest.TestCase):
             evidence = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual("core-fixture-passed", evidence["status"])
             self.assertTrue(evidence["corePresent"])
+            self.assertEqual("portable", evidence["distribution"])
+            self.assertFalse(evidence["mergeHandoff"])
             self.assertLessEqual(evidence["elapsedSeconds"], 300)
 
     def test_budget_exceeded_returns_nonzero_and_writes_evidence(self):

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -3934,17 +3934,32 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
     def test_preflight_inverts_exact_receipt_mcp_servers_and_legacy_aliases(self):
         module = load(HOSTS, "chaos_engine_hosts_receipt_mcp_reconciliation")
+        memory_args = [".chaos-engine/tool.py", "memory-mcp"]
+        palace_args = [
+            ".chaos-engine/tool.py",
+            "mempalace-mcp",
+            "--palace",
+            ".chaos-engine-state/mempalace",
+            "--backend",
+            "sqlite_exact",
+        ]
         candidate_servers = {
             "chaosengine-memory": {
-                "command": "python3", "args": [".chaos-engine/tool.py", "memory-mcp"], "cwd": ".",
+                "command": "python3",
+                "args": memory_args,
+                "commandWindows": "py",
+                "argsWindows": ["-3", *memory_args],
+                "cwd": ".",
             },
             "chaosengine-mempalace": {
-                "command": "python3", "args": [".chaos-engine/tool.py", "mempalace-mcp"], "cwd": ".",
+                "command": "python3",
+                "args": palace_args,
+                "commandWindows": "py",
+                "argsWindows": ["-3", *palace_args],
+                "cwd": ".",
+                "env": dict(module.MEMPALACE_MCP_ENV),
             },
-            "maven-tools-mcp": {
-                "command": "/usr/bin/java",
-                "args": ["-jar", "/user/cache/maven-tools-mcp-3.2.0.jar", "--legacy"],
-            },
+            "maven-tools-mcp": module.LEGACY_MAVEN_TOOLS_SERVER,
         }
         aliases = {
             "shaft-memory": {

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1348,10 +1348,11 @@ class ChaosEngineHostsTest(unittest.TestCase):
             path.parent.mkdir(parents=True)
             original = b'{"name":"user-marketplace","plugins":[{"name":"chaos-engine","source":"./foreign"}]}'
             path.write_bytes(original)
-            with self.assertRaisesRegex(ValueError, "Claude marketplace collision"):
-                module.install(project)
+            module.install(project)
             self.assertEqual(original, path.read_bytes())
-            self.assertFalse(project.joinpath(module.RECEIPT_NAME).exists())
+            handoff = project / ".chaos-engine-state/merge-handoff.md"
+            self.assertTrue(handoff.is_file())
+            self.assertIn(".claude-plugin/marketplace.json", handoff.read_text(encoding="utf-8"))
 
     def test_gitignore_reincludes_tracked_memory_config_under_existing_parent_rule(self):
         module = load(HOSTS, "chaos_engine_gitignore_memory")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1439,8 +1439,11 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
         self.assertTrue(rendered.startswith(b"*.png binary\n"))
         self.assertEqual(rendered, module.gitattributes_content(rendered))
-        with self.assertRaisesRegex(ValueError, "gitattributes collision"):
-            module.gitattributes_content(b"# CHAOSENGINE-EOL:START\nchanged\n")
+        original = b"# CHAOSENGINE-EOL:START\nchanged\n"
+        self.assertEqual(original, module.gitattributes_content(original))
+        notes = module.consume_merge_handoffs()
+        self.assertTrue(notes)
+        self.assertIn("marker count", notes[0]["reason"])
 
     def test_gitattributes_preserves_core_bytes_in_autocrlf_clone(self):
         module = load(HOSTS, "chaos_engine_gitattributes_clone")

--- a/tests/scripts/test_chaos_engine_installer_host_adapter_drift_5633.py
+++ b/tests/scripts/test_chaos_engine_installer_host_adapter_drift_5633.py
@@ -340,7 +340,62 @@ class HostAdapterDrift5633Test(unittest.TestCase):
             )
             self.assertEqual("2" * 40, receipt.get("coreCommit"))
 
+    def test_rematerialize_preflight_drift_self_heals_without_fail_close(self):
+        """#5685: provision-path preflight drift after core rematerialize must not CE-INSTALL-FAILED."""
+        install = load(INSTALL, "chaos_engine_install_5685_provision_drift")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            project = root / "project"
+            project.mkdir()
+            source = root / "chaos-engine-source"
+            shutil.copytree(
+                SOURCE, source, ignore=shutil.ignore_patterns("__pycache__", "*.pyc")
+            )
+            load_controller = install.load_dependency_controller
 
+            def account_loader(installed_root: Path):
+                return AccountDependencyController(load_controller(installed_root))
+
+            with mock.patch.object(
+                install, "load_dependency_controller", side_effect=account_loader
+            ):
+                install.install_with_dependencies(project, source, "1" * 40)
+
+            mcp_path = project / ".mcp.json"
+            payload = json.loads(mcp_path.read_text(encoding="utf-8"))
+            payload.setdefault("mcpServers", {})["user-foreign-5685"] = {
+                "command": "keep-me",
+                "args": ["--foreign"],
+            }
+            mcp_path.write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            marketplace = project / ".claude-plugin" / "marketplace.json"
+            drifted = json.loads(marketplace.read_text(encoding="utf-8"))
+            drifted["name"] = "drifted-provision-5685"
+            marketplace.write_text(
+                json.dumps(drifted, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            self.assertTrue((project / ".chaos-engine-hosts.json").is_file())
+            self.assertTrue((project / ".chaos-engine").is_dir())
+
+            with mock.patch.object(
+                install, "upgrade_host_receipt_drift_needed", return_value=False
+            ), mock.patch.object(
+                install, "load_dependency_controller", side_effect=account_loader
+            ):
+                install.install_with_dependencies(project, source, "2" * 40)
+
+            receipt = json.loads(
+                (project / ".chaos-engine-hosts.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("2" * 40, receipt.get("coreCommit"))
+            healed_mcp = json.loads(mcp_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                "keep-me",
+                healed_mcp["mcpServers"]["user-foreign-5685"]["command"],
+            )
+            self.assertTrue((project / ".chaos-engine").is_dir())
 
 
 class OrphanCoreMissingHosts5636Test(unittest.TestCase):

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -954,6 +954,51 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("[path]", windows)
         self.assertNotIn(r"C:\Users", windows)
 
+    def test_installer_issue_template_asks_to_attach_trace_not_private_path(self):
+        template = (
+            ROOT / ".github/ISSUE_TEMPLATE/chaos-engine-installer.yml"
+        ).read_text(encoding="utf-8")
+        lowered = template.casefold()
+        self.assertIn("attach", lowered)
+        self.assertIn("install-trace.json", template)
+        self.assertIn(".chaos-engine-state/install-trace.json", template)
+        self.assertNotIn("Install trace path", template)
+        self.assertNotIn("/Users/", template)
+        self.assertNotIn("/home/", template)
+
+    def test_failure_prefill_uses_relative_trace_and_asks_for_attachment(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            (project / ".chaos-engine-state").mkdir(parents=True)
+            (project / ".chaos-engine-state" / "install-trace.json").write_text(
+                '{"status":"failed"}\n', encoding="utf-8"
+            )
+            stderr = io.StringIO()
+            with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
+                BOOTSTRAP.emit_install_failure(
+                    "CE-INSTALL-FAILED",
+                    RuntimeError(
+                        "ChaosEngine host adapter drift detected: "
+                        f"{project / 'plugins/chaos-engine/hooks/guard.py'}"
+                    ),
+                    "owner/repo",
+                    project=project,
+                )
+            output = stderr.getvalue()
+            report = next(
+                line
+                for line in output.splitlines()
+                if line.startswith("https://github.com/owner/repo/issues/new?")
+            )
+            query = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)
+            self.assertEqual(
+                [".chaos-engine-state/install-trace.json"], query["install_trace"]
+            )
+            self.assertIn("attach", output.casefold())
+            self.assertNotIn(str(project), query["install_trace"][0])
+            self.assertIn("[path]", query["cause"][0])
+            self.assertNotIn("/private/", query["cause"][0])
+
     def test_pr_gate_runs_fresh_installer_on_exact_three_os_matrix(self):
         workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
         self.assertIn("chaos_installer: ${{ steps.filter.outputs.chaos_installer }}", workflow)

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -122,6 +122,44 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             (dest / "__pycache__" / "install.cpython-313.pyc").write_bytes(b"pyc")
             (dest / "untracked-ci.txt").write_text("ci-only\n", encoding="utf-8")
             self.assertEqual(baseline, MODULE._tree_sha256(dest))
+            tracked = dest / "install.py"
+            original = tracked.read_bytes()
+            tracked.write_bytes(original + b"\n# worktree-only\n")
+            self.assertEqual(baseline, MODULE._tree_sha256(dest))
+            tracked.write_bytes(original)
+            subprocess.run(["git", "add", "chaos-engine/install.py"], cwd=root, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=ChaosGauge",
+                    "-c",
+                    "user.email=chaos-gauge@example.invalid",
+                    "commit",
+                    "-qm",
+                    "change-blob",
+                    "--allow-empty",
+                ],
+                cwd=root,
+                check=True,
+            )
+            tracked.write_bytes(original + b"\n# committed\n")
+            subprocess.run(["git", "add", "chaos-engine/install.py"], cwd=root, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=ChaosGauge",
+                    "-c",
+                    "user.email=chaos-gauge@example.invalid",
+                    "commit",
+                    "-qm",
+                    "change-blob",
+                ],
+                cwd=root,
+                check=True,
+            )
+            self.assertNotEqual(baseline, MODULE._tree_sha256(dest))
 
     def test_canonical_manifest_is_pinned_comparable_and_reproducible(self):
         manifest = self.manifest()

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.util
 import json
 import shutil
+import subprocess
 import sys
 import tempfile
 import types
@@ -90,6 +91,37 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
                 )
             }
             self.assertEqual(first, second)
+
+    def test_harness_digest_ignores_untracked_runtime_junk(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            dest = root / "chaos-engine"
+            shutil.copytree(
+                ROOT / "chaos-engine",
+                dest,
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+            )
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "chaos-engine"], cwd=root, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=ChaosGauge",
+                    "-c",
+                    "user.email=chaos-gauge@example.invalid",
+                    "commit",
+                    "-qm",
+                    "fixture",
+                ],
+                cwd=root,
+                check=True,
+            )
+            baseline = MODULE._tree_sha256(dest)
+            (dest / "__pycache__").mkdir(exist_ok=True)
+            (dest / "__pycache__" / "install.cpython-313.pyc").write_bytes(b"pyc")
+            (dest / "untracked-ci.txt").write_text("ci-only\n", encoding="utf-8")
+            self.assertEqual(baseline, MODULE._tree_sha256(dest))
 
     def test_canonical_manifest_is_pinned_comparable_and_reproducible(self):
         manifest = self.manifest()

--- a/tests/scripts/test_installer_merge_handoff.py
+++ b/tests/scripts/test_installer_merge_handoff.py
@@ -86,3 +86,33 @@ class InstructionMergeHandoffTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class InstallProfileSelectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        spec = importlib.util.spec_from_file_location(
+            "ce_profile_install", ROOT / "chaos-engine" / "install.py"
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError("cannot load install.py")
+        self.install = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.install)
+
+    def test_empty_and_non_java_stay_portable_java_shaft_selects_repository(self) -> None:
+        source = ROOT / "chaos-engine"
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            empty = root / "empty"
+            empty.mkdir()
+            non_java = root / "node"
+            non_java.mkdir()
+            (non_java / "package.json").write_text("{}", encoding="utf-8")
+            java = root / "shaft"
+            java.mkdir()
+            (java / "pom.xml").write_text(
+                "<project><artifactId>shaft-engine</artifactId></project>\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(self.install.detect_distribution(empty, source), "portable")
+            self.assertEqual(self.install.detect_distribution(non_java, source), "portable")
+            self.assertEqual(self.install.detect_distribution(java, source), "repository")

--- a/tests/scripts/test_installer_merge_handoff.py
+++ b/tests/scripts/test_installer_merge_handoff.py
@@ -1,0 +1,88 @@
+"""Instruction-file merge and handoff contract for the installer program."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HOSTS = ROOT / "chaos-engine" / "hosts.py"
+
+
+def load_hosts():
+    spec = importlib.util.spec_from_file_location("ce_merge_handoff_hosts", HOSTS)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {HOSTS}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class InstructionMergeHandoffTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.hosts = load_hosts()
+        self.hosts.consume_merge_handoffs()
+
+    def test_absent_markers_append_the_owned_block(self) -> None:
+        merged = self.hosts.merge_instruction(
+            b"foreign notes\n",
+            self.hosts.INSTRUCTION,
+            relative="AGENTS.md",
+        )
+        text = merged.decode("utf-8")
+        self.assertIn("foreign notes\n", text)
+        self.assertIn(self.hosts.START, text)
+        self.assertEqual(self.hosts.consume_merge_handoffs(), [])
+
+    def test_current_span_is_replaced_without_handoff(self) -> None:
+        before = ("keep\n" + self.hosts.INSTRUCTION + "tail\n").encode()
+        merged = self.hosts.merge_instruction(
+            before, self.hosts.INSTRUCTION, relative="AGENTS.md"
+        )
+        text = merged.decode("utf-8")
+        self.assertIn("keep\n", text)
+        self.assertIn("tail\n", text)
+        self.assertEqual(text.count(self.hosts.START), 1)
+        self.assertEqual(self.hosts.consume_merge_handoffs(), [])
+
+    def test_edited_span_is_left_unchanged_and_handed_off(self) -> None:
+        original = (
+            "foreign\n"
+            f"{self.hosts.START}\noperator edited this span\n{self.hosts.END}\n"
+        ).encode()
+        merged = self.hosts.merge_instruction(
+            original, self.hosts.INSTRUCTION, relative="AGENTS.md"
+        )
+        self.assertEqual(merged, original)
+        notes = self.hosts.consume_merge_handoffs()
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0]["path"], "AGENTS.md")
+        self.assertIn("interior", notes[0]["reason"])
+
+    def test_handoff_markdown_names_the_path_and_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw)
+            self.hosts.merge_instruction(
+                f"{self.hosts.START}\nedited\n{self.hosts.END}\n".encode(),
+                self.hosts.INSTRUCTION,
+                relative="CLAUDE.md",
+            )
+            written = self.hosts.write_merge_handoff(
+                project, "python3 .chaos-engine/install.py doctor --project ."
+            )
+            self.assertIsNotNone(written)
+            body = written.read_text(encoding="utf-8")
+            self.assertIn("## CLAUDE.md", body)
+            self.assertIn("Desired owned block:", body)
+            prompt = self.hosts.merge_handoff_prompt(
+                "python3 .chaos-engine/install.py doctor --project ."
+            )
+            self.assertTrue(prompt.startswith("Merge ChaosEngine host configuration"))
+            self.assertIn(".chaos-engine-state/merge-handoff.md", prompt)
+            self.assertNotIn("\n", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_installer_merge_handoff.py
+++ b/tests/scripts/test_installer_merge_handoff.py
@@ -1,23 +1,48 @@
-"""Instruction-file merge and handoff contract for the installer program."""
+"""Installer-program merge, profile, upgrade, and handoff proofs."""
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import io
+import json
 import tempfile
 import unittest
 from pathlib import Path
 
+
 ROOT = Path(__file__).resolve().parents[2]
 HOSTS = ROOT / "chaos-engine" / "hosts.py"
+INSTALL = ROOT / "chaos-engine" / "install.py"
+BOOTSTRAP = ROOT / "chaos-engine" / "bootstrap.py"
+SOURCE = ROOT / "chaos-engine"
+TEST_COMMIT = "1" * 40
+NEXT_COMMIT = "2" * 40
 
 
-def load_hosts():
-    spec = importlib.util.spec_from_file_location("ce_merge_handoff_hosts", HOSTS)
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load {HOSTS}")
+        raise RuntimeError(f"cannot load {path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def load_hosts():
+    return load_module(HOSTS, "ce_merge_handoff_hosts")
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def seed_core(project: Path, install, commit: str = TEST_COMMIT, distribution: str = "portable"):
+    install.install(project, SOURCE, commit, distribution=distribution)
+
+
+def bind_hosts(hosts, project: Path, commit: str = TEST_COMMIT):
+    return hosts.install(project, core_commit=commit)
 
 
 class InstructionMergeHandoffTest(unittest.TestCase):
@@ -61,6 +86,29 @@ class InstructionMergeHandoffTest(unittest.TestCase):
         self.assertEqual(notes[0]["path"], "AGENTS.md")
         self.assertIn("interior", notes[0]["reason"])
 
+    def test_split_markers_are_left_unchanged_and_handed_off(self) -> None:
+        original = (
+            f"{self.hosts.START}\none\n{self.hosts.END}\n"
+            f"{self.hosts.START}\ntwo\n{self.hosts.END}\n"
+        ).encode()
+        merged = self.hosts.merge_instruction(
+            original, self.hosts.INSTRUCTION, relative="AGENTS.md"
+        )
+        self.assertEqual(merged, original)
+        notes = self.hosts.consume_merge_handoffs()
+        self.assertEqual(len(notes), 1)
+        self.assertIn("marker count", notes[0]["reason"])
+
+    def test_invalid_utf8_instruction_is_byte_preserved(self) -> None:
+        original = b"\xff\xfe foreign"
+        merged = self.hosts.merge_instruction(
+            original, self.hosts.INSTRUCTION, relative="AGENTS.md"
+        )
+        self.assertEqual(merged, original)
+        notes = self.hosts.consume_merge_handoffs()
+        self.assertEqual(len(notes), 1)
+        self.assertIn("UTF-8", notes[0]["reason"])
+
     def test_handoff_markdown_names_the_path_and_prompt(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             project = Path(raw)
@@ -84,19 +132,65 @@ class InstructionMergeHandoffTest(unittest.TestCase):
             self.assertNotIn("\n", prompt)
 
 
-if __name__ == "__main__":
-    unittest.main()
+class NamedRecordMergeHandoffTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.hosts = load_hosts()
+        self.hosts.consume_merge_handoffs()
+
+    def test_unknown_same_name_mcp_is_byte_preserved(self) -> None:
+        original = json.dumps(
+            {
+                "mcpServers": {
+                    "chaosengine-memory": {
+                        "command": "foreign-memory",
+                        "args": ["--owned-by-operator"],
+                    },
+                    "keep-me": {"command": "keep", "args": []},
+                }
+            },
+            indent=2,
+            sort_keys=True,
+        ).encode() + b"\n"
+        merged = self.hosts.json_content(original)
+        self.assertEqual(merged, original)
+        notes = self.hosts.consume_merge_handoffs()
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0]["path"], ".mcp.json")
+        self.assertIn("unknown ownership", notes[0]["reason"])
+
+    def test_unparsable_mcp_json_is_byte_preserved(self) -> None:
+        original = b"{not-json"
+        merged = self.hosts.json_content(original)
+        self.assertEqual(merged, original)
+        notes = self.hosts.consume_merge_handoffs()
+        self.assertEqual(len(notes), 1)
+        self.assertIn("parse", notes[0]["reason"])
+
+    def test_codex_marker_collision_is_byte_preserved(self) -> None:
+        original = (
+            b"# CHAOSENGINE:START\n[mcp_servers.x]\n"
+            b"# CHAOSENGINE:START\n# CHAOSENGINE:END\n"
+        )
+        merged = self.hosts.codex_content(original)
+        self.assertEqual(merged, original)
+        notes = self.hosts.consume_merge_handoffs()
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0]["path"], ".codex/config.toml")
+
+    def test_gitattributes_marker_collision_is_byte_preserved(self) -> None:
+        original = b"# CHAOSENGINE-EOL:START\nchanged\n"
+        merged = self.hosts.gitattributes_content(original)
+        self.assertEqual(merged, original)
+        notes = self.hosts.consume_merge_handoffs()
+        self.assertTrue(notes)
+        self.assertIn("marker count", notes[0]["reason"])
 
 
 class InstallProfileSelectionTest(unittest.TestCase):
     def setUp(self) -> None:
-        spec = importlib.util.spec_from_file_location(
-            "ce_profile_install", ROOT / "chaos-engine" / "install.py"
-        )
-        if spec is None or spec.loader is None:
-            raise RuntimeError("cannot load install.py")
-        self.install = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(self.install)
+        self.install = load_module(INSTALL, "ce_profile_install")
+        self.hosts = load_hosts()
+        self.hosts.consume_merge_handoffs()
 
     def test_empty_and_non_java_stay_portable_java_shaft_selects_repository(self) -> None:
         source = ROOT / "chaos-engine"
@@ -116,3 +210,240 @@ class InstallProfileSelectionTest(unittest.TestCase):
             self.assertEqual(self.install.detect_distribution(empty, source), "portable")
             self.assertEqual(self.install.detect_distribution(non_java, source), "portable")
             self.assertEqual(self.install.detect_distribution(java, source), "repository")
+
+    def _required_names(self, project: Path) -> dict[str, str]:
+        doctor = self.install.status_with_dependencies(project)
+        return self.install.required_component_statuses(doctor)
+
+    def test_empty_first_install_is_portable_without_handoff_or_required_maven_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "empty"
+            project.mkdir()
+            seed_core(project, self.install)
+            bind_hosts(self.hosts, project)
+            manifest = json.loads(
+                (project / ".chaos-engine/manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("portable", manifest["distribution"]["id"])
+            self.assertFalse((project / ".chaos-engine-state/merge-handoff.md").exists())
+            required = self._required_names(project)
+            self.assertNotIn("maven-tools-mcp", required)
+            status = self.install.status_with_dependencies(project)
+            maven = status["components"]["maven-tools-mcp"]
+            self.assertEqual("optional", maven["taskImpact"])
+            if maven.get("status") != "healthy":
+                self.assertNotIn("maven-tools-mcp", required)
+
+    def test_java_first_install_keeps_pom_bytes_and_requires_maven_tools(self) -> None:
+        pom = "<project><artifactId>shaft-engine</artifactId></project>\n"
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "shaft"
+            project.mkdir()
+            pom_path = project / "pom.xml"
+            pom_path.write_text(pom, encoding="utf-8")
+            digest = sha256_bytes(pom_path.read_bytes())
+            distribution = self.install.detect_distribution(project, SOURCE)
+            self.assertEqual("repository", distribution)
+            seed_core(project, self.install, distribution=distribution)
+            bind_hosts(self.hosts, project)
+            self.assertEqual(digest, sha256_bytes(pom_path.read_bytes()))
+            manifest = json.loads(
+                (project / ".chaos-engine/manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("repository", manifest["distribution"]["id"])
+            status = self.install.status_with_dependencies(project)
+            maven = status["components"]["maven-tools-mcp"]
+            self.assertEqual("required", maven["taskImpact"])
+            self.assertFalse((project / ".chaos-engine-state/merge-handoff.md").exists())
+
+    def test_non_java_first_install_stays_portable_without_required_maven_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "node"
+            project.mkdir()
+            package = project / "package.json"
+            package.write_text('{"name":"demo"}\n', encoding="utf-8")
+            digest = sha256_bytes(package.read_bytes())
+            seed_core(project, self.install)
+            bind_hosts(self.hosts, project)
+            self.assertEqual(digest, sha256_bytes(package.read_bytes()))
+            manifest = json.loads(
+                (project / ".chaos-engine/manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("portable", manifest["distribution"]["id"])
+            required = self._required_names(project)
+            self.assertNotIn("maven-tools-mcp", required)
+            self.assertFalse((project / ".chaos-engine-state/merge-handoff.md").exists())
+
+
+class InstallUpgradeHandoffTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.install = load_module(INSTALL, "ce_upgrade_install")
+        self.hosts = load_hosts()
+        self.hosts.consume_merge_handoffs()
+
+    def test_empty_upgrade_keeps_core_commit_palace_data_and_skips_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "empty"
+            project.mkdir()
+            seed_core(project, self.install, TEST_COMMIT)
+            bind_hosts(self.hosts, project, TEST_COMMIT)
+            events = project / ".memory/events.jsonl"
+            events.write_bytes(b'{"keep":true}\n')
+            palace = project / ".chaos-engine-state/mempalace"
+            palace.mkdir(parents=True, exist_ok=True)
+            marker = palace / "operator-data.txt"
+            marker.write_text("keep-me\n", encoding="utf-8")
+            seed_core(project, self.install, NEXT_COMMIT)
+            bind_hosts(self.hosts, project, NEXT_COMMIT)
+            manifest = json.loads(
+                (project / ".chaos-engine/manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(NEXT_COMMIT, manifest["source"]["commit"])
+            self.assertEqual("portable", manifest["distribution"]["id"])
+            self.assertEqual(b'{"keep":true}\n', events.read_bytes())
+            self.assertEqual("keep-me\n", marker.read_text(encoding="utf-8"))
+            self.assertFalse((project / ".chaos-engine-state/merge-handoff.md").exists())
+
+    def test_java_upgrade_keeps_repository_and_pom_digest(self) -> None:
+        pom = "<project><artifactId>shaft-engine</artifactId></project>\n"
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "shaft"
+            project.mkdir()
+            pom_path = project / "pom.xml"
+            pom_path.write_text(pom, encoding="utf-8")
+            foreign = {
+                "mcpServers": {
+                    "operator-server": {"command": "keep", "args": ["x"]},
+                }
+            }
+            (project / ".mcp.json").write_text(
+                json.dumps(foreign, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            digest = sha256_bytes(pom_path.read_bytes())
+            seed_core(project, self.install, TEST_COMMIT, distribution="repository")
+            bind_hosts(self.hosts, project, TEST_COMMIT)
+            seed_core(project, self.install, NEXT_COMMIT, distribution="repository")
+            bind_hosts(self.hosts, project, NEXT_COMMIT)
+            self.assertEqual(digest, sha256_bytes(pom_path.read_bytes()))
+            manifest = json.loads(
+                (project / ".chaos-engine/manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("repository", manifest["distribution"]["id"])
+            servers = json.loads((project / ".mcp.json").read_text(encoding="utf-8"))[
+                "mcpServers"
+            ]
+            self.assertEqual({"command": "keep", "args": ["x"]}, servers["operator-server"])
+
+    def test_non_java_upgrade_stays_portable_and_keeps_foreign_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "node"
+            project.mkdir()
+            package = project / "package.json"
+            package.write_text('{"name":"demo"}\n', encoding="utf-8")
+            (project / "AGENTS.md").write_text("operator prose\n", encoding="utf-8")
+            seed_core(project, self.install, TEST_COMMIT)
+            bind_hosts(self.hosts, project, TEST_COMMIT)
+            seed_core(project, self.install, NEXT_COMMIT)
+            bind_hosts(self.hosts, project, NEXT_COMMIT)
+            manifest = json.loads(
+                (project / ".chaos-engine/manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("portable", manifest["distribution"]["id"])
+            self.assertEqual('{"name":"demo"}\n', package.read_text(encoding="utf-8"))
+            agents = (project / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn("operator prose\n", agents)
+            self.assertIn(self.hosts.START, agents)
+            self.assertFalse((project / ".chaos-engine-state/merge-handoff.md").exists())
+
+
+class InstallConflictHandoffTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.install = load_module(INSTALL, "ce_conflict_install")
+        self.hosts = load_hosts()
+        self.hosts.consume_merge_handoffs()
+
+    def test_partial_success_merges_agents_and_hands_off_colliding_mcp(self) -> None:
+        colliding = json.dumps(
+            {
+                "mcpServers": {
+                    "chaosengine-memory": {
+                        "command": "foreign-memory",
+                        "args": ["--owned-by-operator"],
+                    }
+                }
+            },
+            indent=2,
+            sort_keys=True,
+        ).encode() + b"\n"
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "mixed"
+            project.mkdir()
+            (project / "AGENTS.md").write_text("keep this prose\n", encoding="utf-8")
+            (project / ".mcp.json").write_bytes(colliding)
+            seed_core(project, self.install)
+            bind_hosts(self.hosts, project)
+            agents = (project / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn("keep this prose\n", agents)
+            self.assertIn(self.hosts.START, agents)
+            self.assertEqual(colliding, (project / ".mcp.json").read_bytes())
+            handoff = project / ".chaos-engine-state/merge-handoff.md"
+            self.assertTrue(handoff.is_file())
+            body = handoff.read_text(encoding="utf-8")
+            self.assertIn(".mcp.json", body)
+            self.assertNotIn("## AGENTS.md", body)
+
+    def test_symlink_instruction_file_fails_closed_without_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "linked"
+            project.mkdir()
+            target = Path(raw) / "outside.md"
+            target.write_text("outside\n", encoding="utf-8")
+            (project / "AGENTS.md").symlink_to(target)
+            seed_core(project, self.install)
+            with self.assertRaisesRegex(ValueError, "link or reparse"):
+                bind_hosts(self.hosts, project)
+            self.assertFalse((project / ".chaos-engine-state/merge-handoff.md").exists())
+            self.assertEqual("outside\n", target.read_text(encoding="utf-8"))
+
+    def test_doctor_fix_next_names_handoff_not_reinstall(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw)
+            (project / ".chaos-engine-state").mkdir()
+            (project / ".chaos-engine-state/merge-handoff.md").write_text(
+                "# Merge handoff\n", encoding="utf-8"
+            )
+            components = {
+                "hooks": {"status": "recovery-required", "taskImpact": "required"},
+                "mcps": {"status": "recovery-required", "taskImpact": "required"},
+            }
+            self.install.apply_merge_handoff_fix_next(project, components)
+            for name in ("hooks", "mcps"):
+                fix = components[name]["fixNext"]
+                self.assertIn(".chaos-engine-state/merge-handoff.md", fix)
+                self.assertNotIn("reinstall", fix.casefold())
+
+    def test_success_panel_prints_one_backtick_prompt_without_ce_install_failed(self) -> None:
+        bootstrap = load_module(BOOTSTRAP, "ce_merge_handoff_bootstrap")
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw)
+            (project / ".chaos-engine-state").mkdir()
+            (project / ".chaos-engine-state/merge-handoff.md").write_text(
+                "# Merge handoff\n", encoding="utf-8"
+            )
+            stream = io.StringIO()
+            reporter = bootstrap.InstallReporter(stream=stream)
+            reporter.success(
+                project,
+                {"status": "healthy", "commit": TEST_COMMIT, "components": {}},
+                {},
+                repository="owner/repo",
+            )
+            output = stream.getvalue()
+            self.assertIn("Installation Successful!", output)
+            self.assertIn("Merge handoff", output)
+            self.assertNotIn("CE-INSTALL-FAILED", output)
+            self.assertEqual(1, output.count("`Merge ChaosEngine host configuration"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_installer_merge_handoff.py
+++ b/tests/scripts/test_installer_merge_handoff.py
@@ -396,6 +396,42 @@ class InstallConflictHandoffTest(unittest.TestCase):
             self.assertTrue(handoff.is_file())
             self.assertIn(".mcp.json", handoff.read_text(encoding="utf-8"))
 
+    def test_extra_args_mcp_collision_survives_second_bind(self) -> None:
+        colliding = json.dumps(
+            {
+                "mcpServers": {
+                    "chaosengine-memory": {
+                        "command": "python3",
+                        "args": [
+                            ".chaos-engine/tool.py",
+                            "memory-mcp",
+                            "--operator-flag",
+                        ],
+                        "cwd": ".",
+                    }
+                }
+            },
+            indent=2,
+            sort_keys=True,
+        ).encode() + b"\n"
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "extra-args"
+            project.mkdir()
+            (project / ".mcp.json").write_bytes(colliding)
+            seed_core(project, self.install)
+            bind_hosts(self.hosts, project)
+            bind_hosts(self.hosts, project)
+            live = json.loads((project / ".mcp.json").read_text(encoding="utf-8"))
+            self.assertEqual(
+                [
+                    ".chaos-engine/tool.py",
+                    "memory-mcp",
+                    "--operator-flag",
+                ],
+                live["mcpServers"]["chaosengine-memory"]["args"],
+            )
+            self.assertEqual(colliding, (project / ".mcp.json").read_bytes())
+
     def test_claude_plugin_collision_byte_preserves_and_hands_off(self) -> None:
         settings = json.dumps(
             {
@@ -416,7 +452,76 @@ class InstallConflictHandoffTest(unittest.TestCase):
             self.assertEqual(settings, (claude / "settings.json").read_bytes())
             handoff = project / ".chaos-engine-state/merge-handoff.md"
             self.assertTrue(handoff.is_file())
-            self.assertIn(".claude/settings.json", handoff.read_text(encoding="utf-8"))
+            body = handoff.read_text(encoding="utf-8")
+            self.assertIn(".claude/settings.json", body)
+            self.assertNotIn("same-name MCP", body)
+            self.assertIn("plugin enablement", body)
+            fence = body.split("```", 2)
+            self.assertGreaterEqual(len(fence), 3)
+            self.assertTrue(fence[1].strip())
+
+    def test_companion_plugin_collisions_byte_preserve_and_hand_off(self) -> None:
+        claude_market = json.dumps(
+            {
+                "name": "chaos-engine-project",
+                "owner": {"name": "operator"},
+                "plugins": [
+                    {
+                        "name": "caveman",
+                        "source": "./foreign-caveman",
+                        "version": "0.0.1",
+                    },
+                    {
+                        "name": "ponytail",
+                        "source": "./foreign-ponytail",
+                        "version": "0.0.1",
+                    },
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ).encode() + b"\n"
+        agents_market = json.dumps(
+            {
+                "name": "operator-market",
+                "plugins": [
+                    {
+                        "name": "caveman",
+                        "source": {"source": "local", "path": "./foreign-caveman"},
+                    },
+                    {
+                        "name": "ponytail",
+                        "source": {"source": "local", "path": "./foreign-ponytail"},
+                    },
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ).encode() + b"\n"
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "companions"
+            project.mkdir()
+            (project / ".claude-plugin").mkdir()
+            (project / ".agents/plugins").mkdir(parents=True)
+            (project / ".claude-plugin/marketplace.json").write_bytes(claude_market)
+            (project / ".agents/plugins/marketplace.json").write_bytes(agents_market)
+            seed_core(project, self.install)
+            bind_hosts(self.hosts, project)
+            self.assertEqual(
+                claude_market,
+                (project / ".claude-plugin/marketplace.json").read_bytes(),
+            )
+            self.assertEqual(
+                agents_market,
+                (project / ".agents/plugins/marketplace.json").read_bytes(),
+            )
+            handoff = project / ".chaos-engine-state/merge-handoff.md"
+            self.assertTrue(handoff.is_file())
+            body = handoff.read_text(encoding="utf-8")
+            self.assertIn(".claude-plugin/marketplace.json", body)
+            self.assertIn(".agents/plugins/marketplace.json", body)
+            self.assertIn("plugin marketplace", body)
+            self.assertNotIn("```\n```", body)
 
     def test_edited_gitignore_interior_is_left_unchanged_and_handed_off(self) -> None:
         original = (
@@ -433,7 +538,9 @@ class InstallConflictHandoffTest(unittest.TestCase):
             self.assertEqual(original, (project / ".gitignore").read_bytes())
             handoff = project / ".chaos-engine-state/merge-handoff.md"
             self.assertTrue(handoff.is_file())
-            self.assertIn(".gitignore", handoff.read_text(encoding="utf-8"))
+            body = handoff.read_text(encoding="utf-8")
+            self.assertIn(".gitignore", body)
+            self.assertNotIn("legacy", body)
             self.assertIn("secret.env", (project / ".gitignore").read_text(encoding="utf-8"))
 
     def test_symlink_instruction_file_fails_closed_without_handoff(self) -> None:

--- a/tests/scripts/test_installer_merge_handoff.py
+++ b/tests/scripts/test_installer_merge_handoff.py
@@ -391,6 +391,50 @@ class InstallConflictHandoffTest(unittest.TestCase):
             body = handoff.read_text(encoding="utf-8")
             self.assertIn(".mcp.json", body)
             self.assertNotIn("## AGENTS.md", body)
+            bind_hosts(self.hosts, project)
+            self.assertEqual(colliding, (project / ".mcp.json").read_bytes())
+            self.assertTrue(handoff.is_file())
+            self.assertIn(".mcp.json", handoff.read_text(encoding="utf-8"))
+
+    def test_claude_plugin_collision_byte_preserves_and_hands_off(self) -> None:
+        settings = json.dumps(
+            {
+                "enabledPlugins": {"chaos-engine@chaos-engine-project": False},
+                "extraKnownMarketplaces": {},
+            },
+            indent=2,
+            sort_keys=True,
+        ).encode() + b"\n"
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "claude-plugin"
+            project.mkdir()
+            claude = project / ".claude"
+            claude.mkdir()
+            (claude / "settings.json").write_bytes(settings)
+            seed_core(project, self.install)
+            bind_hosts(self.hosts, project)
+            self.assertEqual(settings, (claude / "settings.json").read_bytes())
+            handoff = project / ".chaos-engine-state/merge-handoff.md"
+            self.assertTrue(handoff.is_file())
+            self.assertIn(".claude/settings.json", handoff.read_text(encoding="utf-8"))
+
+    def test_edited_gitignore_interior_is_left_unchanged_and_handed_off(self) -> None:
+        original = (
+            f"{self.hosts.GITIGNORE_START}\n"
+            "secret.env\n"
+            f"{self.hosts.GITIGNORE_END}\n"
+        ).encode()
+        with tempfile.TemporaryDirectory() as raw:
+            project = Path(raw) / "ignore"
+            project.mkdir()
+            (project / ".gitignore").write_bytes(original)
+            seed_core(project, self.install)
+            bind_hosts(self.hosts, project)
+            self.assertEqual(original, (project / ".gitignore").read_bytes())
+            handoff = project / ".chaos-engine-state/merge-handoff.md"
+            self.assertTrue(handoff.is_file())
+            self.assertIn(".gitignore", handoff.read_text(encoding="utf-8"))
+            self.assertIn("secret.env", (project / ".gitignore").read_text(encoding="utf-8"))
 
     def test_symlink_instruction_file_fails_closed_without_handoff(self) -> None:
         with tempfile.TemporaryDirectory() as raw:


### PR DESCRIPTION
## Summary
- Official one-liner path now leaves either a healthy doctor or success-with-agent-prompt. Impossible host merges stay byte-identical, write `.chaos-engine-state/merge-handoff.md`, print styled success plus one backtick prompt, and exit 0. No `CE-INSTALL-FAILED` for this class.
- First install: empty and non-Java stay `portable` without required Maven Tools; Java `shaft-engine` POM selects `repository`, keeps POM bytes, and marks Maven Tools required.
- Upgrade: empty keeps palace/Memory data and skips handoff on a clean tree; Java stays `repository` with unchanged POM digest and surviving foreign MCP servers; non-Java stays `portable` with foreign bytes intact.
- Conflict merge: marker-count, edited interior, unknown same-name MCP, invalid UTF-8/JSON, and Codex marker collisions hand off. Symlink/reparse stays fail-closed. Partial success merges mergeable files only. Doctor `fix-next` names the handoff file.
- #5685: host-adapter drift during rematerialize+provision quarantines and rebinds instead of CE-INSTALL-FAILED. Foreign MCP servers survive. Issue template and prefill ask operators to attach `.chaos-engine-state/install-trace.json`; prefill uses that repo-relative path, not a private absolute path. Home/media paths stay redacted in the cause line.
- Part of #5669. Does not close the epic.

## Checks
- [x] `python3 -m unittest tests.scripts.test_installer_merge_handoff -v`
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_installer_host_adapter_drift_5633 tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_engine_bootstrap tests.scripts.test_installer_merge_handoff -v` (exit 0, 118 tests)
- [x] ChaosGauge digests refreshed

## Continuation
- Child proofs for #5676 #5673 #5677 #5671 #5672 #5678 #5679 #5685 are on this branch.
- Live SHAFT one-liner: this class of host-adapter drift after core rematerialize should no longer emit CE-INSTALL-FAILED. Unrelated provision failures (uv/graphify tool install, Maven Tools required-unhealthy) can still fail.
- Java Maven Tools JAR cache is not built in unit tests.
- Epic #5669 stays open.

Closes #5676
Closes #5673
Closes #5677
Closes #5671
Closes #5672
Closes #5678
Closes #5679
Closes #5685