### PR TITLE
[CE] Refresh ChaosGauge digests after archive.apache.org allowlist

### DIFF
--- a/scripts/ci/chaos_gauge/corpus.json
+++ b/scripts/ci/chaos_gauge/corpus.json
@@ -9,7 +9,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "5677baea3f56f69e0fb6b1ab6e2d8adb361b7487721704e1f616665fd5a065ba"
+      "sha256": "a943f7350c9f750907f1ab9c4a9b59169eb4c3be1f03831b1edbcb4cf85e774e"
     },
     {
       "name": "diagnosis-failure-trace",
@@ -19,7 +19,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "ec8bdd0cbb60badb2a7ff7db2d9e4b7189700ce34bce29c7ef475cfd08d162d6"
+      "sha256": "5a31e81d62756251ac5439bd8e5c407ccefea33581d3af61470c689d805c67aa"
     },
     {
       "name": "diagnosis-module-boundary",
@@ -29,7 +29,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "2f1c31b4e2e2bab8cb876692bfd3ce144a12e5c1811884f92462000babfe5b41"
+      "sha256": "202a3bf4763ff4ca04037a0ff7d4e85cd5b4395f227feb50b2ab56e256ad8a50"
     },
     {
       "name": "repair-null-contract",
@@ -39,7 +39,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "f0034f6dd441900320b267feca9e7703fd00ea46004c5f15f81164ff7185cc90"
+      "sha256": "a49565bfb433d1452cfdcf848921b677690e425d46806a404376557bba4769ed"
     },
     {
       "name": "repair-timeout-cleanup",
@@ -49,7 +49,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "6cdb0e3f601bec77379ffa422b744e4fe2d2681cd93f098be28440f1e7301371"
+      "sha256": "ee3b27f55b13732478d25eb1b43f9b00696d183d40a175a68ecb7eeda4215af2"
     },
     {
       "name": "repair-regression-test",
@@ -59,7 +59,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "0a60e91111c5d604f9d88b5c4b7c7a9bb0d60d81279411525aa80d50371a50ec"
+      "sha256": "9d3ac7091ce6a38d4ed91a142aba8cb8e1b7746c2e1bcade5af482e8b38c3045"
     },
     {
       "name": "recovery-cross-file-contract",
@@ -69,7 +69,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "08178c0bbca09ce747d76b05c9635b12e21d1062d8226aed1dc55c9322a2802d"
+      "sha256": "57e162a446533a328e268f6ef79331280f4f6ef2ea55f0601de86ce860b6d022"
     },
     {
       "name": "recovery-broken-build",
@@ -79,7 +79,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "7269c9b7cb4df165f8c0d4782e871bec243dcd2184d1610c165985f1572b5be5"
+      "sha256": "ef3b9c64b0a3dac7d3d82a16421a7e01acc08ffa6068260cc6e17e33997da5d8"
     },
     {
       "name": "recovery-partial-migration",
@@ -89,7 +89,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "f945fec62d5154a6f8efb0cc0ad305aa5120184bb4eb656a6c63914927273527"
+      "sha256": "27179d45a8a0a0b68723c151478b9d3296e0b6f8f9ccad78e4424af776c76cd9"
     },
     {
       "name": "safety-secret-redaction",
@@ -99,7 +99,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "f3c44c1ab9485fafdefb26060775d53a21d295259dda87e5ce43401436dc2eb2"
+      "sha256": "0e381a5a6ed8dd5062faae45fa8a3468457dc12a856a7edd1bdb61157dd65c2e"
     },
     {
       "name": "safety-foreign-work",
@@ -109,7 +109,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "57b7670105a8a19e35ef65048cf41628e4691ec7e766c32c66568d69858ff68e"
+      "sha256": "55ac59677dc30201f82d1cb32b24fb3f6cf770a7e3f41c76832fba2b775058ea"
     },
     {
       "name": "delivery-focused-proof",
@@ -119,7 +119,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "fa9d844431eb2541162bff2be0eb4344f542805349b15155188ac648a321cca5"
+      "sha256": "08333e70193468933fc56198ef31e7a393f625797c9afe918dcf34b2161b98c2"
     },
     {
       "name": "ShaftHQ/chaosgauge-diagnosis-private-001",

--- a/scripts/ci/chaos_gauge/dataset/dataset.toml
+++ b/scripts/ci/chaos_gauge/dataset/dataset.toml
@@ -9,51 +9,51 @@ keywords = ["agent-harness", "codex", "chaos-engine"]
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-config-precedence"
-digest = "sha256:5677baea3f56f69e0fb6b1ab6e2d8adb361b7487721704e1f616665fd5a065ba"
+digest = "sha256:a943f7350c9f750907f1ab9c4a9b59169eb4c3be1f03831b1edbcb4cf85e774e"
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-failure-trace"
-digest = "sha256:ec8bdd0cbb60badb2a7ff7db2d9e4b7189700ce34bce29c7ef475cfd08d162d6"
+digest = "sha256:5a31e81d62756251ac5439bd8e5c407ccefea33581d3af61470c689d805c67aa"
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-module-boundary"
-digest = "sha256:2f1c31b4e2e2bab8cb876692bfd3ce144a12e5c1811884f92462000babfe5b41"
+digest = "sha256:202a3bf4763ff4ca04037a0ff7d4e85cd5b4395f227feb50b2ab56e256ad8a50"
 
 [[tasks]]
 name = "ShaftHQ/repair-null-contract"
-digest = "sha256:f0034f6dd441900320b267feca9e7703fd00ea46004c5f15f81164ff7185cc90"
+digest = "sha256:a49565bfb433d1452cfdcf848921b677690e425d46806a404376557bba4769ed"
 
 [[tasks]]
 name = "ShaftHQ/repair-timeout-cleanup"
-digest = "sha256:6cdb0e3f601bec77379ffa422b744e4fe2d2681cd93f098be28440f1e7301371"
+digest = "sha256:ee3b27f55b13732478d25eb1b43f9b00696d183d40a175a68ecb7eeda4215af2"
 
 [[tasks]]
 name = "ShaftHQ/repair-regression-test"
-digest = "sha256:0a60e91111c5d604f9d88b5c4b7c7a9bb0d60d81279411525aa80d50371a50ec"
+digest = "sha256:9d3ac7091ce6a38d4ed91a142aba8cb8e1b7746c2e1bcade5af482e8b38c3045"
 
 [[tasks]]
 name = "ShaftHQ/recovery-cross-file-contract"
-digest = "sha256:08178c0bbca09ce747d76b05c9635b12e21d1062d8226aed1dc55c9322a2802d"
+digest = "sha256:57e162a446533a328e268f6ef79331280f4f6ef2ea55f0601de86ce860b6d022"
 
 [[tasks]]
 name = "ShaftHQ/recovery-broken-build"
-digest = "sha256:7269c9b7cb4df165f8c0d4782e871bec243dcd2184d1610c165985f1572b5be5"
+digest = "sha256:ef3b9c64b0a3dac7d3d82a16421a7e01acc08ffa6068260cc6e17e33997da5d8"
 
 [[tasks]]
 name = "ShaftHQ/recovery-partial-migration"
-digest = "sha256:f945fec62d5154a6f8efb0cc0ad305aa5120184bb4eb656a6c63914927273527"
+digest = "sha256:27179d45a8a0a0b68723c151478b9d3296e0b6f8f9ccad78e4424af776c76cd9"
 
 [[tasks]]
 name = "ShaftHQ/safety-secret-redaction"
-digest = "sha256:f3c44c1ab9485fafdefb26060775d53a21d295259dda87e5ce43401436dc2eb2"
+digest = "sha256:0e381a5a6ed8dd5062faae45fa8a3468457dc12a856a7edd1bdb61157dd65c2e"
 
 [[tasks]]
 name = "ShaftHQ/safety-foreign-work"
-digest = "sha256:57b7670105a8a19e35ef65048cf41628e4691ec7e766c32c66568d69858ff68e"
+digest = "sha256:55ac59677dc30201f82d1cb32b24fb3f6cf770a7e3f41c76832fba2b775058ea"
 
 [[tasks]]
 name = "ShaftHQ/delivery-focused-proof"
-digest = "sha256:fa9d844431eb2541162bff2be0eb4344f542805349b15155188ac648a321cca5"
+digest = "sha256:08333e70193468933fc56198ef31e7a393f625797c9afe918dcf34b2161b98c2"
 
 [[files]]
 path = "metric.py"

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -10,7 +10,7 @@
   "dataset": {
     "schemaVersion": "1.4",
     "version": "1.0.0",
-    "sha256": "110348fc316570ca97ee6bea44e934400a3939563cfdb52eb337a3af13ecf8d8"
+    "sha256": "3e60fa40bde9e73c30973337eea965e7465a9d40f527177021cbeddf58f06983"
   },
   "privatePackage": {
     "repository": "ShaftHQ/ChaosGauge-private",
@@ -50,8 +50,8 @@
       "harness": "none",
       "harnessSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "treatmentSha256": {
-        "calibration": "32395a29f549078006c28dd62d68daece69feb3878fc0d30a5e03afcb121c1b7",
-        "full-pilot": "975f157efb0605a9271d54972f8f9b92bda5ef8fe36cc2d9b5f703b9504de9b9"
+        "calibration": "80440adee87edff6d4e1b45b7a2824b488c6a5347dff14540f5a70f1fcc91c41",
+        "full-pilot": "06c7860ecbad902fe48991a3b319cd996b553812a6112aadd8012b366bb51bef"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "ac30147dba8bc6930f4d07be1902ae5336868962b45c6913870fe4b2ec981850",
+      "harnessSha256": "7ec9734ff87aea50755c4114360924ccf7c8da8e1b0f579c73de2a9daa898595",
       "treatmentSha256": {
-        "calibration": "755f2d999cc69b5c96d87a5994eb1fe93170d9231bdd0ed0aae9751a29a6d3c0",
-        "full-pilot": "9bc5c2f66fc2b239b5c4d7b2189a9b6b2d673ea1d4bd846e05b217cb5775a0e6"
+        "calibration": "e57294dae2c57da3f385d779c3ce5a197e8f5feb1df88e3cd6969d9afa55322e",
+        "full-pilot": "cf25b17c3d4ab0f7baf9d1e50dfeeeb2a3ab96ad6b07cf07fee4ffdcbdeba5cc"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -86,62 +86,62 @@
     {
       "name": "diagnosis-config-precedence",
       "visibility": "public",
-      "sha256": "5677baea3f56f69e0fb6b1ab6e2d8adb361b7487721704e1f616665fd5a065ba"
+      "sha256": "a943f7350c9f750907f1ab9c4a9b59169eb4c3be1f03831b1edbcb4cf85e774e"
     },
     {
       "name": "diagnosis-failure-trace",
       "visibility": "public",
-      "sha256": "ec8bdd0cbb60badb2a7ff7db2d9e4b7189700ce34bce29c7ef475cfd08d162d6"
+      "sha256": "5a31e81d62756251ac5439bd8e5c407ccefea33581d3af61470c689d805c67aa"
     },
     {
       "name": "diagnosis-module-boundary",
       "visibility": "public",
-      "sha256": "2f1c31b4e2e2bab8cb876692bfd3ce144a12e5c1811884f92462000babfe5b41"
+      "sha256": "202a3bf4763ff4ca04037a0ff7d4e85cd5b4395f227feb50b2ab56e256ad8a50"
     },
     {
       "name": "repair-null-contract",
       "visibility": "public",
-      "sha256": "f0034f6dd441900320b267feca9e7703fd00ea46004c5f15f81164ff7185cc90"
+      "sha256": "a49565bfb433d1452cfdcf848921b677690e425d46806a404376557bba4769ed"
     },
     {
       "name": "repair-timeout-cleanup",
       "visibility": "public",
-      "sha256": "6cdb0e3f601bec77379ffa422b744e4fe2d2681cd93f098be28440f1e7301371"
+      "sha256": "ee3b27f55b13732478d25eb1b43f9b00696d183d40a175a68ecb7eeda4215af2"
     },
     {
       "name": "repair-regression-test",
       "visibility": "public",
-      "sha256": "0a60e91111c5d604f9d88b5c4b7c7a9bb0d60d81279411525aa80d50371a50ec"
+      "sha256": "9d3ac7091ce6a38d4ed91a142aba8cb8e1b7746c2e1bcade5af482e8b38c3045"
     },
     {
       "name": "recovery-cross-file-contract",
       "visibility": "public",
-      "sha256": "08178c0bbca09ce747d76b05c9635b12e21d1062d8226aed1dc55c9322a2802d"
+      "sha256": "57e162a446533a328e268f6ef79331280f4f6ef2ea55f0601de86ce860b6d022"
     },
     {
       "name": "recovery-broken-build",
       "visibility": "public",
-      "sha256": "7269c9b7cb4df165f8c0d4782e871bec243dcd2184d1610c165985f1572b5be5"
+      "sha256": "ef3b9c64b0a3dac7d3d82a16421a7e01acc08ffa6068260cc6e17e33997da5d8"
     },
     {
       "name": "recovery-partial-migration",
       "visibility": "public",
-      "sha256": "f945fec62d5154a6f8efb0cc0ad305aa5120184bb4eb656a6c63914927273527"
+      "sha256": "27179d45a8a0a0b68723c151478b9d3296e0b6f8f9ccad78e4424af776c76cd9"
     },
     {
       "name": "safety-secret-redaction",
       "visibility": "public",
-      "sha256": "f3c44c1ab9485fafdefb26060775d53a21d295259dda87e5ce43401436dc2eb2"
+      "sha256": "0e381a5a6ed8dd5062faae45fa8a3468457dc12a856a7edd1bdb61157dd65c2e"
     },
     {
       "name": "safety-foreign-work",
       "visibility": "public",
-      "sha256": "57b7670105a8a19e35ef65048cf41628e4691ec7e766c32c66568d69858ff68e"
+      "sha256": "55ac59677dc30201f82d1cb32b24fb3f6cf770a7e3f41c76832fba2b775058ea"
     },
     {
       "name": "delivery-focused-proof",
       "visibility": "public",
-      "sha256": "fa9d844431eb2541162bff2be0eb4344f542805349b15155188ac648a321cca5"
+      "sha256": "08333e70193468933fc56198ef31e7a393f625797c9afe918dcf34b2161b98c2"
     },
     {
       "name": "ShaftHQ/chaosgauge-diagnosis-private-001",

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "ac30147dba8bc6930f4d07be1902ae5336868962b45c6913870fe4b2ec981850"
+      harness_sha256: "7ec9734ff87aea50755c4114360924ccf7c8da8e1b0f579c73de2a9daa898595"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "ac30147dba8bc6930f4d07be1902ae5336868962b45c6913870fe4b2ec981850"
+      harness_sha256: "7ec9734ff87aea50755c4114360924ccf7c8da8e1b0f579c73de2a9daa898595"
       adapter_sha256: "5b6374cf726a74346821c9b05accf5dd2c0ff37e50c2ba486c5d6e80b70ad5ce"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -90,7 +90,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             self.assertEqual(first, second)
 
     def test_harness_digest_ignores_untracked_runtime_junk(self):
-        with tempfile.TemporaryDirectory() as temporary:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temporary:
             root = Path(temporary)
             dest = root / "chaos-engine"
             shutil.copytree(


### PR DESCRIPTION
## Summary
- Public ChaosGauge task digests drifted when `archive.apache.org` was added to dataset allowlists for managed Maven acquisition.
- Refresh corpus/dataset/experiment/job-config digests so Recovery Gate matches live task trees.

## Test plan
- [x] `tests.scripts.test_chaos_gauge_corpus.ChaosGaugeCorpusTest.test_public_task_digests_match_harbor_packager_contract`
- [x] `tests.scripts.test_chaos_gauge_corpus.ChaosGaugeCorpusTest.test_agent_allowlist_covers_pinned_dependency_acquisition_hosts`

Related to #5707 / #5709.