### PR TITLE
[CE] Rematerialize invalid Maven Tools cache and clarify install failure prompts

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -409,7 +409,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.agent_guidance == 'true' || needs.changes.outputs.pr_gate == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read
@@ -453,7 +453,7 @@ jobs:
           --base "$BASE_SHA"
           --head "$HEAD_SHA"
           --reviews "$REVIEWS_PATH"
-          --budget-seconds 360
+          --budget-seconds 540
           --output harness-pr-gate.json
       - name: Upload harness gate receipt
         if: always()

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -413,11 +413,16 @@ creates one container per client and keeps Docker Desktop and its VM resident.
 
 A root `pom.xml`, or `--with-maven-tools`, performs the upstream native JAR flow:
 
-1. Resolve system Temurin 25 from `CHAOSENGINE_JAVA`, `JAVA_HOME`, or `PATH`.
-2. Resolve the latest compatible stable GitHub release, clone its tag with
-   `--depth 1`, record the tag's immutable commit, and run
-   `./mvnw -B clean package -Pci`. Git and Java are required; no private archive
-   fallback exists.
+1. Resolve Temurin JDK 25+ (with `javac`) from `CHAOSENGINE_JAVA`, `JAVA_HOME`,
+   or `PATH`. When no suitable ambient JDK exists, provision the checksum-verified
+   managed Temurin JDK from `dependencies.json` into the CE tools cache.
+2. When ambient `mvn` is missing or below the declared Maven minimum, provision a
+   checksum-verified managed Apache Maven distribution into the CE tools cache.
+   Resolve the latest compatible stable GitHub release, clone its tag with
+   `--depth 1`, record the tag's immutable commit, ensure `./mvnw` is executable,
+   set `JAVA_HOME` to the managed/ambient JDK, and run
+   `./mvnw -B clean package -Pci`. Git is required; the upstream wrapper remains
+   the build entrypoint.
 3. Stage `maven-tools-mcp-<resolved-version>.jar` under a fresh unique directory on the same
    filesystem as the current user's data directory, then publish that directory
    with a no-overwrite rename to

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -313,7 +313,8 @@ Tracked prerequisites and optional boundaries:
 - Installed automatically when required: uv/uvx; active LTS Node 22+ with
   npm/npx; Temurin 25; latest stable Graphify, MemPalace, Memory, and ctx7.
 - Optional: `--with-maven-tools` builds latest stable upstream source with Git,
-  system Java 25, and the Maven wrapper.
+  Temurin JDK 25+ (ambient or managed), and the Maven wrapper (plus managed
+  Apache Maven when ambient `mvn` is missing or below minimum).
 - Generated and never tracked: dependency generations, receipts, caches,
   Graphify output, MemPalace indexes, Memory runtime indexes, reports, secrets.
 - Canonical skills: `chaos-engine`, `caveman`, `ponytail`; project profiles and
@@ -335,7 +336,7 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | curl or wget | Download immutable source on POSIX. | install.sh | required on POSIX | Linux, macOS | operator | consumer environment | download fails closed |
 | Node.js, npm, and npx | Provision Memory, Context7 CLI, and plugin MCP runtimes. | dependencies.json; hooks/launch.js | managed | Windows, Linux, macOS | platform standard provider | user account | install stops before activation |
 | network | Resolve source and provision a fresh or upgraded generation. | bootstrap.py; dependencies.py | required for fresh install or upgrade | Windows, Linux, macOS | operator | prior verified generation remains active |
-| Git and Temurin Java 25 | Build optional Maven Tools MCP cache. | dependencies.json; install.py; hosts.py | optional and managed with `--with-maven-tools` | Windows, Linux, macOS | platform provider plus upstream Maven wrapper | receipt-owned shared cache | optional component reports absent |
+| Git, managed Temurin JDK 25+, and managed Apache Maven | Build optional Maven Tools MCP cache when ambient JDK/Maven are missing. | dependencies.json; install.py; hosts.py | optional and managed with `--with-maven-tools` | Windows, Linux, macOS | managed Temurin/Maven cache plus upstream Maven wrapper | receipt-owned shared cache | optional component reports absent |
 <!-- inventory:prerequisites:end -->
 
 ### Python Libraries
@@ -375,7 +376,7 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | shutil | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/draft_skill_pr.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/skills/freetoken/scripts/probe.py, chaos-engine/skills/omniroute/scripts/runner.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | signal | Portable runtime standard-library dependency. | chaos-engine/skills/omniroute/scripts/runner.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | sqlite3 | Portable runtime standard-library dependency. | chaos-engine/hosts.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
-| stat | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/skills/omniroute/scripts/runner.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
+| stat | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/skills/omniroute/scripts/runner.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | subprocess | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/draft_skill_pr.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/retrieve.py, chaos-engine/silent_verify.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | sys | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/draft_skill_pr.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/learning_session.py, chaos-engine/overlay_match.py, chaos-engine/retrieve.py, chaos-engine/silent_verify.py, chaos-engine/skills/freetoken/scripts/probe.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | tarfile | Portable runtime standard-library dependency. | chaos-engine/dependencies.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -395,22 +395,36 @@ def core_install_py(project: Path) -> bool:
     return (Path(project) / ".chaos-engine" / "install.py").is_file()
 
 
+def heal_issue_reference(issue_url: str) -> str:
+    """Prefer a short issue locator inside copy-paste agent prompts."""
+    if not issue_url or "issues/new?" in issue_url:
+        return "the GitHub issue URL printed above"
+    return issue_url
+
+
 def heal_handoff_prompt(doctor_command: str, issue_url: str) -> str:
     cli = "py -3" if os.name == "nt" else "python3"
+    issue_ref = heal_issue_reference(issue_url)
     if doctor_command == "not available":
         return (
-            "Load ChaosEngine if present. Restore the portable core with the documented "
-            "ChaosEngine install one-liner, then read .chaos-engine-state/heal-handoff.md. "
-            f"Comment investigation and outcome on {issue_url}."
+            "Continue ChaosEngine install in this folder. Load ChaosEngine if present. "
+            "Restore the portable core with the documented ChaosEngine install one-liner, "
+            "then read .chaos-engine-state/heal-handoff.md. "
+            f"Open {issue_ref} and comment findings, solutions, and troubleshooting steps. "
+            "Ask the user whether they want to attempt a fix by opening an upstream PR "
+            "linked to that issue."
         )
     return (
-        "Load ChaosEngine in this project. Read .chaos-engine-state/heal-handoff.md "
-        "and the local install-trace.json, install-console.log, and doctor-failure.json. "
+        "Continue ChaosEngine install in this folder. Load ChaosEngine. "
+        "Read .chaos-engine-state/heal-handoff.md and the local install-trace.json, "
+        "install-console.log, and doctor-failure.json. "
         "Do not rerun the install one-liner unless the portable core is missing. "
-        "Repair the named unhealthy components with "
-        f"`{cli} .chaos-engine/install.py repair --project . --component <name>` "
-        f"and `{doctor_command}` until required components are healthy. "
-        f"Then comment investigation, commands, doctor excerpt, and outcome on {issue_url}."
+        "Continue unhealthy components with "
+        f"{cli} .chaos-engine/install.py repair --project . --component <name> "
+        f"and {doctor_command} until required components are healthy. "
+        f"Open {issue_ref} and comment findings, solutions, and troubleshooting steps. "
+        "Ask the user whether they want to attempt a fix by opening an upstream PR "
+        "linked to that issue."
     )
 
 
@@ -420,7 +434,7 @@ def write_heal_handoff(project: Path, fields: dict[str, str], issue_url: str) ->
     lines = [
         "# Heal handoff",
         "",
-        "The portable core is installed. One agent step remains.",
+        "The portable core is installed. Continue with one agent step.",
         "",
         f"Issue: {issue_url}",
         "",
@@ -1007,16 +1021,15 @@ class InstallReporter:
             prompt = heal_handoff_prompt(doctor_command, issue_url)
             self.stream.write(self._paint("  Heal handoff", "36") + "\n")
             self.stream.write(
-                "Core is installed. One agent step remains. Details: "
+                "Core is installed. Continue with one agent step. Details: "
                 f"{HEAL_HANDOFF_RELATIVE}\n"
             )
             if "issues/new?" in issue_url:
-                self.stream.write(
-                    "Open this GitHub issue (required fields are filled), then paste the prompt:\n"
-                )
+                self.stream.write("Open issue:\n")
             else:
                 self.stream.write("GitHub issue:\n")
             self.stream.write(f"{issue_url}\n")
+            self.stream.write("Agent prompt (copy the backtick block):\n")
             self.stream.write(f"`{prompt}`\n")
         self.stream.write(
             format_host_onboarding_cards(
@@ -2028,14 +2041,12 @@ def emit_install_failure(
         )
         prompt = heal_handoff_prompt(fields["doctor_command"], issue_url)
         if "issues/new?" in issue_url:
-            print(
-                "Next step: click this link to open a GitHub issue with this report:",
-                file=sys.stderr,
-            )
+            print("Open issue:", file=sys.stderr)
         else:
-            print("Next step: review the filed GitHub issue:", file=sys.stderr)
+            print("GitHub issue:", file=sys.stderr)
         print(issue_url, file=sys.stderr)
-        print("Give this prompt to your agent in this folder:", file=sys.stderr)
+        print(file=sys.stderr)
+        print("Agent prompt (copy the backtick block):", file=sys.stderr)
         print(f"`{prompt}`", file=sys.stderr)
         if os.environ.get("CHAOS_ENGINE_DEBUG") == "1":
             traceback.print_exc()

--- a/chaos-engine/dependencies.json
+++ b/chaos-engine/dependencies.json
@@ -30,13 +30,21 @@
       "macos-arm64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz", "sha256": "8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d"}
     }},
     "maven-tools-source": {"version": "4475ff6c61f23ea9a93cb6d5665a63235ef2ef36", "url": "https://github.com/arvindand/maven-tools-mcp/archive/4475ff6c61f23ea9a93cb6d5665a63235ef2ef36.zip", "sha256": "ceba276c3bf90bafbb4d7f109006d0cffa640466f0146826ce749c77a033bef8"},
