### PR TITLE
[CE] Fix nightly E2E visual OCR, Flutter dash shell, WinAppDriver (#5696 #5697)

### DIFF
--- a/.chaos-engine/profiles/shaft/references/shaft-mastery/appium-mobile.md
+++ b/.chaos-engine/profiles/shaft/references/shaft-mastery/appium-mobile.md
@@ -9,11 +9,13 @@ web emulation (Chrome device metrics) is a separate, cheaper path from real
 native automation.
 
 ## Incidents that must not repeat
-- `appium driver run windows install-wad` launches the WinAppDriver MSI via
-  an unawaited elevated `Start-Process` and returns "success" ~0.3s later —
-  the next step races the still-running installer. Poll for the installed
-  binary/process readiness before starting the server (PR #3408; the job had
-  failed 8/8 scheduled runs with 300s session-create timeouts).
+- Never use `appium driver run windows install-wad` in CI: it lists
+  `api.github.com/repos/microsoft/winappdriver/releases` unauthenticated and
+  403s under shared Actions IP rate limits (#5697). Install a pinned MSI via
+  `scripts/ci/install_winappdriver.ps1` (or an equivalent authenticated /
+  cached asset path). The older race where `install-wad` returned before the
+  MSI finished still applies if you resurrect that path — poll for
+  `WinAppDriver.exe` before starting Appium (PR #3408).
 - Chrome's emulated-device list drifts: Chrome 143 removed "Pixel 5",
   silently breaking every mobile-web-emulation flow pinned to it. Treat
   device names as data that rots; validate against the running browser and

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -360,28 +360,15 @@ jobs:
           bash scripts/ci/build_retry.sh 2 60
           mvn -pl shaft-engine -am -e test
           "-DskipTests" "-Dallure.automaticallyOpen=false" "-Dgpg.skip" "-Dcyclonedx.skip"
-      - name: Install Appium Windows driver
+      - name: Install Appium Windows driver and pinned WinAppDriver
+        shell: powershell
         run: |
           npm install -g appium@3.5.2
           appium driver install windows
-          appium driver run windows install-wad
-      - name: Verify WinAppDriver installation
-        shell: powershell
-        run: |
-          # install-wad launches the WinAppDriver MSI via an unawaited elevated
-          # Start-Process and returns immediately, so the binary may not exist yet.
-          $winAppDriverPath = Join-Path ${env:ProgramFiles(x86)} 'Windows Application Driver\WinAppDriver.exe'
-          $installed = $false
-          for ($i = 0; $i -lt 60; $i++) {
-            if (Test-Path $winAppDriverPath) {
-              $installed = $true
-              break
-            }
-            Start-Sleep -Seconds 1
-          }
-          if (-not $installed) {
-            throw "WinAppDriver did not finish installing at $winAppDriverPath after 60s."
-          }
+          # Do not use Appium's windows driver release lookup helper: it lists
+          # api.github.com/repos/microsoft/winappdriver/releases unauthenticated and
+          # 403s on Actions rate limits (#5697). Pin the MSI asset instead.
+          & "$env:GITHUB_WORKSPACE/scripts/ci/install_winappdriver.ps1" -Version "1.2.1"
       - name: Start Appium server and run Windows desktop flow
         continue-on-error: true
         shell: powershell

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -1212,7 +1212,10 @@ jobs:
           target: google_apis
           arch: x86_64
           script: |
-            set -euo pipefail
+            # android-emulator-runner invokes this script with /usr/bin/sh (dash on
+            # ubuntu-latest). dash rejects bash-only -o options and exits 2 before Maven
+            # runs, so Post-Test Report then fails with missing Allure/JaCoCo (#5696).
+            set -eu
             APK_PATH="$GITHUB_WORKSPACE/shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk"
             ls -l "$APK_PATH"
             adb devices

--- a/chaos-engine/profiles/shaft/references/shaft-mastery/appium-mobile.md
+++ b/chaos-engine/profiles/shaft/references/shaft-mastery/appium-mobile.md
@@ -9,11 +9,13 @@ web emulation (Chrome device metrics) is a separate, cheaper path from real
 native automation.
 
 ## Incidents that must not repeat
-- `appium driver run windows install-wad` launches the WinAppDriver MSI via
-  an unawaited elevated `Start-Process` and returns "success" ~0.3s later —
-  the next step races the still-running installer. Poll for the installed
-  binary/process readiness before starting the server (PR #3408; the job had
-  failed 8/8 scheduled runs with 300s session-create timeouts).
+- Never use `appium driver run windows install-wad` in CI: it lists
+  `api.github.com/repos/microsoft/winappdriver/releases` unauthenticated and
+  403s under shared Actions IP rate limits (#5697). Install a pinned MSI via
+  `scripts/ci/install_winappdriver.ps1` (or an equivalent authenticated /
+  cached asset path). The older race where `install-wad` returned before the
+  MSI finished still applies if you resurrect that path — poll for
+  `WinAppDriver.exe` before starting Appium (PR #3408).
 - Chrome's emulated-device list drifts: Chrome 143 removed "Pixel 5",
   silently breaking every mobile-web-emulation flow pinned to it. Treat
   device names as data that rots; validate against the running browser and

--- a/scripts/ci/install_winappdriver.ps1
+++ b/scripts/ci/install_winappdriver.ps1
@@ -1,0 +1,55 @@
+# Install a pinned WinAppDriver MSI without calling the GitHub Releases API.
+# Appium's windows-driver release lookup lists
+# https://api.github.com/repos/microsoft/winappdriver/releases unauthenticated and
+# 403s under shared Actions IP rate limits (#5697).
+param(
+    [string]$Version = "1.2.1",
+    [string]$MsiUrl = "",
+    [int]$ReadyTimeoutSeconds = 60
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($MsiUrl)) {
+    $MsiUrl = "https://github.com/microsoft/WinAppDriver/releases/download/v$Version/WindowsApplicationDriver_$Version.msi"
+}
+
+if ($MsiUrl -match "api\.github\.com/repos/microsoft/winappdriver") {
+    throw "Refusing WinAppDriver install URL that hits the GitHub Releases API: $MsiUrl"
+}
+
+$winAppDriverPath = Join-Path ${env:ProgramFiles(x86)} "Windows Application Driver\WinAppDriver.exe"
+if (Test-Path $winAppDriverPath) {
+    Write-Host "WinAppDriver already present at $winAppDriverPath"
+    exit 0
+}
+
+$msiPath = Join-Path $env:RUNNER_TEMP "WindowsApplicationDriver_$Version.msi"
+if (-not $env:RUNNER_TEMP) {
+    $msiPath = Join-Path ([System.IO.Path]::GetTempPath()) "WindowsApplicationDriver_$Version.msi"
+}
+
+Write-Host "Downloading pinned WinAppDriver from $MsiUrl"
+Invoke-WebRequest -Uri $MsiUrl -OutFile $msiPath
+
+Write-Host "Installing $msiPath"
+$install = Start-Process -FilePath "msiexec.exe" `
+    -ArgumentList @("/i", $msiPath, "/quiet", "/norestart") `
+    -Wait -PassThru
+if ($install.ExitCode -ne 0 -and $install.ExitCode -ne 3010) {
+    throw "msiexec failed with exit code $($install.ExitCode) while installing WinAppDriver."
+}
+
+$installed = $false
+for ($i = 0; $i -lt $ReadyTimeoutSeconds; $i++) {
+    if (Test-Path $winAppDriverPath) {
+        $installed = $true
+        break
+    }
+    Start-Sleep -Seconds 1
+}
+if (-not $installed) {
+    throw "WinAppDriver did not finish installing at $winAppDriverPath after ${ReadyTimeoutSeconds}s."
+}
+
+Write-Host "WinAppDriver ready at $winAppDriverPath"

--- a/scripts/ci/install_winappdriver.ps1
+++ b/scripts/ci/install_winappdriver.ps1
@@ -5,6 +5,8 @@
 param(
     [string]$Version = "1.2.1",
     [string]$MsiUrl = "",
+    # Matches shaft-infrastructure DesktopMobileSetupPlanner.WINAPPDRIVER_SHA256 for v1.2.1.
+    [string]$ExpectedSha256 = "a76a8f4e44b29bad331acf6b6c248fcc65324f502f28826ad2acd5f3c80857fe",
     [int]$ReadyTimeoutSeconds = 60
 )
 
@@ -31,6 +33,11 @@ if (-not $env:RUNNER_TEMP) {
 
 Write-Host "Downloading pinned WinAppDriver from $MsiUrl"
 Invoke-WebRequest -Uri $MsiUrl -OutFile $msiPath
+
+$actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $msiPath).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
+    throw "WinAppDriver MSI SHA-256 mismatch. expected=$ExpectedSha256 actual=$actualSha256"
+}
 
 Write-Host "Installing $msiPath"
 $install = Start-Process -FilePath "msiexec.exe" `

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -220,14 +220,16 @@ public class AndroidBasicInteractionsTests extends MobileTest {
                 .tap(AppiumBy.accessibilityId("Expandable Lists"))
                 .tap(AppiumBy.accessibilityId("3. Simple Adapter"));
 
-        byte[] group1Screenshot = driver.get().getDriver().findElement(group1).getScreenshotAs(OutputType.BYTES);
-        driver.get().touch()
-                .swipeElementIntoView(group18, TouchActions.SwipeDirection.DOWN)
-                .swipeElementIntoView(ImageTarget.fromBytes(group1Screenshot).matchingMode(ImageMatchingMode.AUTO),
-                        TouchActions.SwipeDirection.UP);
+        driver.get().touch().swipeElementIntoView(group18, TouchActions.SwipeDirection.DOWN);
+        byte[] group18Screenshot = driver.get().getDriver().findElement(group18).getScreenshotAs(OutputType.BYTES);
+
+        // Tiny "Group 1" crops match many list rows under AUTO; OCR uniquely names Group 1.
+        driver.get().touch().swipeElementIntoView(OcrTarget.exact("Group 1"), TouchActions.SwipeDirection.UP);
         Assert.assertTrue(driver.get().getDriver().findElement(group1).isDisplayed());
 
-        driver.get().touch().swipeElementIntoView(OcrTarget.exact("Group 18"), TouchActions.SwipeDirection.DOWN);
+        driver.get().touch().swipeElementIntoView(
+                ImageTarget.fromBytes(group18Screenshot).matchingMode(ImageMatchingMode.TEMPLATE).minimumConfidence(0.85),
+                TouchActions.SwipeDirection.DOWN);
         Assert.assertTrue(driver.get().getDriver().findElement(group18).isDisplayed());
     }
 
@@ -246,14 +248,15 @@ public class AndroidBasicInteractionsTests extends MobileTest {
                 .tap(AppiumBy.accessibilityId("5. Scrollable"));
 
         byte[] tab1Screenshot = driver.get().getDriver().findElement(tab1).getScreenshotAs(OutputType.BYTES);
-        driver.get().touch()
-                .swipeElementIntoView(tabs, tab12, TouchActions.SwipeDirection.RIGHT)
-                .swipeElementIntoView(tabs,
-                        ImageTarget.fromBytes(tab1Screenshot).matchingMode(ImageMatchingMode.AUTO),
-                        TouchActions.SwipeDirection.LEFT);
+        driver.get().touch().swipeElementIntoView(tabs, tab12, TouchActions.SwipeDirection.RIGHT);
+
+        driver.get().touch().swipeElementIntoView(tabs,
+                ImageTarget.fromBytes(tab1Screenshot).matchingMode(ImageMatchingMode.TEMPLATE).minimumConfidence(0.85),
+                TouchActions.SwipeDirection.LEFT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab1).isDisplayed());
 
-        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.exact("TAB 12"), TouchActions.SwipeDirection.RIGHT);
+        // Exact OCR on short tab labels is brittle on BrowserStack screenshots; containing keeps OCR proof.
+        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.containing("TAB 12"), TouchActions.SwipeDirection.RIGHT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab12).isDisplayed());
     }
 

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -227,8 +227,9 @@ public class AndroidBasicInteractionsTests extends MobileTest {
         driver.get().touch().swipeElementIntoView(OcrTarget.exact("Group 1"), TouchActions.SwipeDirection.UP);
         Assert.assertTrue(driver.get().getDriver().findElement(group1).isDisplayed());
 
+        // Image proof uses the Group 18 crop captured while that row was visible.
         driver.get().touch().swipeElementIntoView(
-                ImageTarget.fromBytes(group18Screenshot).matchingMode(ImageMatchingMode.TEMPLATE).minimumConfidence(0.85),
+                ImageTarget.fromBytes(group18Screenshot).matchingMode(ImageMatchingMode.AUTO),
                 TouchActions.SwipeDirection.DOWN);
         Assert.assertTrue(driver.get().getDriver().findElement(group18).isDisplayed());
     }
@@ -249,15 +250,22 @@ public class AndroidBasicInteractionsTests extends MobileTest {
 
         byte[] tab1Screenshot = driver.get().getDriver().findElement(tab1).getScreenshotAs(OutputType.BYTES);
         driver.get().touch().swipeElementIntoView(tabs, tab12, TouchActions.SwipeDirection.RIGHT);
+        byte[] tab12Screenshot = driver.get().getDriver().findElement(tab12).getScreenshotAs(OutputType.BYTES);
 
+        // Nightly LEFT image swipe already succeeded under AUTO; keep that proven path.
         driver.get().touch().swipeElementIntoView(tabs,
-                ImageTarget.fromBytes(tab1Screenshot).matchingMode(ImageMatchingMode.TEMPLATE).minimumConfidence(0.85),
+                ImageTarget.fromBytes(tab1Screenshot).matchingMode(ImageMatchingMode.AUTO),
                 TouchActions.SwipeDirection.LEFT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab1).isDisplayed());
 
-        // Exact OCR on short tab labels is brittle on BrowserStack screenshots; containing keeps OCR proof.
-        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.containing("TAB 12"), TouchActions.SwipeDirection.RIGHT);
+        // Exact OCR on short tab labels failed on BrowserStack; return with the selected-state tab12 crop.
+        driver.get().touch().swipeElementIntoView(tabs,
+                ImageTarget.fromBytes(tab12Screenshot).matchingMode(ImageMatchingMode.AUTO),
+                TouchActions.SwipeDirection.RIGHT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab12).isDisplayed());
+
+        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.containing("TAB 1"), TouchActions.SwipeDirection.LEFT);
+        Assert.assertTrue(driver.get().getDriver().findElement(tab1).isDisplayed());
     }
 
     @Test(groups = {"ApiDemosDebug"})

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -264,7 +264,8 @@ public class AndroidBasicInteractionsTests extends MobileTest {
                 TouchActions.SwipeDirection.RIGHT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab12).isDisplayed());
 
-        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.containing("TAB 1"), TouchActions.SwipeDirection.LEFT);
+        // Exact "TAB 1" — containing("TAB 1") also matches TAB 10–13.
+        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.exact("TAB 1"), TouchActions.SwipeDirection.LEFT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab1).isDisplayed());
     }
 

--- a/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
@@ -9,6 +9,7 @@ import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.ios.IOSDriver;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
@@ -27,13 +28,19 @@ import java.util.zip.ZipFile;
 public class IOSBasicInteractionsTest {
     private static final String ENABLE_NATIVE_IOS_E2E_PROPERTY = "shaft.enableNativeIosE2E";
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
+    /** BrowserStack Sample-iOS home control that opens the text screen. */
+    private static final By TEXT_BUTTON = AppiumBy.accessibilityId("Text Button");
+    /** BrowserStack Sample-iOS text field on the secondary text screen. */
+    private static final By TEXT_INPUT = AppiumBy.accessibilityId("Text Input");
+    /** BrowserStack Sample-iOS label that echoes typed text. */
+    private static final By TEXT_OUTPUT = AppiumBy.accessibilityId("Text Output");
 
     @Test
     public void test() {
-        new ElementActions(driver.get().getDriver()).performTouchAction().tap(AppiumBy.accessibilityId("Text Button"));
-        new ElementActions(driver.get().getDriver()).type(AppiumBy.accessibilityId("Text Input"), "hello@browserstack.com" + "\n");
+        new ElementActions(driver.get().getDriver()).performTouchAction().tap(TEXT_BUTTON);
+        new ElementActions(driver.get().getDriver()).type(TEXT_INPUT, "hello@browserstack.com" + "\n");
         Validations.assertThat()
-                .element(driver.get().getDriver(), AppiumBy.accessibilityId("Text Output"))
+                .element(driver.get().getDriver(), TEXT_OUTPUT)
                 .text()
                 .isEqualTo("hello@browserstack.com")
                 .perform();
@@ -42,7 +49,10 @@ public class IOSBasicInteractionsTest {
     /** Opt-in real-device proof that iOS can interact through device screenshots and OCR text. */
     @Test(groups = {"visual-ocr-mobile-acceptance"})
     public void visualAndOcrTargetsShouldInteractWithNativeControls() {
-        byte[] inputScreenshot = driver.get().getDriver().findElement(AppiumBy.accessibilityId("Text Input"))
+        // Text Input lives on the secondary screen opened by Text Button.
+        new ElementActions(driver.get().getDriver()).performTouchAction().tap(TEXT_BUTTON);
+
+        byte[] inputScreenshot = driver.get().getDriver().findElement(TEXT_INPUT)
                 .getScreenshotAs(OutputType.BYTES);
 
         driver.get().touch()
@@ -53,10 +63,10 @@ public class IOSBasicInteractionsTest {
         Assert.assertNotEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
         driver.get().touch().tap(OcrTarget.exact("Text Input"));
         Assert.assertEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
-        driver.get().element().type(AppiumBy.accessibilityId("Text Input"), "visual ocr ios" + "\n");
+        driver.get().element().type(TEXT_INPUT, "visual ocr ios" + "\n");
 
         Validations.assertThat()
-                .element(driver.get().getDriver(), AppiumBy.accessibilityId("Text Output"))
+                .element(driver.get().getDriver(), TEXT_OUTPUT)
                 .text()
                 .isEqualTo("visual ocr ios")
                 .perform();

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -6,9 +6,14 @@ import unittest
 import yaml
 
 
-WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "e2eTests.yml"
-ANDROID_TESTS = (Path(__file__).resolve().parents[2] / "shaft-engine" / "src" / "test" / "java" /
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "e2eTests.yml"
+LOCAL_WORKFLOW = ROOT / ".github" / "workflows" / "e2eLocalTests.yml"
+ANDROID_TESTS = (ROOT / "shaft-engine" / "src" / "test" / "java" /
                  "testPackage" / "appium" / "AndroidBasicInteractionsTests.java")
+IOS_TESTS = (ROOT / "shaft-engine" / "src" / "test" / "java" /
+             "testPackage" / "appium" / "IOSBasicInteractionsTest.java")
+WINAPPDRIVER_INSTALLER = ROOT / "scripts" / "ci" / "install_winappdriver.ps1"
 
 
 class VisualOcrWorkflowTest(unittest.TestCase):
@@ -91,3 +96,49 @@ class VisualOcrWorkflowTest(unittest.TestCase):
                         names.index("Set up JDK 25 for Maven"))
         self.assertLess(names.index("Set up JDK 25 for Maven"),
                         names.index("Install engine dependencies for FlutterTest"))
+
+    def test_flutter_emulator_script_avoids_pipefail_under_dash(self):
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["Android_Flutter_Emulator_E2E"]["steps"]
+        emulator = next(step for step in steps if step.get("uses", "").startswith(
+            "reactivecircus/android-emulator-runner@"))
+        script = emulator["with"]["script"]
+        self.assertNotRegex(script, r"(?m)^\s*set -[^\n]*pipefail")
+        self.assertRegex(script, r"(?m)^\s*set -eu\s*$")
+
+    def test_ios_visual_ocr_uses_shared_locators_and_opens_text_screen(self):
+        ios_tests = IOS_TESTS.read_text(encoding="utf-8")
+        self.assertIn('TEXT_BUTTON = AppiumBy.accessibilityId("Text Button")', ios_tests)
+        self.assertIn('TEXT_INPUT = AppiumBy.accessibilityId("Text Input")', ios_tests)
+        method = re.search(
+            r"public void visualAndOcrTargetsShouldInteractWithNativeControls\(\) \{(.*?)\n    @",
+            ios_tests,
+            flags=re.S,
+        )
+        self.assertIsNotNone(method)
+        body = method.group(1)
+        self.assertIn("tap(TEXT_BUTTON)", body)
+        self.assertIn("findElement(TEXT_INPUT)", body)
+        self.assertNotRegex(body, r'AppiumBy\.accessibilityId\("Text Input"\)')
+
+    def test_android_visual_ocr_avoids_ambiguous_auto_group1_image_target(self):
+        android_tests = ANDROID_TESTS.read_text(encoding="utf-8")
+        method = re.search(
+            r"public void visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls\(\) \{(.*?)\n    @",
+            android_tests,
+            flags=re.S,
+        )
+        self.assertIsNotNone(method)
+        body = method.group(1)
+        self.assertIn('OcrTarget.exact("Group 1")', body)
+        self.assertNotIn("ImageMatchingMode.AUTO", body)
+
+    def test_windows_appium_desktop_pins_winappdriver_without_releases_api(self):
+        local_workflow = LOCAL_WORKFLOW.read_text(encoding="utf-8")
+        installer = WINAPPDRIVER_INSTALLER.read_text(encoding="utf-8")
+        self.assertNotRegex(local_workflow, r"(?m)^\s*[^#\n]*install-wad")
+        self.assertNotRegex(local_workflow, r"(?m)^\s*[^#\n]*api\.github\.com/repos/microsoft/winappdriver")
+        self.assertIn("install_winappdriver.ps1", local_workflow)
+        self.assertIn("WindowsApplicationDriver_", installer)
+        self.assertIn("api\\.github\\.com/repos/microsoft/winappdriver", installer)
+        self.assertIn("Refusing WinAppDriver install URL that hits the GitHub Releases API", installer)

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -149,7 +149,8 @@ class VisualOcrWorkflowTest(unittest.TestCase):
         self.assertIn("tab12Screenshot", body)
         self.assertIn("ImageTarget.fromBytes(tab12Screenshot)", body)
         self.assertNotIn('OcrTarget.exact("TAB 12")', body)
-        self.assertIn('OcrTarget.containing("TAB 1")', body)
+        self.assertNotIn('OcrTarget.containing("TAB 1")', body)
+        self.assertIn('OcrTarget.exact("TAB 1")', body)
 
     def test_windows_appium_desktop_pins_winappdriver_without_releases_api(self):
         local_workflow = LOCAL_WORKFLOW.read_text(encoding="utf-8")

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -131,7 +131,25 @@ class VisualOcrWorkflowTest(unittest.TestCase):
         self.assertIsNotNone(method)
         body = method.group(1)
         self.assertIn('OcrTarget.exact("Group 1")', body)
-        self.assertNotIn("ImageMatchingMode.AUTO", body)
+        self.assertIsNone(re.search(
+            r"ImageTarget\.fromBytes\(group1Screenshot\).*ImageMatchingMode\.AUTO",
+            body,
+            flags=re.S,
+        ))
+
+    def test_android_visual_ocr_horizontal_uses_tab12_image_not_exact_ocr(self):
+        android_tests = ANDROID_TESTS.read_text(encoding="utf-8")
+        method = re.search(
+            r"public void visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl\(\) \{(.*?)\n    @",
+            android_tests,
+            flags=re.S,
+        )
+        self.assertIsNotNone(method)
+        body = method.group(1)
+        self.assertIn("tab12Screenshot", body)
+        self.assertIn("ImageTarget.fromBytes(tab12Screenshot)", body)
+        self.assertNotIn('OcrTarget.exact("TAB 12")', body)
+        self.assertIn('OcrTarget.containing("TAB 1")', body)
 
     def test_windows_appium_desktop_pins_winappdriver_without_releases_api(self):
         local_workflow = LOCAL_WORKFLOW.read_text(encoding="utf-8")
@@ -142,3 +160,5 @@ class VisualOcrWorkflowTest(unittest.TestCase):
         self.assertIn("WindowsApplicationDriver_", installer)
         self.assertIn("api\\.github\\.com/repos/microsoft/winappdriver", installer)
         self.assertIn("Refusing WinAppDriver install URL that hits the GitHub Releases API", installer)
+        self.assertIn("a76a8f4e44b29bad331acf6b6c248fcc65324f502f28826ad2acd5f3c80857fe", installer)
+        self.assertIn("Get-FileHash -Algorithm SHA256", installer)


### PR DESCRIPTION
## Summary
Fixes scheduled nightly failures from runs [34316011126](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/34316011126) and [34316227830](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/34316227830).

### #5696 E2E Tests
- **iOS_Visual_Ocr_BrowserStack:** `visualAndOcrTargetsShouldInteractWithNativeControls` looked for accessibility id `Text Input` on the Sample-iOS home screen. That control still exists on the secondary text screen opened by `Text Button`. Shared locators now open that screen first.
- **Android_Visual_Ocr_BrowserStack:** vertical AUTO image matching of Group 1 was ambiguous across list rows; OCR uniquely finds `Group 1`, then image-scrolls using a Group 18 crop captured while visible. Horizontal keeps the proven AUTO image LEFT for TAB 1, returns via a selected-state TAB 12 image crop (exact tab OCR failed nightly), then OCR-exact `TAB 1` for OCR proof.
- **Android_Flutter_Emulator_E2E:** Gradle/Maven succeeded, but `reactivecircus/android-emulator-runner` runs the job script with `/usr/bin/sh` (dash), which rejected `set -o pipefail` (`Illegal option -o pipefail`, exit 2). Maven FlutterTest never ran, so Post-Test Report failed on missing Allure/JaCoCo. Script now uses dash-safe `set -eu`.

### #5697 Local E2E Tests
- **Windows_Appium_Desktop_Local:** `appium driver run windows install-wad` listed `api.github.com/repos/microsoft/winappdriver/releases` unauthenticated and 403'd. Replaced with pinned MSI install via `scripts/ci/install_winappdriver.ps1` (v1.2.1 asset URL + SHA-256 check matching DesktopMobileSetupPlanner, no Releases API). Only this Windows desktop job performed that fetch.

### Recurrence guards
- `tests/scripts/test_visual_ocr_workflow.py` asserts iOS shared locators + Text Button navigation, Android vertical/horizontal visual-OCR contracts, Flutter script has no executable `pipefail`, and Local E2E does not invoke unauthenticated WinAppDriver release lookup.

## Test plan
- [x] `python3 -m unittest tests.scripts.test_visual_ocr_workflow -v`
- [ ] Exact-head PR checks

Fixes #5696
Fixes #5697