### PR TITLE
[CE] Split install-verify health from host-environment advisories

### DIFF
--- a/.chaos-engine/install.py
+++ b/.chaos-engine/install.py
@@ -4916,6 +4916,40 @@ def format_blocking_fidelity_warnings(document: dict[str, object]) -> list[str]:
     return lines
 
 
+def format_host_environment_findings(document: dict[str, object]) -> list[str]:
+    """Surface install-owned-healthy host-environment advisories (#5699)."""
+    lines: list[str] = []
+    components = document.get("components")
+    if not isinstance(components, dict):
+        return lines
+    for name in sorted(str(item) for item in components):
+        item = components[name]
+        if not isinstance(item, dict):
+            continue
+        finding = item.get("hostEnvironment")
+        if not isinstance(finding, dict):
+            continue
+        if finding.get("status") not in {"sync-advisory", "compatible-legacy", "degraded"}:
+            continue
+        detail = finding.get("detail")
+        fix = finding.get("fixNext")
+        detail_text = detail if isinstance(detail, str) and detail.strip() else "advisory"
+        lines.append(f"[info] {name}/hostEnvironment — {detail_text}")
+        if isinstance(fix, str) and fix.strip():
+            lines.append(f"  fix-next: {fix.strip()}")
+    hosts = document.get("hosts")
+    if isinstance(hosts, dict):
+        finding = hosts.get("hostEnvironment")
+        if isinstance(finding, dict) and finding.get("status") == "sync-advisory":
+            detail = finding.get("detail")
+            fix = finding.get("fixNext")
+            detail_text = detail if isinstance(detail, str) and detail.strip() else "advisory"
+            lines.append(f"[info] hosts/hostEnvironment — {detail_text}")
+            if isinstance(fix, str) and fix.strip():
+                lines.append(f"  fix-next: {fix.strip()}")
+    return lines
+
+
 
 def format_fix_next_only(document: dict[str, object]) -> str:
     """Emit only actionable fix-next lines for unhealthy components (#5582)."""
@@ -4963,13 +4997,21 @@ def format_health_report(document: dict[str, object], *, kind: str | None = None
     ]
     if total:
         lines.append(f"components: {healthy}/{total} healthy")
+    advisories = format_host_environment_findings(document)
+    advisory_count = sum(1 for line in advisories if line.startswith("[info]"))
     if not failures:
-        # Keep the happy path short for first-time users.
+        # Keep the happy path short; still show host-environment advisories (#5699).
+        if advisories:
+            lines.append(f"issues: {advisory_count} info")
+            lines.append("")
+            lines.extend(advisories)
         lines.extend(format_blocking_fidelity_warnings(document))
         return "\n".join(lines) + "\n"
     counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
     for _name, _item, severity in failures:
         counts[severity] = counts.get(severity, 0) + 1
+    if advisory_count:
+        counts["info"] = counts.get("info", 0) + advisory_count
     summary = ", ".join(
         f"{counts[key]} {key}" for key in ("error", "warning", "info") if counts.get(key)
     )