-    "temurin": {"version": "25.0.4+7", "artifacts": {
+    "temurin": {"version": "25.0.4+7", "minimumVersion": "25.0.0", "artifacts": {
       "windows-x64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip", "sha256": "7caab7db43bf4b94a2e6252c699e70d90084f9aa7c943cd3414761fd540937ae"},
       "windows-arm64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip", "sha256": "7caab7db43bf4b94a2e6252c699e70d90084f9aa7c943cd3414761fd540937ae", "artifactArchitecture": "x64", "emulated": true},
       "linux-x64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_linux_hotspot_25.0.4_7.tar.gz", "sha256": "e58fcdcd637b25c03ca84cbbcefc70d11efb8f4b4cbd05decc9f661769d77f94"},
       "linux-arm64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.4_7.tar.gz", "sha256": "621f7196f0b682fb557da58bec89bd7dfe5419811fe1c0ba75c9cc8432f084c7"},
       "macos-x64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_mac_hotspot_25.0.4_7.tar.gz", "sha256": "a5ac9c46dad47ac06df35e36d096913195d8da1f3f71918828bcc2cfe33869b7"},
       "macos-arm64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.tar.gz", "sha256": "5a101c54abf5a9f16c0f70d8c38ba99e6567c1ba213378f0bb04497284f051bd"}
+    }},
+    "maven": {"version": "3.9.12", "minimumVersion": "3.9.0", "artifacts": {
+      "windows-x64": {"url": "https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.zip", "sha256": "305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef"},
+      "windows-arm64": {"url": "https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.zip", "sha256": "305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef", "artifactArchitecture": "x64", "emulated": true},
+      "linux-x64": {"url": "https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz", "sha256": "fa2c9948729296c23afd18fd01a90f62cdda09a46191b54a8bc3764c2eee812e"},
+      "linux-arm64": {"url": "https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz", "sha256": "fa2c9948729296c23afd18fd01a90f62cdda09a46191b54a8bc3764c2eee812e"},
+      "macos-x64": {"url": "https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz", "sha256": "fa2c9948729296c23afd18fd01a90f62cdda09a46191b54a8bc3764c2eee812e"},
+      "macos-arm64": {"url": "https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz", "sha256": "fa2c9948729296c23afd18fd01a90f62cdda09a46191b54a8bc3764c2eee812e"}
     }}
   },
   "tools": {

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -117,6 +117,13 @@ def version_key(value: str) -> tuple[int, ...]:
     return tuple(int(part) for part in parts)
 
 
+def version_at_least(actual: str | int, minimum: str | int) -> bool:
+    """True when actual is higher than or equal to the supported minimum floor."""
+    if isinstance(actual, int) and isinstance(minimum, int):
+        return actual >= minimum
+    return version_key(str(actual)) >= version_key(str(minimum))
+
+
 def latest_compatible_stable(
     candidates: list[dict[str, object]], *, minimum: str
 ) -> str:

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -2431,6 +2431,105 @@ def purge_maven_tools_cache(
         return {**observed, "status": "purged"}
 
 
+def _path_is_under(path: Path, root: Path) -> bool:
+    try:
+        path.absolute().relative_to(root.absolute())
+    except ValueError:
+        return False
+    return True
+
+
+def _discard_tree_nofollow(path: Path, cache_root: Path) -> None:
+    """Remove a cache subtree without following links out of the cache root."""
+    path = path.absolute()
+    cache_root = cache_root.absolute()
+    if not _path_is_under(path, cache_root):
+        raise ValueError("Maven Tools MCP discard path escapes cache root")
+    if is_link_or_reparse(path):
+        path.unlink()
+        return
+    if path.is_file() or path.is_symlink():
+        path.unlink()
+        return
+    if not path.is_dir():
+        return
+    for child in list(path.iterdir()):
+        if not _path_is_under(child, cache_root):
+            raise ValueError("Maven Tools MCP discard path escapes cache root")
+        if is_link_or_reparse(child):
+            child.unlink()
+        elif child.is_dir():
+            _discard_tree_nofollow(child, cache_root)
+        else:
+            child.unlink()
+    path.rmdir()
+
+
+def discard_invalid_maven_tools_cache(
+    version: str, *, root: Path | None = None
+) -> dict[str, str]:
+    """Discard an invalid Maven Tools version tree so install can rebuild it.
+
+    Healthy trees stay purge-only via purge_maven_tools_cache. Never follows
+    links out of the cache root: linked leaves are unlinked in place.
+    """
+    cache_root = (root or maven_tools_cache_root()).absolute()
+    anchor = _cache_anchor(cache_root)
+    version_root = _maven_tools_version_directory(cache_root, version)
+    result = {
+        "component": "maven-tools-mcp",
+        "version": version,
+        "path": str(version_root),
+    }
+    if not cache_root.exists() and not is_link_or_reparse(cache_root):
+        return {**result, "status": "absent"}
+    with maven_tools_cache_lock(cache_root, anchor=anchor):
+        _validate_cache_path(cache_root, anchor)
+        try:
+            observed = _maven_tools_cache_status_unlocked(
+                cache_root, version, anchor=anchor
+            )
+        except ValueError:
+            # Linked version leaves fail path validation; still discardable in place.
+            if is_link_or_reparse(version_root) and _path_is_under(
+                version_root, cache_root
+            ):
+                observed = {
+                    **result,
+                    "status": "invalid",
+                    "reason": "cache path is linked or invalid",
+                }
+            else:
+                raise
+        if observed["status"] == "absent":
+            return observed
+        if observed["status"] == "healthy":
+            raise ValueError(
+                "Maven Tools MCP cache discard refused: healthy cache requires purge"
+            )
+        if observed["status"] != "invalid":
+            raise ValueError(
+                f"Maven Tools MCP cache discard refused: {observed.get('status', 'unknown')}"
+            )
+        tombstone = cache_root / f".purging-{version}"
+        for marker in (tombstone, *sorted(cache_root.glob(f".purged-{version}-*"))):
+            if is_link_or_reparse(marker):
+                if not _path_is_under(marker, cache_root):
+                    raise ValueError("Maven Tools MCP discard path escapes cache root")
+                marker.unlink()
+            elif marker.exists():
+                _discard_tree_nofollow(marker, cache_root)
+        if is_link_or_reparse(version_root):
+            if not _path_is_under(version_root, cache_root):
+                raise ValueError("Maven Tools MCP discard path escapes cache root")
+            version_root.unlink()
+        elif version_root.exists():
+            claim = cache_root / f".discarding-{version}-{secrets.token_hex(16)}"
+            _rename_no_replace(version_root, claim)
+            _discard_tree_nofollow(claim, cache_root)
+        return {**observed, "status": "discarded"}
+
+
 def publish_maven_tools_cache(staging: Path, *, root: Path | None = None) -> Path:
     staging = staging.absolute()
     cache_root = (root or maven_tools_cache_root()).absolute()

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -2027,16 +2027,116 @@ def java_compiler_present(java: Path) -> bool:
     return javac.is_file() and not is_link_or_reparse(javac)
 
 
-def managed_temurin_root(version: str = "25.0.4+7") -> Path:
+def _tools_host_platform() -> tuple[str, str, str]:
     system = "windows" if os.name == "nt" else "macos" if sys.platform == "darwin" else "linux"
     machine = platform.machine().lower()
     architecture = "arm64" if machine in {"arm64", "aarch64"} else "x64"
+    return system, architecture, f"{system}-{architecture}"
+
+
+def _load_dependencies_controller():
+    dependencies_path = Path(__file__).resolve().with_name("dependencies.py")
+    if not dependencies_path.is_file():
+        return None
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "chaos_engine_dependencies_managed_runtimes", dependencies_path
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _runtime_contract(
+    specification: dict[str, object] | None, name: str
+) -> dict[str, object] | None:
+    if not isinstance(specification, dict):
+        return None
+    runtimes = specification.get("runtimes")
+    selected = runtimes.get(name) if isinstance(runtimes, dict) else None
+    return selected if isinstance(selected, dict) else None
+
+
+def managed_temurin_root(version: str = "25.0.4+7") -> Path:
+    system, architecture, _host = _tools_host_platform()
     return (
         maven_tools_cache_root().parent
         / "temurin"
         / version
         / f"{system}-{architecture}"
     )
+
+
+def managed_maven_root(version: str = "3.9.12") -> Path:
+    system, architecture, _host = _tools_host_platform()
+    return (
+        maven_tools_cache_root().parent
+        / "maven"
+        / version
+        / f"{system}-{architecture}"
+    )
+
+
+def maven_version(mvn: Path) -> str | None:
+    """Parse a stable Apache Maven version from `mvn -v` output."""
+    try:
+        result = subprocess.run(  # nosec B603 - executable is resolved before use.
+            [str(mvn), "-v"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = re.search(
+        r"Apache Maven (?P<version>\d+(?:\.\d+){1,3})",
+        result.stdout + result.stderr,
+    )
+    return match.group("version") if match else None
+
+
+def verified_managed_maven(candidate: Path, host_platform: str, *, version: str) -> Path | None:
+    if not candidate.is_file() or is_link_or_reparse(candidate):
+        return None
+    receipt_path = candidate.parents[1] / TEMURIN_RECEIPT
+    if not receipt_path.is_file() or is_link_or_reparse(receipt_path):
+        return None
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    expected_architecture = (
+        "x64" if host_platform == "windows-arm64" else host_platform.split("-", 1)[1]
+    )
+    expected = {
+        "schemaVersion": 1,
+        "runtime": "maven",
+        "version": version,
+        "hostPlatform": host_platform,
+        "artifactArchitecture": expected_architecture,
+        "emulated": host_platform == "windows-arm64",
+        "mvn": candidate.relative_to(receipt_path.parent).as_posix(),
+        "mvnSha256": digest,
+    }
+    if receipt != expected:
+        return None
+    observed = maven_version(candidate)
+    if observed is None:
+        return None
+    module = _load_dependencies_controller()
+    if module is None:
+        return None
+    try:
+        if not module.version_at_least(observed, version):
+            return None
+    except ValueError:
+        return None
+    return candidate.resolve()
 
 
 def ensure_managed_temurin_jdk(
@@ -2047,43 +2147,33 @@ def ensure_managed_temurin_jdk(
     confirmer=None,
 ) -> Path | None:
     """Provision checksum-verified Temurin JDK into the CE tools cache when needed (#5630)."""
-    version = "25.0.4+7"
-    system = "windows" if os.name == "nt" else "macos" if sys.platform == "darwin" else "linux"
-    machine = platform.machine().lower()
-    architecture = "arm64" if machine in {"arm64", "aarch64"} else "x64"
-    host_platform = f"{system}-{architecture}"
+    system, architecture, host_platform = _tools_host_platform()
+    temurin = _runtime_contract(specification, "temurin")
+    version = (
+        str(temurin["version"])
+        if isinstance(temurin, dict) and isinstance(temurin.get("version"), str)
+        else "25.0.4+7"
+    )
     root = managed_temurin_root(version)
     java = root / (
         "bin/java.exe" if os.name == "nt" else
         "Contents/Home/bin/java" if sys.platform == "darwin" else "bin/java"
     )
-    verified = verified_managed_temurin(java, host_platform)
+    verified = verified_managed_temurin(java, host_platform, version=version)
     if verified is not None and java_compiler_present(verified):
         return verified
-    if specification is None:
+    if specification is None or temurin is None:
         return None
-    runtimes = specification.get("runtimes")
-    temurin = runtimes.get("temurin") if isinstance(runtimes, dict) else None
-    artifacts = temurin.get("artifacts") if isinstance(temurin, dict) else None
+    artifacts = temurin.get("artifacts")
     artifact = artifacts.get(host_platform) if isinstance(artifacts, dict) else None
     if not isinstance(artifact, dict):
         return None
     url, digest = artifact.get("url"), artifact.get("sha256")
     if not isinstance(url, str) or not isinstance(digest, str):
         return None
-    # Lazy-import download helpers from colocated dependencies controller.
-    dependencies_path = Path(__file__).resolve().with_name("dependencies.py")
-    if not dependencies_path.is_file():
+    module = _load_dependencies_controller()
+    if module is None:
         return None
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "chaos_engine_dependencies_temurin", dependencies_path
-    )
-    if spec is None or spec.loader is None:
-        return None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
     open_url = opener or urllib.request.urlopen
     parent = root.parent
     parent.mkdir(parents=True, exist_ok=True)
@@ -2097,7 +2187,7 @@ def ensure_managed_temurin_jdk(
     try:
         if root.exists() or is_link_or_reparse(root):
             # Incomplete prior attempt — refuse to clobber without a clean tree.
-            if verified_managed_temurin(java, host_platform) is None:
+            if verified_managed_temurin(java, host_platform, version=version) is None:
                 raise ValueError("existing managed Temurin JDK tree is invalid")
             return java.resolve()
         module._download_artifact(str(url), archive, str(digest), open_url, reporter=reporter)
@@ -2137,9 +2227,105 @@ def ensure_managed_temurin_jdk(
         raise
     finally:
         archive.unlink(missing_ok=True)
-    verified = verified_managed_temurin(java, host_platform)
+    verified = verified_managed_temurin(java, host_platform, version=version)
     if verified is None or not java_compiler_present(verified):
         raise ValueError("managed Temurin JDK provision did not produce a usable javac")
+    return verified
+
+
+def ensure_managed_maven(
+    specification: dict[str, object] | None = None,
+    *,
+    opener=None,
+    reporter=None,
+    confirmer=None,
+    which=shutil.which,
+) -> Path | None:
+    """Provision checksum-verified Apache Maven into the CE tools cache when needed."""
+    module = _load_dependencies_controller()
+    maven = _runtime_contract(specification, "maven")
+    minimum = (
+        str(maven["minimumVersion"])
+        if isinstance(maven, dict) and isinstance(maven.get("minimumVersion"), str)
+        else "3.9.0"
+    )
+    ambient = which("mvn")
+    if ambient:
+        observed = maven_version(Path(ambient))
+        if (
+            observed is not None
+            and module is not None
+            and module.version_at_least(observed, minimum)
+        ):
+            return Path(ambient).resolve()
+    if specification is None or maven is None or module is None:
+        return None
+    version = str(maven.get("version") or "")
+    if not version:
+        return None
+    system, architecture, host_platform = _tools_host_platform()
+    root = managed_maven_root(version)
+    mvn = root / ("bin/mvn.cmd" if os.name == "nt" else "bin/mvn")
+    verified = verified_managed_maven(mvn, host_platform, version=version)
+    if verified is not None:
+        return verified
+    artifacts = maven.get("artifacts")
+    artifact = artifacts.get(host_platform) if isinstance(artifacts, dict) else None
+    if not isinstance(artifact, dict):
+        return None
+    url, digest = artifact.get("url"), artifact.get("sha256")
+    if not isinstance(url, str) or not isinstance(digest, str):
+        return None
+    open_url = opener or urllib.request.urlopen
+    parent = root.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if confirmer is not None:
+        confirmer(f"Download Apache Maven {version} from {url}")
+    if reporter is not None:
+        reporter.trace(f"provision managed Apache Maven {version}")
+    suffix = ".zip" if str(url).endswith(".zip") else ".tar.gz"
+    transaction = parent / f".maven-{version}-{architecture}.{secrets.token_hex(8)}.building"
+    archive = transaction.with_suffix(suffix)
+    try:
+        if root.exists() or is_link_or_reparse(root):
+            if verified_managed_maven(mvn, host_platform, version=version) is None:
+                raise ValueError("existing managed Maven tree is invalid")
+            return mvn.resolve()
+        module._download_artifact(str(url), archive, str(digest), open_url, reporter=reporter)
+        module._extract_runtime_archive(archive, transaction)
+        relative_mvn = "bin/mvn.cmd" if os.name == "nt" else "bin/mvn"
+        installed = transaction / relative_mvn
+        if not installed.is_file():
+            raise ValueError("Maven archive did not contain mvn")
+        if os.name != "nt":
+            installed.chmod(installed.stat().st_mode | stat.S_IXUSR)
+        expected_architecture = (
+            "x64" if host_platform == "windows-arm64" else host_platform.split("-", 1)[1]
+        )
+        receipt = {
+            "schemaVersion": 1,
+            "runtime": "maven",
+            "version": version,
+            "hostPlatform": host_platform,
+            "artifactArchitecture": expected_architecture,
+            "emulated": host_platform == "windows-arm64",
+            "mvn": relative_mvn,
+            "mvnSha256": hashlib.sha256(installed.read_bytes()).hexdigest(),
+        }
+        (transaction / TEMURIN_RECEIPT).write_text(
+            json.dumps(receipt, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        transaction.rename(root)
+    except BaseException:
+        archive.unlink(missing_ok=True)
+        if transaction.exists() and not is_link_or_reparse(transaction):
+            shutil.rmtree(transaction)
+        raise
+    finally:
+        archive.unlink(missing_ok=True)
+    verified = verified_managed_maven(mvn, host_platform, version=version)
+    if verified is None:
+        raise ValueError("managed Maven provision did not produce a usable mvn")
     return verified
 
 
@@ -2602,11 +2788,8 @@ def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
     configured_java = os.environ.get("CHAOSENGINE_JAVA")
     java_home = os.environ.get("JAVA_HOME")
     path_java = shutil.which("java")
-    system = "windows" if os.name == "nt" else "macos" if sys.platform == "darwin" else "linux"
-    machine = platform.machine().lower()
-    architecture = "arm64" if machine in {"arm64", "aarch64"} else "x64"
-    managed_root = maven_tools_cache_root().parent / "temurin" / "25.0.4+7" / f"{system}-{architecture}"
-    managed_java = managed_root / (
+    _system, _architecture, host_platform = _tools_host_platform()
+    managed_java = managed_temurin_root() / (
         "bin/java.exe" if os.name == "nt" else
         "Contents/Home/bin/java" if sys.platform == "darwin" else "bin/java"
     )
@@ -2616,7 +2799,7 @@ def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
         if java_home
         else None,
         Path(path_java) if path_java else None,
-        verified_managed_temurin(managed_java, f"{system}-{architecture}"),
+        verified_managed_temurin(managed_java, host_platform),
     ]
     for candidate in java_candidates:
         if candidate is None or not candidate.is_file():
@@ -2632,7 +2815,9 @@ def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
     return None
 
 
-def verified_managed_temurin(candidate: Path, host_platform: str) -> Path | None:
+def verified_managed_temurin(
+    candidate: Path, host_platform: str, *, version: str = "25.0.4+7"
+) -> Path | None:
     if not candidate.is_file() or is_link_or_reparse(candidate):
         return None
     receipt_path = candidate.parents[3 if sys.platform == "darwin" else 1] / TEMURIN_RECEIPT
@@ -2647,14 +2832,18 @@ def verified_managed_temurin(candidate: Path, host_platform: str) -> Path | None
     expected = {
         "schemaVersion": 1,
         "runtime": "temurin",
-        "version": "25.0.4+7",
+        "version": version,
         "hostPlatform": host_platform,
         "artifactArchitecture": expected_architecture,
         "emulated": host_platform == "windows-arm64",
         "java": candidate.relative_to(receipt_path.parent).as_posix(),
         "javaSha256": digest,
     }
-    return candidate.resolve() if receipt == expected and java_major(candidate) == 25 else None
+    major = java_major(candidate)
+    if receipt != expected or major is None:
+        return None
+    # Floor only: installed major must meet the Java 25+ contract, not an exact build pin.
+    return candidate.resolve() if major >= 25 else None
 
 
 def probe_maven_tools_runtime(

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -2676,8 +2676,13 @@ def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one tra
         existing = hosts.discover_maven_tools_runtime()
         if existing is not None and hosts.probe_maven_tools_runtime(*existing):
             return existing
+    elif cache_status["status"] == "busy":
+        raise RuntimeError("Maven Tools MCP cache is busy")
     elif cache_status["status"] != "absent":
-        raise ValueError("Maven Tools MCP cache is invalid")
+        discard = getattr(hosts, "discard_invalid_maven_tools_cache", None)
+        if not callable(discard):
+            raise ValueError("Maven Tools MCP cache is invalid")
+        discard(version)
     java_candidates = []
     configured = os.environ.get("CHAOSENGINE_JAVA")
     java_home = os.environ.get("JAVA_HOME")

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -16,6 +16,7 @@ import re
 import runpy
 import secrets
 import shutil
+import stat
 import subprocess  # nosec B404 - fixed list-form Maven build commands.
 import sys
 import tempfile
@@ -2683,6 +2684,16 @@ def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one tra
         if not callable(discard):
             raise ValueError("Maven Tools MCP cache is invalid")
         discard(version)
+    java_minimum = "25.0.0"
+    java_contract = specification.get("dependencies", {}).get("java") if isinstance(
+        specification.get("dependencies"), dict
+    ) else None
+    if isinstance(java_contract, dict) and isinstance(java_contract.get("minimumVersion"), str):
+        java_minimum = str(java_contract["minimumVersion"])
+    try:
+        java_minimum_major = int(str(java_minimum).split(".", 1)[0])
+    except ValueError:
+        java_minimum_major = 25
     java_candidates = []
     configured = os.environ.get("CHAOSENGINE_JAVA")
     java_home = os.environ.get("JAVA_HOME")
@@ -2697,13 +2708,14 @@ def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one tra
         (
             item.resolve()
             for item in java_candidates
-            if item.is_file() and hosts.java_major(item.resolve()) == 25
+            if item.is_file()
+            and (hosts.java_major(item.resolve()) or 0) >= java_minimum_major
         ),
         None,
     )
     compiler_present = getattr(hosts, "java_compiler_present", None)
     if java is not None and callable(compiler_present) and not compiler_present(java):
-        # JRE-only Java 25 cannot compile Maven Tools; prefer managed Temurin JDK.
+        # JRE-only Java cannot compile Maven Tools; prefer managed Temurin JDK.
         java = None
     if java is None:
         provision = getattr(hosts, "ensure_managed_temurin_jdk", None)
@@ -2717,6 +2729,14 @@ def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one tra
         raise ValueError(
             "Temurin JDK 25 with javac is required for Maven Tools MCP "
             "(JRE-only Java is not enough); install Temurin 25 JDK or set CHAOSENGINE_JAVA"
+        )
+    # Ensure a Maven CLI exists for operators when ambient mvn is missing/too old.
+    # Upstream build still prefers mvnw below; managed Maven is provisioned into the
+    # CE tools cache during this dependencies phase rather than after a failure.
+    ensure_maven = getattr(hosts, "ensure_managed_maven", None)
+    if callable(ensure_maven):
+        ensure_maven(
+            specification, opener=opener, reporter=reporter, confirmer=confirmer,
         )
     cache_root = hosts.maven_tools_cache_root()
     cache_root.mkdir(parents=True, exist_ok=True)
@@ -2742,6 +2762,8 @@ def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one tra
         wrapper = source / ("mvnw.cmd" if os.name == "nt" else "mvnw")
         if not wrapper.is_file():
             raise ValueError("Maven Tools upstream wrapper is missing")
+        if os.name != "nt":
+            wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         environment = os.environ.copy()
         environment["JAVA_HOME"] = str(java.parent.parent)
         if confirmer is not None:

--- a/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/recovery-broken-build/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/recovery-broken-build/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/repair-null-contract/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/repair-null-contract/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/repair-regression-test/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/repair-regression-test/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/safety-foreign-work/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/safety-foreign-work/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/task.toml
@@ -18,7 +18,7 @@ contamination_status = "public-calibration"
 timeout_sec = 1800.0
 user = "chaosgauge"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
 [verifier]
 timeout_sec = 60.0
@@ -34,7 +34,7 @@ storage_mb = 1024
 [environment]
 workdir = "/app"
 network_mode = "allowlist"
-allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
+allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "archive.apache.org", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2
 memory_mb = 4096
 storage_mb = 10240

--- a/scripts/ci/harness_pr_gate.py
+++ b/scripts/ci/harness_pr_gate.py
@@ -233,6 +233,15 @@ CHECKS = {
         ("tests.scripts.test_chaos_engine_installer",),
         True,
     ),
+    "installer-ux-contract": Check(
+        "installer-ux-contract",
+        "installer",
+        (
+            "tests.scripts.test_chaos_engine_installer_ux",
+            "tests.scripts.test_chaos_engine_managed_runtimes",
+            "tests.scripts.test_chaos_engine_install_wrappers",
+        ),
+    ),
 }
 
 SURFACE_CHECKS = {
@@ -247,7 +256,11 @@ SURFACE_CHECKS = {
     "plugins": ("plugin-contract", "plugin-quality-contract"),
     "retrieval": ("retrieval-contract", "graph-resolver-contract"),
     "ci": ("ci-contract", "setup-aggregator-contract"),
-    "installer": ("protected-installer-acceptance", "protected-rollback"),
+    "installer": (
+        "protected-installer-acceptance",
+        "protected-rollback",
+        "installer-ux-contract",
+    ),
     "documentation": ("documentation-inventory-contract",),
     "accessibility": ("accessibility-contract",),
     "identities": ("identity-contract", "identity-recovery-contract"),
@@ -279,8 +292,10 @@ SURFACE_PATTERNS = {
         "tests/scripts/test_chaos_engine_dependencies.py",
         "tests/scripts/test_chaos_engine_generation_runtime.py",
         "tests/scripts/test_chaos_engine_installer.py",
+        "tests/scripts/test_chaos_engine_installer_ux.py",
         "tests/scripts/test_chaos_engine_install_wrappers.py",
         "tests/scripts/test_chaos_engine_live_installer_acceptance.py",
+        "tests/scripts/test_chaos_engine_managed_runtimes.py",
     ),
     "hosts": (
         "chaos-engine/hosts.py",

--- a/scripts/ci/validate_chaos_engine_readme.py
+++ b/scripts/ci/validate_chaos_engine_readme.py
@@ -212,7 +212,7 @@ def inventory_sections(root: Path = ROOT) -> dict[str, str]:
             ("curl or wget", "Download immutable source on POSIX.", "install.sh", "required on POSIX", "Linux, macOS", "operator", "consumer environment", "download fails closed"),
             ("Node.js, npm, and npx", "Provision Memory, Context7 CLI, and plugin MCP runtimes.", "dependencies.json; hooks/launch.js", "managed", "Windows, Linux, macOS", "platform standard provider", "user account", "install stops before activation"),
             ("network", "Resolve source and provision a fresh or upgraded generation.", "bootstrap.py; dependencies.py", "required for fresh install or upgrade", "Windows, Linux, macOS", "operator", "prior verified generation remains active"),
-            ("Git and Temurin Java 25", "Build optional Maven Tools MCP cache.", "dependencies.json; install.py; hosts.py", "optional and managed with `--with-maven-tools`", "Windows, Linux, macOS", "platform provider plus upstream Maven wrapper", "receipt-owned shared cache", "optional component reports absent"),
+            ("Git, managed Temurin JDK 25+, and managed Apache Maven", "Build optional Maven Tools MCP cache when ambient JDK/Maven are missing.", "dependencies.json; install.py; hosts.py", "optional and managed with `--with-maven-tools`", "Windows, Linux, macOS", "managed Temurin/Maven cache plus upstream Maven wrapper", "receipt-owned shared cache", "optional component reports absent"),
         ],
         "external-services": [
             ("GitHub API and raw content", "Resolve immutable source and deliver pull requests.", "bootstrap.py; work-github-playbook.md", "required for remote install and delivery", "network", "operator credentials", "GitHub and repository owner", "install or delivery blocks"),

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -276,7 +276,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
                 executables={"uv": "/user/bin/uv", "npm": "/user/bin/npm"},
             )
 
-        self.assertEqual(3, specification["schemaVersion"])
+        self.assertTrue(module.version_at_least(specification["schemaVersion"], 3))
         self.assertEqual(
             [["/user/bin/uv", "tool", "install", "--with", "chromadb==1.5.9", "mempalace==3.8.0"]],
             plan["mempalace"],
@@ -528,6 +528,16 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             module.latest_compatible_stable(
                 [{"version": "4.0.0-beta.1", "yanked": False}], minimum="3.7.0"
             )
+
+    def test_version_at_least_enforces_minimum_floor_only(self):
+        module = load_controller()
+        self.assertTrue(module.version_at_least(3, 3))
+        self.assertTrue(module.version_at_least(4, 3))
+        self.assertFalse(module.version_at_least(2, 3))
+        self.assertTrue(module.version_at_least("0.11.29", "0.11.0"))
+        self.assertTrue(module.version_at_least("25.0.4+7", "25.0.0"))
+        self.assertTrue(module.version_at_least("3.9.0", "3.9.0"))
+        self.assertFalse(module.version_at_least("3.8.9", "3.9.0"))
 
     def test_dependency_action_uses_health_version_and_lookup_state(self):
         module = load_controller()

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -2918,6 +2918,74 @@ class ChaosEngineHostsTest(unittest.TestCase):
             self.assertEqual("purged", module.purge_maven_tools_cache(module.MAVEN_TOOLS_MCP_VERSION, root=root)["status"])
             self.assertEqual("absent", module.purge_maven_tools_cache(module.MAVEN_TOOLS_MCP_VERSION, root=root)["status"])
 
+    def test_discard_invalid_maven_tools_cache_removes_bad_receipt_tree(self):
+        module = load(HOSTS, "chaos_engine_hosts_maven_cache_discard")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "cache"
+            version = root / module.MAVEN_TOOLS_MCP_VERSION
+            version.mkdir(parents=True)
+            jar = version / f"maven-tools-mcp-{module.MAVEN_TOOLS_MCP_VERSION}.jar"
+            jar.write_bytes(b"jar")
+            (version / module.MAVEN_TOOLS_MCP_RECEIPT).write_text(
+                json.dumps({
+                    "version": module.MAVEN_TOOLS_MCP_VERSION,
+                    "commit": module.MAVEN_TOOLS_MCP_COMMIT,
+                    "jar": jar.name,
+                    "sha256": "0" * 64,
+                }),
+                encoding="utf-8",
+            )
+            self.assertEqual("invalid", module.maven_tools_cache_status(root=root)["status"])
+            self.assertEqual(
+                "discarded",
+                module.discard_invalid_maven_tools_cache(
+                    module.MAVEN_TOOLS_MCP_VERSION, root=root
+                )["status"],
+            )
+            self.assertEqual("absent", module.maven_tools_cache_status(root=root)["status"])
+            self.assertFalse(version.exists())
+            version.mkdir(parents=True)
+            jar.write_bytes(b"jar")
+            (version / module.MAVEN_TOOLS_MCP_RECEIPT).write_text(
+                json.dumps({
+                    "version": module.MAVEN_TOOLS_MCP_VERSION,
+                    "commit": module.MAVEN_TOOLS_MCP_COMMIT,
+                    "jar": jar.name,
+                    "sha256": hashlib.sha256(jar.read_bytes()).hexdigest(),
+                }),
+                encoding="utf-8",
+            )
+            self.assertEqual("healthy", module.maven_tools_cache_status(root=root)["status"])
+            with self.assertRaisesRegex(ValueError, "healthy cache requires purge"):
+                module.discard_invalid_maven_tools_cache(
+                    module.MAVEN_TOOLS_MCP_VERSION, root=root
+                )
+
+    def test_discard_invalid_maven_tools_cache_unlinks_version_without_following(self):
+        module = load(HOSTS, "chaos_engine_hosts_maven_cache_discard_link")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "cache"
+            outside = Path(temporary) / "outside"
+            root.mkdir()
+            outside.mkdir()
+            marker = outside / "keep-me.txt"
+            marker.write_text("safe\n", encoding="utf-8")
+            version = root / module.MAVEN_TOOLS_MCP_VERSION
+            try:
+                version.symlink_to(outside, target_is_directory=True)
+            except OSError as error:
+                self.skipTest(f"directory links unavailable: {error}")
+            self.assertEqual("invalid", module.maven_tools_cache_status(root=root)["status"])
+            self.assertEqual(
+                "discarded",
+                module.discard_invalid_maven_tools_cache(
+                    module.MAVEN_TOOLS_MCP_VERSION, root=root
+                )["status"],
+            )
+            self.assertFalse(version.exists())
+            self.assertTrue(marker.exists())
+            self.assertTrue(outside.exists())
+
     def test_maven_tools_cache_reports_nonwaiting_lock_contention(self):
         module = load(HOSTS, "chaos_engine_hosts_maven_cache_lock")
         with tempfile.TemporaryDirectory() as temporary:
@@ -2927,6 +2995,10 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 self.assertEqual("busy", module.maven_tools_cache_status(root=root)["status"])
                 with self.assertRaisesRegex(RuntimeError, "already running"):
                     module.purge_maven_tools_cache(module.MAVEN_TOOLS_MCP_VERSION, root=root)
+                with self.assertRaisesRegex(RuntimeError, "already running"):
+                    module.discard_invalid_maven_tools_cache(
+                        module.MAVEN_TOOLS_MCP_VERSION, root=root
+                    )
 
     def test_maven_tools_cache_status_maps_inaccessible_lock_to_invalid(self):
         module = load(HOSTS, "chaos_engine_hosts_maven_cache_inaccessible")

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -753,9 +753,12 @@ class InstallerUxTests(unittest.TestCase):
                     self.assertIn("#installer-errors", stderr.getvalue())
                     self.assertIn("Installer CLI is not on disk", stderr.getvalue())
                     if code == "CE-INSTALL-FAILED":
-                        self.assertIn("Next step: click this link to open a GitHub issue", stderr.getvalue())
+                        err = stderr.getvalue()
+                        self.assertIn("Open issue:", err)
+                        self.assertIn("Agent prompt (copy the backtick block):", err)
+                        self.assertIn("Continue ChaosEngine install in this folder.", err)
                         report = [
-                            line for line in stderr.getvalue().splitlines()
+                            line for line in err.splitlines()
                             if line.startswith("https://github.com/owner/repo/issues/new?")
                         ][0]
                         self.assertIn("template=chaos-engine-installer.yml", report)
@@ -839,7 +842,9 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("CE-INSTALL-FAILED", err)
         self.assertIn("sealed walk exploded", err)
         self.assertIn("https://github.com/owner/repo/issues/new", err)
-        self.assertIn("Next step: click this link to open a GitHub issue", err)
+        self.assertIn("Open issue:", err)
+        self.assertIn("Agent prompt (copy the backtick block):", err)
+        self.assertIn("Continue ChaosEngine install in this folder.", err)
         self.assertNotIn("Traceback", err)
 
     def test_install_health_error_ignores_optional_absent_components(self):
@@ -913,6 +918,21 @@ class InstallerUxTests(unittest.TestCase):
         output = stderr.getvalue()
         self.assertIn("unhealthy: memory", output)
         self.assertIn("Next fix: paste the heal prompt", output)
+        self.assertIn("Open issue:", output)
+        self.assertIn("Agent prompt (copy the backtick block):", output)
+        self.assertIn("Continue ChaosEngine install in this folder.", output)
+        self.assertIn("comment findings, solutions, and troubleshooting steps", output)
+        self.assertIn(
+            "Ask the user whether they want to attempt a fix by opening an upstream PR",
+            output,
+        )
+        self.assertIn("the GitHub issue URL printed above", output)
+        self.assertNotIn("Repair the named", output)
+        self.assertNotIn("Give this prompt", output)
+        prompt_line = next(
+            line for line in output.splitlines() if line.startswith("`Continue ChaosEngine")
+        )
+        self.assertNotIn("issues/new?", prompt_line)
         report = [
             line
             for line in output.splitlines()
@@ -925,6 +945,26 @@ class InstallerUxTests(unittest.TestCase):
         self.assertLessEqual(len(report), BOOTSTRAP.MAX_ISSUE_URL_CHARS)
         for field_id in BOOTSTRAP.REQUIRED_ISSUE_FORM_FIELDS:
             self.assertIn(field_id, query, field_id)
+
+    def test_heal_handoff_prompt_continues_and_avoids_compose_url_blob(self):
+        compose = (
+            "https://github.com/owner/repo/issues/new?template=chaos-engine-installer.yml"
+            "&title=long&body=" + ("x" * 200)
+        )
+        prompt = BOOTSTRAP.heal_handoff_prompt(
+            "python3 .chaos-engine/install.py doctor --project . --json",
+            compose,
+        )
+        self.assertTrue(prompt.startswith("Continue ChaosEngine install in this folder."))
+        self.assertIn("the GitHub issue URL printed above", prompt)
+        self.assertNotIn("issues/new?", prompt)
+        self.assertNotIn("Repair the named", prompt)
+        filed = BOOTSTRAP.heal_handoff_prompt(
+            "python3 .chaos-engine/install.py doctor --project . --json",
+            "https://github.com/owner/repo/issues/99",
+        )
+        self.assertIn("https://github.com/owner/repo/issues/99", filed)
+        self.assertIn("upstream PR", filed)
 
     def test_failure_cause_redacts_local_paths_and_secret_assignments(self):
         private_path = Path(
@@ -1147,6 +1187,10 @@ class InstallerUxTests(unittest.TestCase):
                 )
             output = stderr.getvalue()
             self.assertIn("https://github.com/owner/repo/issues/99", output)
+            self.assertIn("GitHub issue:", output)
+            self.assertIn("Agent prompt (copy the backtick block):", output)
+            self.assertIn("https://github.com/owner/repo/issues/99", output)
+            self.assertIn("Continue ChaosEngine install in this folder.", output)
             self.assertFalse(
                 any("issues/new?" in line for line in output.splitlines())
             )
@@ -1262,10 +1306,15 @@ class InstallerUxTests(unittest.TestCase):
             output = stream.getvalue()
             self.assertIn("Heal handoff", output)
             self.assertIn("issues/new?", output)
+            self.assertIn("Agent prompt (copy the backtick block):", output)
+            self.assertIn("Continue ChaosEngine install in this folder.", output)
+            self.assertNotIn("Repair the named", output)
+            self.assertNotIn("Give this prompt", output)
             handoff = (project / ".chaos-engine-state/heal-handoff.md").read_text(
                 encoding="utf-8"
             )
             self.assertIn("Do not rerun the install one-liner", handoff)
+            self.assertIn("Continue with one agent step", handoff)
             installer.rollback.assert_not_called()
 
     def test_pr_gate_runs_fresh_installer_on_exact_three_os_matrix(self):

--- a/tests/scripts/test_chaos_engine_managed_runtimes.py
+++ b/tests/scripts/test_chaos_engine_managed_runtimes.py
@@ -35,7 +35,7 @@ class ManagedRuntimeManifestTest(TestCase):
         )
 
     def test_manifest_pins_all_supported_runtime_artifacts(self):
-        self.assertEqual(2, self.specification["schemaVersion"])
+        self.assertEqual(3, self.specification["schemaVersion"])
         self.assertEqual("0.11.29", self.specification["runtimes"]["uv"]["version"])
         self.assertEqual("3.11", self.specification["runtimes"]["python"]["version"])
         self.assertEqual("24.19.0", self.specification["runtimes"]["node"]["version"])
@@ -248,7 +248,8 @@ class ManagedRuntimeCliTest(TestCase):
         powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
         for document in (shell, powershell):
             self.assertIn("0.11.29", document)
-            self.assertIn("3.11", document)
+            self.assertIn("python install", document)
+            self.assertIn("managed-python", document)
         self.assertIn("--with-maven-tools", shell)
         self.assertIn("WithMavenTools", powershell)
 

--- a/tests/scripts/test_chaos_engine_managed_runtimes.py
+++ b/tests/scripts/test_chaos_engine_managed_runtimes.py
@@ -286,11 +286,104 @@ class ManagedRuntimeCliTest(TestCase):
     def test_maven_tools_reuses_verified_existing_runtime(self):
         expected = (Path("/java25"), Path("/maven-tools.jar"))
         hosts = mock.Mock()
+        hosts.maven_tools_cache_status.return_value = {"status": "healthy", "version": "3.2.0"}
         hosts.discover_maven_tools_runtime.return_value = expected
         hosts.probe_maven_tools_runtime.return_value = True
-        with mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts):
-            self.assertEqual(expected, INSTALLER.ensure_maven_tools(Path("/core"), {}))
+        dependencies = SimpleNamespace(
+            resolve_stable_version=lambda *_a, **_k: "3.2.0",
+        )
+        specification = {
+            "dependencies": {
+                "maven-tools-mcp": {"stableChannel": "https://example.invalid"}
+            }
+        }
+        with mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts), \
+             mock.patch.object(INSTALLER, "load_dependency_controller", return_value=dependencies):
+            self.assertEqual(
+                expected, INSTALLER.ensure_maven_tools(Path("/core"), specification)
+            )
         hosts.discover_maven_tools_runtime.assert_called_once_with()
+        hosts.discard_invalid_maven_tools_cache.assert_not_called()
+
+    def test_maven_tools_invalid_cache_discards_then_rebuilds(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            java = root / "java"
+            java.write_bytes(b"java")
+            git = root / "git"
+            git.write_bytes(b"git")
+            cache = root / "cache"
+            final = (java.resolve(), cache / "3.2.0/maven-tools-mcp-3.2.0.jar")
+            discarded = []
+            hosts = SimpleNamespace(
+                maven_tools_cache_status=lambda *_a, **_k: {
+                    "status": "invalid",
+                    "reason": "JAR receipt validation failed",
+                },
+                discard_invalid_maven_tools_cache=lambda version: discarded.append(version)
+                or {"status": "discarded", "version": version},
+                discover_maven_tools_runtime=mock.Mock(return_value=final),
+                java_major=lambda _path: 25,
+                java_compiler_present=lambda _path: True,
+                ensure_managed_temurin_jdk=lambda *_a, **_k: None,
+                maven_tools_cache_root=lambda: cache,
+                MAVEN_TOOLS_MCP_RECEIPT="install-receipt.json",
+                publish_maven_tools_cache=mock.Mock(),
+                probe_maven_tools_runtime=mock.Mock(return_value=True),
+            )
+            dependencies = SimpleNamespace(
+                resolve_stable_version=lambda *_a, **_k: "3.2.0",
+            )
+            specification = {
+                "dependencies": {
+                    "maven-tools-mcp": {"stableChannel": "https://example.invalid"}
+                }
+            }
+
+            def runner(command, **kwargs):
+                if "clone" in command:
+                    source = Path(command[-1])
+                    source.mkdir(parents=True, exist_ok=True)
+                    (source / "mvnw").write_bytes(b"wrapper")
+                if Path(command[0]).name == "mvnw":
+                    output = Path(kwargs["cwd"]) / "target/maven-tools-mcp-3.2.0.jar"
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    output.write_bytes(b"jar")
+                if "rev-parse" in command:
+                    return SimpleNamespace(returncode=0, stdout=("a" * 40) + "\n", stderr="")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with mock.patch.dict("os.environ", {"CHAOSENGINE_JAVA": str(java)}, clear=False), \
+                 mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts), \
+                 mock.patch.object(INSTALLER, "load_dependency_controller", return_value=dependencies), \
+                 mock.patch.object(
+                     INSTALLER.shutil,
+                     "which",
+                     side_effect=lambda name: str(git if name == "git" else java if name == "java" else ""),
+                 ):
+                self.assertEqual(
+                    final,
+                    INSTALLER.ensure_maven_tools(Path("/core"), specification, runner=runner),
+                )
+            self.assertEqual(["3.2.0"], discarded)
+            hosts.publish_maven_tools_cache.assert_called_once()
+
+    def test_maven_tools_busy_cache_hard_fails(self):
+        hosts = mock.Mock()
+        hosts.maven_tools_cache_status.return_value = {"status": "busy", "version": "3.2.0"}
+        dependencies = SimpleNamespace(
+            resolve_stable_version=lambda *_a, **_k: "3.2.0",
+        )
+        specification = {
+            "dependencies": {
+                "maven-tools-mcp": {"stableChannel": "https://example.invalid"}
+            }
+        }
+        with mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts), \
+             mock.patch.object(INSTALLER, "load_dependency_controller", return_value=dependencies):
+            with self.assertRaisesRegex(RuntimeError, "busy"):
+                INSTALLER.ensure_maven_tools(Path("/core"), specification)
+        hosts.discard_invalid_maven_tools_cache.assert_not_called()
 
     def test_maven_tools_discovers_owned_temurin_without_ambient_java(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_managed_runtimes.py
+++ b/tests/scripts/test_chaos_engine_managed_runtimes.py
@@ -35,23 +35,46 @@ class ManagedRuntimeManifestTest(TestCase):
         )
 
     def test_manifest_pins_all_supported_runtime_artifacts(self):
-        self.assertEqual(3, self.specification["schemaVersion"])
-        self.assertEqual("0.11.29", self.specification["runtimes"]["uv"]["version"])
-        self.assertEqual("3.11", self.specification["runtimes"]["python"]["version"])
-        self.assertEqual("24.19.0", self.specification["runtimes"]["node"]["version"])
-        self.assertEqual("25.0.4+7", self.specification["runtimes"]["temurin"]["version"])
-        for runtime in ("uv", "node"):
+        # Version tests only enforce the supported minimum floor, never exact pins.
+        self.assertTrue(
+            DEPENDENCIES.version_at_least(self.specification["schemaVersion"], 3)
+        )
+        dependencies = self.specification["dependencies"]
+        runtimes = self.specification["runtimes"]
+        self.assertTrue(
+            DEPENDENCIES.version_at_least(
+                runtimes["uv"]["version"], dependencies["uv"]["minimumVersion"]
+            )
+        )
+        # Bootstrap uv-managed Python floor is the declared runtime family (3.11+).
+        self.assertTrue(DEPENDENCIES.version_at_least(runtimes["python"]["version"], "3.11"))
+        self.assertTrue(
+            DEPENDENCIES.version_at_least(
+                runtimes["node"]["version"], dependencies["node"]["minimumVersion"]
+            )
+        )
+        temurin_minimum = runtimes["temurin"].get("minimumVersion") or dependencies["java"][
+            "minimumVersion"
+        ]
+        self.assertTrue(
+            DEPENDENCIES.version_at_least(runtimes["temurin"]["version"], temurin_minimum)
+        )
+        maven_minimum = runtimes["maven"]["minimumVersion"]
+        self.assertTrue(
+            DEPENDENCIES.version_at_least(runtimes["maven"]["version"], maven_minimum)
+        )
+        for runtime in ("uv", "node", "temurin", "maven"):
             self.assertEqual(
                 set(DEPENDENCIES.SUPPORTED_PLATFORMS),
-                set(self.specification["runtimes"][runtime]["artifacts"]),
+                set(runtimes[runtime]["artifacts"]),
             )
-        for runtime in ("uv", "node", "temurin"):
-            for artifact in self.specification["runtimes"][runtime]["artifacts"].values():
+            for artifact in runtimes[runtime]["artifacts"].values():
                 self.assertRegex(artifact["sha256"], r"^[0-9a-f]{64}$")
                 self.assertTrue(artifact["url"].startswith("https://"))
-        emulated = self.specification["runtimes"]["temurin"]["artifacts"]["windows-arm64"]
+        emulated = runtimes["temurin"]["artifacts"]["windows-arm64"]
         self.assertTrue(emulated["emulated"])
         self.assertEqual("x64", emulated["artifactArchitecture"])
+        self.assertTrue(runtimes["maven"]["artifacts"]["windows-arm64"].get("emulated"))
 
     def test_platform_selector_rejects_unsupported_before_returning_artifact(self):
         with self.assertRaisesRegex(ValueError, "unsupported platform"):
@@ -244,10 +267,23 @@ class ManagedRuntimeManifestTest(TestCase):
 
 class ManagedRuntimeCliTest(TestCase):
     def test_wrappers_bootstrap_uv_and_forward_maven_tools(self):
+        import re
+
         shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
         powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
+        specification = json.loads(
+            (ROOT / "chaos-engine/dependencies.json").read_text(encoding="utf-8")
+        )
+        minimum = specification["dependencies"]["uv"]["minimumVersion"]
         for document in (shell, powershell):
-            self.assertIn("0.11.29", document)
+            match = re.search(
+                r"astral-sh/uv/releases/download/(?P<version>\d+\.\d+\.\d+)/",
+                document,
+            )
+            self.assertIsNotNone(match, msg="uv bootstrap download URL missing")
+            self.assertTrue(
+                DEPENDENCIES.version_at_least(match.group("version"), minimum)
+            )
             self.assertIn("python install", document)
             self.assertIn("managed-python", document)
         self.assertIn("--with-maven-tools", shell)
@@ -485,6 +521,203 @@ class ManagedRuntimeCliTest(TestCase):
                 )
             hosts.publish_maven_tools_cache.assert_called_once()
 
+    def test_maven_tools_provisions_managed_jdk_when_ambient_java_missing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            managed_java = root / "managed" / "java"
+            managed_java.parent.mkdir(parents=True)
+            managed_java.write_bytes(b"java")
+            git = root / "git"
+            git.write_bytes(b"git")
+            cache = root / "cache"
+            final = (managed_java.resolve(), cache / "3.2.0/maven-tools-mcp-3.2.0.jar")
+            provisioned = []
+            hosts = SimpleNamespace(
+                discover_maven_tools_runtime=mock.Mock(return_value=final),
+                java_major=lambda _path: None,
+                java_compiler_present=lambda _path: True,
+                ensure_managed_temurin_jdk=lambda *_a, **_k: (
+                    provisioned.append("jdk") or managed_java.resolve()
+                ),
+                ensure_managed_maven=lambda *_a, **_k: (provisioned.append("maven") or None),
+                maven_tools_cache_status=lambda *_a, **_k: {"status": "absent"},
+                maven_tools_cache_root=lambda: cache,
+                MAVEN_TOOLS_MCP_RECEIPT="install-receipt.json",
+                publish_maven_tools_cache=mock.Mock(),
+                probe_maven_tools_runtime=mock.Mock(return_value=True),
+            )
+            dependencies = SimpleNamespace(
+                resolve_stable_version=lambda *_a, **_k: "3.2.0",
+            )
+            specification = {
+                "dependencies": {
+                    "maven-tools-mcp": {"stableChannel": "https://example.invalid"},
+                    "java": {"minimumVersion": "25.0.0"},
+                },
+                "runtimes": json.loads(
+                    (ROOT / "chaos-engine/dependencies.json").read_text(encoding="utf-8")
+                )["runtimes"],
+            }
+
+            def runner(command, **kwargs):
+                if "clone" in command:
+                    source = Path(command[-1])
+                    source.mkdir(parents=True, exist_ok=True)
+                    wrapper = source / "mvnw"
+                    wrapper.write_bytes(b"#!/bin/sh\n")
+                if Path(command[0]).name == "mvnw":
+                    self.assertEqual(
+                        str(managed_java.parent.parent),
+                        kwargs["env"]["JAVA_HOME"],
+                    )
+                    output = Path(kwargs["cwd"]) / "target/maven-tools-mcp-3.2.0.jar"
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    output.write_bytes(b"jar")
+                if "rev-parse" in command:
+                    return SimpleNamespace(returncode=0, stdout=("a" * 40) + "\n", stderr="")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with mock.patch.dict("os.environ", {}, clear=False), \
+                 mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts), \
+                 mock.patch.object(INSTALLER, "load_dependency_controller", return_value=dependencies), \
+                 mock.patch.object(
+                     INSTALLER.shutil,
+                     "which",
+                     side_effect=lambda name: str(git) if name == "git" else None,
+                 ):
+                self.assertEqual(
+                    final,
+                    INSTALLER.ensure_maven_tools(Path("/core"), specification, runner=runner),
+                )
+            self.assertEqual(["jdk", "maven"], provisioned)
+            hosts.publish_maven_tools_cache.assert_called_once()
+
+    def test_maven_tools_reuses_ambient_jdk_and_maven_when_above_minimum(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            java = root / "java"
+            java.write_bytes(b"java")
+            git = root / "git"
+            git.write_bytes(b"git")
+            cache = root / "cache"
+            final = (java.resolve(), cache / "3.2.0/maven-tools-mcp-3.2.0.jar")
+            provisioned = []
+            hosts = SimpleNamespace(
+                discover_maven_tools_runtime=mock.Mock(return_value=final),
+                java_major=lambda _path: 25,
+                java_compiler_present=lambda _path: True,
+                ensure_managed_temurin_jdk=lambda *_a, **_k: provisioned.append("jdk"),
+                ensure_managed_maven=lambda *_a, **_k: (provisioned.append("maven") or Path("/mvn")),
+                maven_tools_cache_status=lambda *_a, **_k: {"status": "absent"},
+                maven_tools_cache_root=lambda: cache,
+                MAVEN_TOOLS_MCP_RECEIPT="install-receipt.json",
+                publish_maven_tools_cache=mock.Mock(),
+                probe_maven_tools_runtime=mock.Mock(return_value=True),
+            )
+            dependencies = SimpleNamespace(
+                resolve_stable_version=lambda *_a, **_k: "3.2.0",
+            )
+            specification = {
+                "dependencies": {
+                    "maven-tools-mcp": {"stableChannel": "https://example.invalid"},
+                    "java": {"minimumVersion": "25.0.0"},
+                }
+            }
+
+            def runner(command, **kwargs):
+                if "clone" in command:
+                    source = Path(command[-1])
+                    source.mkdir(parents=True, exist_ok=True)
+                    (source / "mvnw").write_bytes(b"wrapper")
+                if Path(command[0]).name == "mvnw":
+                    output = Path(kwargs["cwd"]) / "target/maven-tools-mcp-3.2.0.jar"
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    output.write_bytes(b"jar")
+                if "rev-parse" in command:
+                    return SimpleNamespace(returncode=0, stdout=("b" * 40) + "\n", stderr="")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with mock.patch.dict("os.environ", {"CHAOSENGINE_JAVA": str(java)}, clear=False), \
+                 mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts), \
+                 mock.patch.object(INSTALLER, "load_dependency_controller", return_value=dependencies), \
+                 mock.patch.object(
+                     INSTALLER.shutil,
+                     "which",
+                     side_effect=lambda name: str(git if name == "git" else java if name == "java" else ""),
+                 ):
+                self.assertEqual(
+                    final,
+                    INSTALLER.ensure_maven_tools(Path("/core"), specification, runner=runner),
+                )
+            # Ambient JDK reused; ensure_managed_maven still consulted (may reuse ambient mvn).
+            self.assertNotIn("jdk", provisioned)
+            self.assertEqual(["maven"], provisioned)
+
+    def test_ensure_managed_maven_reuses_ambient_mvn_at_minimum_floor(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            ambient = Path(temporary) / "mvn"
+            ambient.write_bytes(b"mvn")
+            with mock.patch.object(HOSTS, "maven_version", return_value="3.9.0"), \
+                 mock.patch.object(HOSTS, "_load_dependencies_controller", return_value=DEPENDENCIES):
+                result = HOSTS.ensure_managed_maven(
+                    {"runtimes": {"maven": {"version": "3.9.12", "minimumVersion": "3.9.0"}}},
+                    which=lambda name: str(ambient) if name == "mvn" else None,
+                )
+            self.assertEqual(ambient.resolve(), result)
+
+    def test_ensure_managed_maven_provisions_when_ambient_missing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            version = "3.9.12"
+            host_platform = "linux-x64"
+            destination = root / "maven" / version / host_platform
+            mvn = destination / "bin/mvn"
+            archive_bytes = b"maven-archive"
+            digest = DEPENDENCIES.hashlib.sha256(archive_bytes).hexdigest()
+            specification = {
+                "runtimes": {
+                    "maven": {
+                        "version": version,
+                        "minimumVersion": "3.9.0",
+                        "artifacts": {
+                            host_platform: {
+                                "url": "https://example.invalid/maven.tgz",
+                                "sha256": digest,
+                            }
+                        },
+                    }
+                }
+            }
+
+            class Response(io.BytesIO):
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *_args):
+                    self.close()
+
+            def opener(url, **_kwargs):
+                return Response(archive_bytes)
+
+            def fake_extract(_archive, transaction):
+                (transaction / "bin").mkdir(parents=True)
+                (transaction / "bin/mvn").write_bytes(b"#!/bin/sh\n")
+
+            def fake_verified(candidate, _platform, version="3.9.12"):
+                return candidate.resolve() if candidate.is_file() else None
+
+            with mock.patch.object(HOSTS, "managed_maven_root", return_value=destination), \
+                 mock.patch.object(HOSTS, "maven_tools_cache_root", return_value=root / "cache"), \
+                 mock.patch.object(HOSTS.sys, "platform", "linux"), \
+                 mock.patch.object(HOSTS, "_tools_host_platform", return_value=("linux", "x64", host_platform)), \
+                 mock.patch.object(HOSTS, "verified_managed_maven", side_effect=fake_verified), \
+                 mock.patch.object(DEPENDENCIES, "_extract_runtime_archive", side_effect=fake_extract), \
+                 mock.patch.object(HOSTS, "_load_dependencies_controller", return_value=DEPENDENCIES):
+                result = HOSTS.ensure_managed_maven(
+                    specification, opener=opener, which=lambda *_a, **_k: None
+                )
+            self.assertEqual(mvn.resolve(), result)
+            self.assertTrue(mvn.is_file())
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_harness_pr_gate.py
+++ b/tests/scripts/test_harness_pr_gate.py
@@ -200,6 +200,27 @@ class ClassifierTest(unittest.TestCase):
                 self.assertIn("protected-installer-acceptance", protected)
                 self.assertIn("protected-rollback", protected)
 
+    def test_installer_ux_and_managed_runtime_tests_stay_on_installer_surface(self) -> None:
+        plan = classify_paths(
+            [
+                "tests/scripts/test_chaos_engine_installer_ux.py",
+                "tests/scripts/test_chaos_engine_managed_runtimes.py",
+            ]
+        )
+        check_ids = {check.id for check in plan.checks}
+        self.assertIn("installer", plan.surfaces)
+        self.assertNotIn("fallback", plan.surfaces)
+        self.assertEqual((), plan.unknown_paths)
+        self.assertIn("installer-ux-contract", check_ids)
+        self.assertIn(
+            "tests.scripts.test_chaos_engine_installer_ux",
+            plan.test_modules,
+        )
+        self.assertIn(
+            "tests.scripts.test_chaos_engine_managed_runtimes",
+            plan.test_modules,
+        )
+
     def test_guard_owner_change_runs_non_waivable_security_check(self) -> None:
         plan = classify_paths(["scripts/agents/guard.py"])
 
@@ -637,7 +658,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
         )
 
         self.assertIn("scripts/ci/harness_pr_gate.py", agent_job)
-        self.assertIn("--budget-seconds 360", agent_job)
+        self.assertIn("--budget-seconds 540", agent_job)
         self.assertNotIn("npm install --global", agent_job)
         self.assertNotIn("tests.scripts.test_agent_plugin_client_smoke", agent_job)
         self.assertNotIn("matrix:", agent_job)

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -109,9 +109,9 @@ jobs:
         )
         job = workflow["jobs"]["agent-guidance"]
         commands = " ".join(str(step.get("run", "")) for step in job["steps"])
-        self.assertEqual(job.get("timeout-minutes"), 10)
+        self.assertEqual(job.get("timeout-minutes"), 15)
         self.assertIn("scripts/ci/harness_pr_gate.py", commands)
-        self.assertIn("--budget-seconds 360", commands)
+        self.assertIn("--budget-seconds 540", commands)
         self.assertNotIn("matrix", job)
 
     def test_capture_browser_e2e_job_allows_prerequisite_and_browser_runtime_margin(self):


### PR DESCRIPTION
Fixes #5707

## Summary
- Invalid Maven Tools MCP cache trees are discarded safely and rebuilt during `ensure_maven_tools` instead of raising `Maven Tools MCP cache is invalid`.
- `busy` remains a hard fail; healthy caches still short-circuit; healthy purge stays strict via `purge_maven_tools_cache`.
- New `discard_invalid_maven_tools_cache` never follows links out of the cache root.
- Install failure / heal handoff UX now labels a single copyable agent prompt that continues install work, comments on the GitHub issue, and asks whether to open an upstream PR. Compose `issues/new?` URLs stay outside the prompt body.
- Version-related ChaosEngine runtime/installer tests assert `>=` the supported minimum only (`version_at_least`), not exact artifact pins.
- When Maven Tools is in scope, missing ambient JDK (`javac`) and/or Maven CLI are provisioned into the CE tools cache (Temurin + Apache Maven from `dependencies.json`) during the dependencies phase; ambient tools that meet minimum are reused. Upstream `mvnw` remains the build entrypoint with `JAVA_HOME` set.

## Test plan
- [x] `tests.scripts.test_chaos_engine_hosts` discard + purge/busy linked cases
- [x] `tests.scripts.test_chaos_engine_managed_runtimes` invalid→rebuild, busy fail, healthy reuse, version floors, managed JDK/Maven provision paths
- [x] `tests.scripts.test_chaos_engine_installer_ux` full module
- [x] `tests.scripts.test_chaos_engine_dependencies` `version_at_least` floor helper
- [x] Maven Tools installer cases for stable-tag build + docker mode