@@ -4985,6 +5027,7 @@ def format_health_report(document: dict[str, object], *, kind: str | None = None
         fix = component_fix_next(name, item)
         if fix:
             lines.append(f"  fix-next: {fix}")
+    lines.extend(advisories)
     lines.extend(format_blocking_fidelity_warnings(document))
     return "\n".join(lines) + "\n"
 

--- a/.chaos-engine/install.py
+++ b/.chaos-engine/install.py
@@ -3652,8 +3652,26 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
             if result["hosts"]["status"] != "healthy":  # type: ignore[index]
                 result["status"] = "recovery-required"
             if active_probes:
-                result["hosts"]["grok"] = host_controller.grok_runtime_status(project)  # type: ignore[index]
-                if result["hosts"]["grok"]["status"] == "recovery-required":  # type: ignore[index]
+                # Grok CLI trust/loaded-hooks probe is host-environment, not install-owned (#5699).
+                grok_probe = host_controller.grok_runtime_status(project)
+                result["hosts"]["grok"] = grok_probe  # type: ignore[index]
+                if (
+                    isinstance(grok_probe, dict)
+                    and grok_probe.get("status") == "recovery-required"
+                    and result["hosts"].get("status") == "healthy"  # type: ignore[index]
+                ):
+                    result["hosts"]["hostEnvironment"] = {  # type: ignore[index]
+                        "status": "sync-advisory",
+                        "detail": "grok-hooks-probe",
+                        "fixNext": str(
+                            grok_probe.get("detail")
+                            or "Trust and reload Grok project hooks, then rerun doctor."
+                        ),
+                    }
+                elif (
+                    isinstance(grok_probe, dict)
+                    and grok_probe.get("status") == "recovery-required"
+                ):
                     result["hosts"]["status"] = "recovery-required"  # type: ignore[index]
                     result["status"] = "recovery-required"
             removing = project / ".chaos-engine-runtime.removing"
@@ -3955,6 +3973,87 @@ def apply_hooks_probe_failure(result: dict[str, object], components: object) -> 
         hooks["fixNext"] = named
 
 
+def attach_host_environment_finding(
+    component: dict[str, object],
+    *,
+    detail: str,
+    fix_next: str,
+    code: str | None = None,
+) -> None:
+    """Record a host-environment advisory without flipping install-owned component health (#5699)."""
+    finding: dict[str, object] = {
+        "status": "sync-advisory",
+        "detail": detail,
+        "fixNext": fix_next,
+    }
+    if isinstance(code, str) and re.fullmatch(r"[A-Z][A-Z0-9_]{0,63}", code):
+        finding["code"] = code
+    component["hostEnvironment"] = finding
+
+
+def apply_hooks_host_environment_probe(
+    result: dict[str, object],
+    components: object,
+) -> None:
+    """Owned hook files stay healthy; runtime host probe is advisory (#5699)."""
+    if not isinstance(components, dict) or not isinstance(components.get("hooks"), dict):
+        return
+    hooks = components["hooks"]
+    if hooks.get("status") != "healthy":
+        apply_hooks_probe_failure(result, components)
+        return
+    named = component_fix_next(
+        "hooks",
+        {
+            "status": "recovery-required",
+            "detail": HOOKS_PROBE_FAILED_DETAIL,
+            "code": HOOKS_PROBE_FAILED_CODE,
+        },
+    )
+    attach_host_environment_finding(
+        hooks,
+        detail=HOOKS_PROBE_FAILED_DETAIL,
+        fix_next=named
+        or (
+            f"Run `{_doctor_python_cli()} .chaos-engine/install.py repair "
+            "--project . --component hooks`, reload/trust hooks in the active host, "
+            f"then `{_doctor_python_cli()} .chaos-engine/install.py doctor --project .`."
+        ),
+        code=HOOKS_PROBE_FAILED_CODE,
+    )
+
+
+def apply_mcp_policy_doctor(
+    result: dict[str, object],
+    components: object,
+    project: Path,
+    policy_mod: object,
+) -> None:
+    """Project-overlay MCP conflicts fail doctor; user/global aliases are advisory (#5699)."""
+    if not isinstance(components, dict) or not isinstance(components.get("mcps"), dict):
+        return
+    mcps = components["mcps"]
+    project_error = policy_mod.project_mcp_policy_error(project)
+    if project_error:
+        result["status"] = "recovery-required"
+        mcps["status"] = "recovery-required"
+        mcps["detail"] = project_error
+        mcps["fixNext"] = policy_mod.HEAL_PROMPT
+        return
+    finding = policy_mod.user_mcp_policy_finding(project)
+    if finding and mcps.get("status") in {
+        "healthy",
+        "compatible-legacy",
+        "degraded",
+        "sync-advisory",
+    }:
+        attach_host_environment_finding(
+            mcps,
+            detail=finding,
+            fix_next=policy_mod.HEAL_PROMPT,
+        )
+
+
 def doctor_with_dependencies(
     project: Path, *, verify_clients: bool = True
 ) -> dict[str, object]:
@@ -4011,7 +4110,8 @@ def doctor_with_dependencies(
             ),
         )
         if not host_controller.hook_runtime_healthy(project.resolve(), managed_python):
-            apply_hooks_probe_failure(result, components)
+            # Owned hook payload stays healthy; host runtime probe is advisory (#5699).
+            apply_hooks_host_environment_probe(result, components)
     apply_merge_handoff_fix_next(project.resolve(), components)
     try:
         import importlib.util as _ilu
@@ -4022,13 +4122,7 @@ def doctor_with_dependencies(
             if _spec is not None and _spec.loader is not None:
                 _mod = _ilu.module_from_spec(_spec)
                 _spec.loader.exec_module(_mod)
-                server_ids = _mod.collect_server_ids(project.resolve())
-                error = _mod.uniqueness_error(server_ids)
-                if error and isinstance(components.get("mcps"), dict):
-                    result["status"] = "recovery-required"
-                    components["mcps"]["status"] = "recovery-required"
-                    components["mcps"]["detail"] = error
-                    components["mcps"]["fixNext"] = _mod.HEAL_PROMPT
+                apply_mcp_policy_doctor(result, components, project.resolve(), _mod)
                 conflict = _mod.user_instruction_conflict_error(project.resolve())
                 if conflict and isinstance(components.get("hosts"), dict):
                     result["status"] = "recovery-required"
@@ -4043,20 +4137,8 @@ def doctor_with_dependencies(
             if _spec is not None and _spec.loader is not None:
                 _mod = _ilu.module_from_spec(_spec)
                 _spec.loader.exec_module(_mod)
-                matched = _mod.core_matches_source(project.resolve())
-                core = components.get("core")
-                if isinstance(core, dict):
-                    core["coreMatchesSource"] = bool(matched.get("coreMatchesSource"))
-                    if matched.get("scope") == "repository" and not matched.get(
-                        "coreMatchesSource"
-                    ):
-                        # Record mismatch. Do not flip overall doctor status:
-                        # origin overlay already drifts from SOURCE on main.
-                        core["detail"] = "overlay-source-mismatch"
-                        core["fixNext"] = (
-                            "Reinstall so .chaos-engine owned files match chaos-engine/."
-                        )
-    except (OSError, RuntimeError, ValueError, AttributeError):
+                _mod.apply_doctor_overlay_match(result, project.resolve())
+    except (OSError, RuntimeError, ValueError, AttributeError, ImportError):
         # Optional #5689 probes; missing helpers must not crash doctor.
         pass
     if not verify_clients:

--- a/.chaos-engine/mcp_policy.py
+++ b/.chaos-engine/mcp_policy.py
@@ -106,18 +106,53 @@ def user_mcp_paths(home: Path | None = None) -> tuple[tuple[str, Path], ...]:
     return named
 
 
-def collect_server_ids(
-    project: Path,
-    home: Path | None = None,
-) -> list[str]:
-    names: list[str] = []
+def collect_project_server_ids(project: Path) -> list[str]:
+    """Server ids published by the project overlay `.mcp.json` (install-owned)."""
     project_mcp = project / ".mcp.json"
-    if project_mcp.is_file():
-        names.extend(server_ids_from_text(project_mcp.read_text(encoding="utf-8")))
+    if not project_mcp.is_file():
+        return []
+    return server_ids_from_text(project_mcp.read_text(encoding="utf-8"))
+
+
+def collect_user_server_ids(home: Path | None = None) -> list[str]:
+    """Server ids from user/global host MCP files (host-environment)."""
+    names: list[str] = []
     for _host, path in user_mcp_paths(home):
         if path.is_file():
             names.extend(server_ids_from_text(path.read_text(encoding="utf-8")))
     return names
+
+
+def collect_server_ids(
+    project: Path,
+    home: Path | None = None,
+) -> list[str]:
+    return [
+        *collect_project_server_ids(project),
+        *collect_user_server_ids(home),
+    ]
+
+
+def project_mcp_policy_error(project: Path) -> str | None:
+    """Install-blocking / doctor-failing when the project overlay published the conflict."""
+    return uniqueness_error(collect_project_server_ids(project))
+
+
+def user_mcp_policy_finding(
+    project: Path,
+    home: Path | None = None,
+) -> str | None:
+    """Host-environment advisory when only user/global (or cross-layer) MCP policy fails.
+
+    Project-overlay conflicts remain install-blocking via project_mcp_policy_error.
+    """
+    if project_mcp_policy_error(project) is not None:
+        return None
+    user_ids = collect_user_server_ids(home)
+    user_error = uniqueness_error(user_ids)
+    if user_error:
+        return user_error
+    return uniqueness_error([*collect_project_server_ids(project), *user_ids])
 
 
 _INSTRUCTION_START = "<!-- CHAOSENGINE:START -->"

--- a/.chaos-engine/overlay_match.py
+++ b/.chaos-engine/overlay_match.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Origin overlay must byte-match SOURCE for installer-owned files."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+
+SOURCE_DIR = "chaos-engine"
+OVERLAY_DIR = ".chaos-engine"
+REPOSITORY_DISTRIBUTION = "repository"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def is_repository_checkout(project: Path) -> bool:
+    return (project / SOURCE_DIR / "skills/chaos-engine/SKILL.md").is_file()
+
+
+def _install_module():
+    """Load sibling install.py without creating an import cycle."""
+    install_path = Path(__file__).resolve().with_name("install.py")
+    for module in list(sys.modules.values()):
+        file_name = getattr(module, "__file__", None)
+        if not file_name:
+            continue
+        try:
+            if Path(file_name).resolve() == install_path and hasattr(module, "source_files"):
+                return module
+        except OSError:
+            continue
+    spec = importlib.util.spec_from_file_location(
+        "ce_install_for_overlay_match", install_path
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to load ChaosEngine installer: {install_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def owned_source_files(source: Path) -> tuple[Path, ...]:
+    """Same payload source_files() copies for distribution=repository."""
+    return _install_module().source_files(source, REPOSITORY_DISTRIBUTION)
+
+
+def core_matches_source(project: Path) -> dict[str, object]:
+    """Compare overlay owned files to SOURCE. Adopters have no SOURCE tree."""
+    root = project.resolve()
+    if not is_repository_checkout(root):
+        return {"coreMatchesSource": True, "scope": "adopter"}
+    source = root / SOURCE_DIR
+    overlay = root / OVERLAY_DIR
+    if not overlay.is_dir():
+        return {
+            "coreMatchesSource": False,
+            "scope": "repository",
+            "detail": "overlay-absent",
+        }
+    mismatches: list[str] = []
+    for path in owned_source_files(source):
+        relative = path.relative_to(source).as_posix()
+        other = overlay / relative
+        if not other.is_file() or _sha256(path) != _sha256(other):
+            mismatches.append(relative)
+    return {
+        "coreMatchesSource": not mismatches,
+        "scope": "repository",
+        "mismatches": mismatches[:8],
+    }
+
+
+def apply_doctor_overlay_match(
+    result: dict[str, object], project: Path
+) -> None:
+    """Record coreMatchesSource; flip recovery-required only on mismatch."""
+    components = result.get("components")
+    if not isinstance(components, dict):
+        return
+    matched = core_matches_source(project)
+    core = components.get("core")
+    if not isinstance(core, dict):
+        return
+    core["coreMatchesSource"] = bool(matched.get("coreMatchesSource"))
+    if matched.get("scope") == "repository" and not matched.get("coreMatchesSource"):
+        result["status"] = "recovery-required"
+        core["status"] = "recovery-required"
+        core["detail"] = "overlay-source-mismatch"
+        core["fixNext"] = (
+            "Reinstall so .chaos-engine owned files match chaos-engine/."
+        )

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -162,11 +162,17 @@ schema v2 machine contract. **Contract:** for every **required** component,
 plugins false-healthy case is closed by reconciling marketplace activation in
 both commands). `doctor --json` also emits per-host `activationProof` and
 `clients`. CE-INSTALL-FAILED / Verify installation / doctor share the same
-component ids and fix-next vocabulary. Memory, MemPalace, and Graphify are
-advisory to ordinary tasks but remain strict in `doctor`; an unhealthy selected
-store still returns `recovery-required`. Maven Tools MCP is auto-installed when
-the project has a root `pom.xml`. On non-Maven projects it stays optional and
-absent does not make project health fail.
+component ids and fix-next vocabulary for **install-owned** health. User/global
+MCP alias pairs and non-owned host hook probes (for example Grok trust/loaded
+hooks, or a failed runtime hook probe when owned hook files are present) nest
+under `hostEnvironment` as `sync-advisory` findings with the existing heal
+prompt; they do not flip install-owned `hooks` / `mcps` to `recovery-required`
+and do not cause CE-INSTALL-FAILED. Project-overlay GitHub MCP duplicates still
+fail doctor (#5698). Memory, MemPalace, and Graphify are advisory to ordinary
+tasks but remain strict in `doctor`; an unhealthy selected store still returns
+`recovery-required`. Maven Tools MCP is auto-installed when the project has a
+root `pom.xml`. On non-Maven projects it stays optional and absent does not make
+project health fail.
 
 ### Default-on all-in-one bundle
 

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -3652,8 +3652,26 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
             if result["hosts"]["status"] != "healthy":  # type: ignore[index]
                 result["status"] = "recovery-required"
             if active_probes:
-                result["hosts"]["grok"] = host_controller.grok_runtime_status(project)  # type: ignore[index]
-                if result["hosts"]["grok"]["status"] == "recovery-required":  # type: ignore[index]
+                # Grok CLI trust/loaded-hooks probe is host-environment, not install-owned (#5699).
+                grok_probe = host_controller.grok_runtime_status(project)
+                result["hosts"]["grok"] = grok_probe  # type: ignore[index]
+                if (
+                    isinstance(grok_probe, dict)
+                    and grok_probe.get("status") == "recovery-required"
+                    and result["hosts"].get("status") == "healthy"  # type: ignore[index]
+                ):
+                    result["hosts"]["hostEnvironment"] = {  # type: ignore[index]
+                        "status": "sync-advisory",
+                        "detail": "grok-hooks-probe",
+                        "fixNext": str(
+                            grok_probe.get("detail")
+                            or "Trust and reload Grok project hooks, then rerun doctor."
+                        ),
+                    }
+                elif (
+                    isinstance(grok_probe, dict)
+                    and grok_probe.get("status") == "recovery-required"
+                ):
                     result["hosts"]["status"] = "recovery-required"  # type: ignore[index]
                     result["status"] = "recovery-required"
             removing = project / ".chaos-engine-runtime.removing"
@@ -3955,6 +3973,87 @@ def apply_hooks_probe_failure(result: dict[str, object], components: object) -> 
         hooks["fixNext"] = named
 
 
+def attach_host_environment_finding(
+    component: dict[str, object],
+    *,
+    detail: str,
+    fix_next: str,
+    code: str | None = None,
+) -> None:
+    """Record a host-environment advisory without flipping install-owned component health (#5699)."""
+    finding: dict[str, object] = {
+        "status": "sync-advisory",
+        "detail": detail,
+        "fixNext": fix_next,
+    }
+    if isinstance(code, str) and re.fullmatch(r"[A-Z][A-Z0-9_]{0,63}", code):
+        finding["code"] = code
+    component["hostEnvironment"] = finding
+
+
+def apply_hooks_host_environment_probe(
+    result: dict[str, object],
+    components: object,
+) -> None:
+    """Owned hook files stay healthy; runtime host probe is advisory (#5699)."""
+    if not isinstance(components, dict) or not isinstance(components.get("hooks"), dict):
+        return
+    hooks = components["hooks"]
+    if hooks.get("status") != "healthy":
+        apply_hooks_probe_failure(result, components)
+        return
+    named = component_fix_next(
+        "hooks",
+        {
+            "status": "recovery-required",
+            "detail": HOOKS_PROBE_FAILED_DETAIL,
+            "code": HOOKS_PROBE_FAILED_CODE,
+        },
+    )
+    attach_host_environment_finding(
+        hooks,
+        detail=HOOKS_PROBE_FAILED_DETAIL,
+        fix_next=named
+        or (
+            f"Run `{_doctor_python_cli()} .chaos-engine/install.py repair "
+            "--project . --component hooks`, reload/trust hooks in the active host, "
+            f"then `{_doctor_python_cli()} .chaos-engine/install.py doctor --project .`."
+        ),
+        code=HOOKS_PROBE_FAILED_CODE,
+    )
+
+
+def apply_mcp_policy_doctor(
+    result: dict[str, object],
+    components: object,
+    project: Path,
+    policy_mod: object,
+) -> None:
+    """Project-overlay MCP conflicts fail doctor; user/global aliases are advisory (#5699)."""
+    if not isinstance(components, dict) or not isinstance(components.get("mcps"), dict):
+        return
+    mcps = components["mcps"]
+    project_error = policy_mod.project_mcp_policy_error(project)
+    if project_error:
+        result["status"] = "recovery-required"
+        mcps["status"] = "recovery-required"
+        mcps["detail"] = project_error
+        mcps["fixNext"] = policy_mod.HEAL_PROMPT
+        return
+    finding = policy_mod.user_mcp_policy_finding(project)
+    if finding and mcps.get("status") in {
+        "healthy",
+        "compatible-legacy",
+        "degraded",
+        "sync-advisory",
+    }:
+        attach_host_environment_finding(
+            mcps,
+            detail=finding,
+            fix_next=policy_mod.HEAL_PROMPT,
+        )
+
+
 def doctor_with_dependencies(
     project: Path, *, verify_clients: bool = True
 ) -> dict[str, object]:
@@ -4011,7 +4110,8 @@ def doctor_with_dependencies(
             ),
         )
         if not host_controller.hook_runtime_healthy(project.resolve(), managed_python):
-            apply_hooks_probe_failure(result, components)
+            # Owned hook payload stays healthy; host runtime probe is advisory (#5699).
+            apply_hooks_host_environment_probe(result, components)
     apply_merge_handoff_fix_next(project.resolve(), components)
     try:
         import importlib.util as _ilu
@@ -4022,13 +4122,7 @@ def doctor_with_dependencies(
             if _spec is not None and _spec.loader is not None:
                 _mod = _ilu.module_from_spec(_spec)
                 _spec.loader.exec_module(_mod)
-                server_ids = _mod.collect_server_ids(project.resolve())
-                error = _mod.uniqueness_error(server_ids)
-                if error and isinstance(components.get("mcps"), dict):
-                    result["status"] = "recovery-required"
-                    components["mcps"]["status"] = "recovery-required"
-                    components["mcps"]["detail"] = error
-                    components["mcps"]["fixNext"] = _mod.HEAL_PROMPT
+                apply_mcp_policy_doctor(result, components, project.resolve(), _mod)
                 conflict = _mod.user_instruction_conflict_error(project.resolve())
                 if conflict and isinstance(components.get("hosts"), dict):
                     result["status"] = "recovery-required"

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -4916,6 +4916,40 @@ def format_blocking_fidelity_warnings(document: dict[str, object]) -> list[str]:
     return lines
 
 
+def format_host_environment_findings(document: dict[str, object]) -> list[str]:
+    """Surface install-owned-healthy host-environment advisories (#5699)."""
+    lines: list[str] = []
+    components = document.get("components")
+    if not isinstance(components, dict):
+        return lines
+    for name in sorted(str(item) for item in components):
+        item = components[name]
+        if not isinstance(item, dict):
+            continue
+        finding = item.get("hostEnvironment")
+        if not isinstance(finding, dict):
+            continue
+        if finding.get("status") not in {"sync-advisory", "compatible-legacy", "degraded"}:
+            continue
+        detail = finding.get("detail")
+        fix = finding.get("fixNext")
+        detail_text = detail if isinstance(detail, str) and detail.strip() else "advisory"
+        lines.append(f"[info] {name}/hostEnvironment — {detail_text}")
+        if isinstance(fix, str) and fix.strip():
+            lines.append(f"  fix-next: {fix.strip()}")
+    hosts = document.get("hosts")
+    if isinstance(hosts, dict):
+        finding = hosts.get("hostEnvironment")
+        if isinstance(finding, dict) and finding.get("status") == "sync-advisory":
+            detail = finding.get("detail")
+            fix = finding.get("fixNext")
+            detail_text = detail if isinstance(detail, str) and detail.strip() else "advisory"
+            lines.append(f"[info] hosts/hostEnvironment — {detail_text}")
+            if isinstance(fix, str) and fix.strip():
+                lines.append(f"  fix-next: {fix.strip()}")
+    return lines
+
+
 
 def format_fix_next_only(document: dict[str, object]) -> str:
     """Emit only actionable fix-next lines for unhealthy components (#5582)."""
@@ -4963,13 +4997,21 @@ def format_health_report(document: dict[str, object], *, kind: str | None = None
     ]
     if total:
         lines.append(f"components: {healthy}/{total} healthy")
+    advisories = format_host_environment_findings(document)
+    advisory_count = sum(1 for line in advisories if line.startswith("[info]"))
     if not failures:
-        # Keep the happy path short for first-time users.
+        # Keep the happy path short; still show host-environment advisories (#5699).
+        if advisories:
+            lines.append(f"issues: {advisory_count} info")
+            lines.append("")
+            lines.extend(advisories)
         lines.extend(format_blocking_fidelity_warnings(document))
         return "\n".join(lines) + "\n"
     counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
     for _name, _item, severity in failures:
         counts[severity] = counts.get(severity, 0) + 1
+    if advisory_count:
+        counts["info"] = counts.get("info", 0) + advisory_count
     summary = ", ".join(
         f"{counts[key]} {key}" for key in ("error", "warning", "info") if counts.get(key)
     )
@@ -4985,6 +5027,7 @@ def format_health_report(document: dict[str, object], *, kind: str | None = None
         fix = component_fix_next(name, item)
         if fix:
             lines.append(f"  fix-next: {fix}")
+    lines.extend(advisories)
     lines.extend(format_blocking_fidelity_warnings(document))
     return "\n".join(lines) + "\n"
 

--- a/chaos-engine/mcp_policy.py
+++ b/chaos-engine/mcp_policy.py
@@ -106,18 +106,53 @@ def user_mcp_paths(home: Path | None = None) -> tuple[tuple[str, Path], ...]:
     return named
 
 
-def collect_server_ids(
-    project: Path,
-    home: Path | None = None,
-) -> list[str]:
-    names: list[str] = []
+def collect_project_server_ids(project: Path) -> list[str]:
+    """Server ids published by the project overlay `.mcp.json` (install-owned)."""
     project_mcp = project / ".mcp.json"
-    if project_mcp.is_file():
-        names.extend(server_ids_from_text(project_mcp.read_text(encoding="utf-8")))
+    if not project_mcp.is_file():
+        return []
+    return server_ids_from_text(project_mcp.read_text(encoding="utf-8"))
+
+
+def collect_user_server_ids(home: Path | None = None) -> list[str]:
+    """Server ids from user/global host MCP files (host-environment)."""
+    names: list[str] = []
     for _host, path in user_mcp_paths(home):
         if path.is_file():
             names.extend(server_ids_from_text(path.read_text(encoding="utf-8")))
     return names
+
+
+def collect_server_ids(
+    project: Path,
+    home: Path | None = None,
+) -> list[str]:
+    return [
+        *collect_project_server_ids(project),
+        *collect_user_server_ids(home),
+    ]
+
+
+def project_mcp_policy_error(project: Path) -> str | None:
+    """Install-blocking / doctor-failing when the project overlay published the conflict."""
+    return uniqueness_error(collect_project_server_ids(project))
+
+
+def user_mcp_policy_finding(
+    project: Path,
+    home: Path | None = None,
+) -> str | None:
+    """Host-environment advisory when only user/global (or cross-layer) MCP policy fails.
+
+    Project-overlay conflicts remain install-blocking via project_mcp_policy_error.
+    """
+    if project_mcp_policy_error(project) is not None:
+        return None
+    user_ids = collect_user_server_ids(home)
+    user_error = uniqueness_error(user_ids)
+    if user_error:
+        return user_error
+    return uniqueness_error([*collect_project_server_ids(project), *user_ids])
 
 
 _INSTRUCTION_START = "<!-- CHAOSENGINE:START -->"

--- a/tests/scripts/test_chaos_engine_install_verify_5699.py
+++ b/tests/scripts/test_chaos_engine_install_verify_5699.py
@@ -1,0 +1,224 @@
+"""Install-verify health vs host-environment advisory (#5699)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "chaos-engine"
+TEST_COMMIT = "1" * 40
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+INSTALL = load(SOURCE / "install.py", "ce_install_verify_5699")
+POLICY = load(SOURCE / "mcp_policy.py", "ce_mcp_policy_5699")
+BOOTSTRAP = load(SOURCE / "bootstrap.py", "ce_bootstrap_5699")
+
+
+class AccountDependencyController:
+    def __init__(self, controller):
+        self._controller = controller
+
+    def __getattr__(self, name):
+        return getattr(self._controller, name)
+
+    def install_account_dependencies(self, project, _specification, **_kwargs):
+        receipt = {
+            "schemaVersion": 2,
+            "scope": "user",
+            "components": {
+                name: {"status": "healthy", "action": "reused"}
+                for name in (
+                    "uv",
+                    "python",
+                    "node",
+                    "java",
+                    "mempalace",
+                    "graphify",
+                    "memory",
+                    "context7",
+                )
+            },
+            "commands": {
+                name: str(Path(sys.executable).resolve())
+                for name in ("python3", "node", "memory-mcp", "mempalace-mcp")
+            },
+        }
+        project.joinpath(".chaos-engine-dependencies.json").write_text(
+            json.dumps(receipt), encoding="utf-8"
+        )
+        return receipt
+
+
+class InstallVerifyHealth5699Tests(unittest.TestCase):
+    def _install_portable(self, project: Path) -> None:
+        load_controller = INSTALL.load_dependency_controller
+
+        def load_account_controller(installed_root):
+            return AccountDependencyController(load_controller(installed_root))
+
+        with mock.patch.object(
+            INSTALL, "load_dependency_controller", side_effect=load_account_controller
+        ):
+            INSTALL.install_with_dependencies(project, SOURCE, TEST_COMMIT)
+
+    def _doctor_with_probes(
+        self,
+        project: Path,
+        *,
+        hook_healthy: bool,
+        home: Path | None = None,
+    ) -> dict:
+        hosts = INSTALL.load_installed_controller(project / ".chaos-engine", "hosts")
+        original_load = INSTALL.load_installed_controller
+        env = {**os.environ}
+        if home is not None:
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+            env["XDG_CONFIG_HOME"] = str(home / ".config")
+            for key in (
+                "CLAUDE_CONFIG",
+                "CODEX_HOME",
+                "GROK_HOME",
+                "GEMINI_HOME",
+                "COPILOT_HOME",
+            ):
+                env.pop(key, None)
+        with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+            hosts, "retrieval_runtime_status", return_value={"status": "healthy"}
+        ), mock.patch.object(
+            hosts,
+            "mcp_runtime_status",
+            return_value={"status": "healthy"},
+        ), mock.patch.object(
+            hosts, "hook_runtime_healthy", return_value=hook_healthy
+        ), mock.patch.object(
+            hosts, "grok_runtime_status", return_value={"status": "not-detected"}
+        ), mock.patch.object(
+            INSTALL,
+            "load_installed_controller",
+            side_effect=lambda root, name: (
+                hosts if name == "hosts" else original_load(root, name)
+            ),
+        ):
+            return INSTALL.doctor_with_dependencies(project, verify_clients=False)
+
+    def test_portable_verify_ignores_user_mcp_aliases_and_nonowned_hook_probe(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            project = root / "consumer"
+            home = root / "home"
+            project.mkdir()
+            home.mkdir()
+            self._install_portable(project)
+
+            (home / ".claude.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "github": {"command": "npx"},
+                            "github-gh": {"command": "npx"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            doctor = self._doctor_with_probes(
+                project, hook_healthy=False, home=home
+            )
+            hooks = doctor["components"]["hooks"]
+            mcps = doctor["components"]["mcps"]
+            self.assertEqual("healthy", hooks["status"])
+            self.assertEqual("healthy", mcps["status"])
+            self.assertEqual(
+                "sync-advisory",
+                hooks.get("hostEnvironment", {}).get("status"),
+            )
+            self.assertEqual(
+                "sync-advisory",
+                mcps.get("hostEnvironment", {}).get("status"),
+            )
+            self.assertEqual(POLICY.HEAL_PROMPT, mcps["hostEnvironment"]["fixNext"])
+            self.assertFalse(BOOTSTRAP._required_install_unhealthy(doctor))
+            self.assertTrue((project / ".chaos-engine/hooks/guard.py").is_file())
+            self.assertTrue((project / ".mcp.json").is_file())
+
+    def test_missing_owned_hook_or_project_mcp_still_fails_verify(self):
+        missing_hook = {
+            "status": "recovery-required",
+            "commit": TEST_COMMIT,
+            "kernel": {"status": "healthy"},
+            "hosts": {"status": "healthy"},
+            "dependencies": {"status": "healthy"},
+            "components": {
+                "hooks": {"status": "absent", "taskImpact": "required"},
+                "mcps": {"status": "healthy", "taskImpact": "required"},
+            },
+        }
+        missing_mcp = {
+            "status": "recovery-required",
+            "commit": TEST_COMMIT,
+            "kernel": {"status": "healthy"},
+            "hosts": {"status": "healthy"},
+            "dependencies": {"status": "healthy"},
+            "components": {
+                "hooks": {"status": "healthy", "taskImpact": "required"},
+                "mcps": {"status": "absent", "taskImpact": "required"},
+            },
+        }
+        self.assertTrue(BOOTSTRAP._required_install_unhealthy(missing_hook))
+        self.assertTrue(BOOTSTRAP._required_install_unhealthy(missing_mcp))
+
+    def test_project_level_github_mcp_still_fails_doctor(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            (project / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "github": {"command": "npx"},
+                            "github-gh": {"command": "npx"},
+                            "maven-tools-mcp": {"command": "java"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            error = POLICY.project_mcp_policy_error(project)
+            self.assertIsNotNone(error)
+            self.assertIn("github", error.casefold())
+
+            doctor = {
+                "status": "healthy",
+                "components": {
+                    "mcps": {"status": "healthy", "taskImpact": "required"},
+                },
+            }
+            INSTALL.apply_mcp_policy_doctor(doctor, doctor["components"], project, POLICY)
+            mcps = doctor["components"]["mcps"]
+            self.assertEqual("recovery-required", mcps["status"])
+            self.assertEqual(POLICY.HEAL_PROMPT, mcps.get("fixNext"))
+            self.assertEqual("recovery-required", doctor["status"])
+            self.assertTrue(BOOTSTRAP._required_install_unhealthy(doctor))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_chaos_engine_install_verify_5699.py
+++ b/tests/scripts/test_chaos_engine_install_verify_5699.py
@@ -158,6 +158,9 @@ class InstallVerifyHealth5699Tests(unittest.TestCase):
             )
             self.assertEqual(POLICY.HEAL_PROMPT, mcps["hostEnvironment"]["fixNext"])
             self.assertFalse(BOOTSTRAP._required_install_unhealthy(doctor))
+            rendered = INSTALL.format_health_report(doctor, kind="doctor")
+            self.assertIn("hostEnvironment", rendered)
+            self.assertIn(POLICY.HEAL_PROMPT, rendered)
             self.assertTrue((project / ".chaos-engine/hooks/guard.py").is_file())
             self.assertTrue((project / ".mcp.json").is_file())
 


### PR DESCRIPTION
## Summary

Delivers the installer verify health split for ChaosEngine so a successful portable install is not marked `CE-INSTALL-FAILED` by host-environment noise.

- Install-owned `hooks` / `mcps` stay healthy when owned files and project MCP policy are sound.
- User/global MCP alias pairs and non-owned host hook probes (failed runtime hook probe with owned files present; Grok trust/loaded-hooks probe) nest under `hostEnvironment` as `sync-advisory` findings with the existing heal prompt.
- Project-overlay GitHub MCP duplicates still fail doctor (#5698 preserved).
- Missing owned hooks or missing owned project MCP still fail verify.

Fixes #5699

## Tests

- `python3 -m unittest tests.scripts.test_chaos_engine_install_verify_5699`
- `python3 -m unittest tests.scripts.test_chaos_engine_host_parity_5698 tests.scripts.test_chaos_engine_token_max`
- `python3 -m unittest tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_keeps_memory_origin_main_desync_as_compatible_legacy_mcps tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_names_missing_managed_python_on_hooks_and_mcps`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`

## Note on PR family

#5701 already merged host parity. This follow-up keeps the same branch/problem family and lands only the installer verify split for #5699.