### PR TITLE
fix: Flutter Allure path and visual OCR viewport/focus (#5721)

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -1211,11 +1211,13 @@ jobs:
           api-level: 30
           target: google_apis
           arch: x86_64
+          working-directory: ${{ github.workspace }}
           script: |
             # android-emulator-runner invokes this script with /usr/bin/sh (dash on
             # ubuntu-latest). dash rejects bash-only -o options and exits 2 before Maven
             # runs, so Post-Test Report then fails with missing Allure/JaCoCo (#5696).
             set -eu
+            cd "$GITHUB_WORKSPACE"
             APK_PATH="$GITHUB_WORKSPACE/shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk"
             ls -l "$APK_PATH"
             adb devices
@@ -1255,7 +1257,7 @@ jobs:
             curl --max-time 30 -fsS -X DELETE "http://127.0.0.1:4723/session/$SESSION_ID" || true
 
             # Issue #5638: real tap/type/text via SHAFT.GUI.Locator.flutter*.
-            mvn -pl shaft-engine -e test \
+            mvn -f "$GITHUB_WORKSPACE/pom.xml" -pl shaft-engine -e test \
               "-Dtest=testPackage.appium.FlutterTest" \
               "-Dshaft.enableFlutterE2E=true" \
               "-DexecutionAddress=127.0.0.1:4723" \
@@ -1263,7 +1265,19 @@ jobs:
               "-Dmobile_automationName=FlutterIntegration" \
               "-DtargetOperatingSystem=android" \
               "-DdefaultElementIdentificationTimeout=60" \
+              "-Dallure.automaticallyOpen=false" \
+              "-DheadlessExecution=true" \
               "-DgenerateAllureReportArchive=true"
+            # Post-Test Report only reads shaft-engine/allure-results (#5721).
+            if [ ! -d "$GITHUB_WORKSPACE/shaft-engine/allure-results" ]; then
+              for d in "$PWD/shaft-engine/allure-results" "$PWD/allure-results" "$GITHUB_WORKSPACE/allure-results"; do
+                if [ -n "$(find "$d" -name '*-result.json' -type f -print -quit 2>/dev/null)" ]; then
+                  mkdir -p "$GITHUB_WORKSPACE/shaft-engine/allure-results"
+                  cp -a "$d"/. "$GITHUB_WORKSPACE/shaft-engine/allure-results/"
+                  break
+                fi
+              done
+            fi
       - name: Upload Appium server log
         if: always()
         uses: actions/upload-artifact@v7.0.1

--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -1654,11 +1654,11 @@ public class TouchActions extends FluentWebDriverAction {
                 // for the animated GIF:
                 elementActionsHelper.takeScreenshot(driverFactoryHelper.getDriver(), null, "swipeElementIntoView", null, true);
 
-                var elementExistsOnViewPort = !ElementActionsHelper.safeFindElements(driverFactoryHelper.getDriver(), targetElementLocator).isEmpty();
+                var elementExistsOnViewPort = isTargetVisibleInViewport(targetElementLocator);
                 if (elementExistsOnViewPort)
                     return true;
                 canScrollMore.set(performW3cCompliantScroll(scrollParameters, isFirstAttempt.getAndSet(false)));
-                elementExistsOnViewPort = !ElementActionsHelper.safeFindElements(driverFactoryHelper.getDriver(), targetElementLocator).isEmpty();
+                elementExistsOnViewPort = isTargetVisibleInViewport(targetElementLocator);
                 if (!canScrollMore.get() && !elementExistsOnViewPort)
                     throw new RuntimeException("Element not found after scrolling to the end of the page.");
                 return elementExistsOnViewPort;
@@ -1687,6 +1687,35 @@ public class TouchActions extends FluentWebDriverAction {
         }
         ReportManager.logDiscrete("Element found on screen.");
         return true;
+    }
+
+    /**
+     * Native lists often keep off-screen rows in the tree. Presence is not
+     * viewport membership; element screenshots then crop outside the bitmap (#5721).
+     */
+    private boolean isTargetVisibleInViewport(By targetElementLocator) {
+        var matches = ElementActionsHelper.safeFindElements(driverFactoryHelper.getDriver(), targetElementLocator);
+        if (matches == null || matches.isEmpty()) {
+            return false;
+        }
+        WebElement element = matches.get(0);
+        try {
+            if (!element.isDisplayed()) {
+                return false;
+            }
+            Rectangle rect = element.getRect();
+            if (rect.getWidth() <= 0 || rect.getHeight() <= 0) {
+                return false;
+            }
+            Dimension window = driverFactoryHelper.getDriver().manage().window().getSize();
+            int left = Math.max(rect.getX(), 0);
+            int top = Math.max(rect.getY(), 0);
+            int right = Math.min(rect.getX() + rect.getWidth(), window.getWidth());
+            int bottom = Math.min(rect.getY() + rect.getHeight(), window.getHeight());
+            return right > left && bottom > top;
+        } catch (RuntimeException ignored) {
+            return false;
+        }
     }
 
     /**

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -221,6 +221,7 @@ public class AndroidBasicInteractionsTests extends MobileTest {
                 .tap(AppiumBy.accessibilityId("3. Simple Adapter"));
 
         driver.get().touch().swipeElementIntoView(group18, TouchActions.SwipeDirection.DOWN);
+        Assert.assertTrue(driver.get().getDriver().findElement(group18).isDisplayed());
         byte[] group18Screenshot = driver.get().getDriver().findElement(group18).getScreenshotAs(OutputType.BYTES);
 
         // Tiny "Group 1" crops match many list rows under AUTO; OCR uniquely names Group 1.
@@ -250,6 +251,7 @@ public class AndroidBasicInteractionsTests extends MobileTest {
 
         byte[] tab1Screenshot = driver.get().getDriver().findElement(tab1).getScreenshotAs(OutputType.BYTES);
         driver.get().touch().swipeElementIntoView(tabs, tab12, TouchActions.SwipeDirection.RIGHT);
+        Assert.assertTrue(driver.get().getDriver().findElement(tab12).isDisplayed());
         byte[] tab12Screenshot = driver.get().getDriver().findElement(tab12).getScreenshotAs(OutputType.BYTES);
 
         // Nightly LEFT image swipe already succeeded under AUTO; keep that proven path.

--- a/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
@@ -57,12 +57,12 @@ public class IOSBasicInteractionsTest {
 
         driver.get().touch()
                 .tap(ImageTarget.fromBytes(inputScreenshot));
-        Assert.assertEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
+        Assert.assertTrue(isAccessibilityFocused(TEXT_INPUT), "Image tap should focus Text Input");
 
         ((IOSDriver) driver.get().getDriver()).hideKeyboard();
-        Assert.assertNotEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
+        Assert.assertFalse(isAccessibilityFocused(TEXT_INPUT), "Hiding the keyboard should blur Text Input");
         driver.get().touch().tap(OcrTarget.exact("Text Input"));
-        Assert.assertEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
+        Assert.assertTrue(isAccessibilityFocused(TEXT_INPUT), "OCR tap should focus Text Input");
         driver.get().element().type(TEXT_INPUT, "visual ocr ios" + "\n");
 
         Validations.assertThat()
@@ -189,6 +189,12 @@ public class IOSBasicInteractionsTest {
 //        System.setProperty("browserStack.appUrl", "bs://e2c374a22cf954e582b5c02e9a9f7cfd650a8325");
         driver.set(new SHAFT.GUI.WebDriver());
 
+    }
+
+    /** XCUITest {@code switchTo().activeElement()} is getActiveElement with null locators. */
+    private boolean isAccessibilityFocused(By locator) {
+        String focused = driver.get().getDriver().findElement(locator).getAttribute("focused");
+        return "true".equalsIgnoreCase(focused) || "1".equals(focused);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -654,6 +654,8 @@ public class AndroidTouchActionsCoverageUnitTest {
     public void reflectionAndWrapperMethodsShouldCoverRemainingTouchActionPaths() throws Exception {
         AndroidDriver driver = createMockAndroidDriver();
         WebElement targetElement = mock(WebElement.class);
+        when(targetElement.isDisplayed()).thenReturn(true);
+        when(targetElement.getRect()).thenReturn(new org.openqa.selenium.Rectangle(40, 80, 120, 40));
         when(driver.findElements(any(By.class))).thenReturn(List.of(), List.of(targetElement), List.of(targetElement));
         doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
 
@@ -1056,6 +1058,26 @@ public class AndroidTouchActionsCoverageUnitTest {
         touchActions.activateInjectedImage("mock-image-123");
 
         verify(elementActionsHelper).failAction(eq(driver), anyString(), isNull(By.class));
+    }
+
+    @Test
+    public void offScreenNativeElementIsNotTreatedAsInViewport() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        TouchActions touchActions = new TouchActions(new DriverFactoryHelper(driver));
+        WebElement offScreen = mock(WebElement.class);
+        WebElement onScreen = mock(WebElement.class);
+        when(offScreen.isDisplayed()).thenReturn(true);
+        when(onScreen.isDisplayed()).thenReturn(true);
+        when(offScreen.getRect()).thenReturn(new org.openqa.selenium.Rectangle(2367, 278, 100, 50));
+        when(onScreen.getRect()).thenReturn(new org.openqa.selenium.Rectangle(80, 278, 100, 50));
+        Method visible = TouchActions.class.getDeclaredMethod("isTargetVisibleInViewport", By.class);
+        visible.setAccessible(true);
+
+        when(driver.findElements(any(By.class))).thenReturn(List.of(offScreen));
+        SHAFT.Validations.assertThat().object(visible.invoke(touchActions, By.id("tab12"))).isEqualTo(false).perform();
+
+        when(driver.findElements(any(By.class))).thenReturn(List.of(onScreen));
+        SHAFT.Validations.assertThat().object(visible.invoke(touchActions, By.id("tab12"))).isEqualTo(true).perform();
     }
 
     private AndroidDriver createMockAndroidDriver() {

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -816,6 +816,8 @@ public class AndroidTouchActionsCoverageUnitTest {
     public void swipeElementIntoViewWithNativeLocatorShouldStillUseMobileScrollGesture() throws Exception {
         AndroidDriver driver = createMockAndroidDriver();
         WebElement targetElement = mock(WebElement.class);
+        when(targetElement.isDisplayed()).thenReturn(true);
+        when(targetElement.getRect()).thenReturn(new org.openqa.selenium.Rectangle(80, 278, 100, 50));
         when(driver.findElements(any(By.class))).thenReturn(List.of(), List.of(targetElement));
         doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -1063,21 +1063,25 @@ public class AndroidTouchActionsCoverageUnitTest {
     @Test
     public void offScreenNativeElementIsNotTreatedAsInViewport() throws Exception {
         AndroidDriver driver = createMockAndroidDriver();
-        TouchActions touchActions = new TouchActions(new DriverFactoryHelper(driver));
         WebElement offScreen = mock(WebElement.class);
         WebElement onScreen = mock(WebElement.class);
         when(offScreen.isDisplayed()).thenReturn(true);
         when(onScreen.isDisplayed()).thenReturn(true);
         when(offScreen.getRect()).thenReturn(new org.openqa.selenium.Rectangle(2367, 278, 100, 50));
         when(onScreen.getRect()).thenReturn(new org.openqa.selenium.Rectangle(80, 278, 100, 50));
-        Method visible = TouchActions.class.getDeclaredMethod("isTargetVisibleInViewport", By.class);
-        visible.setAccessible(true);
+        when(driver.findElements(any(By.class))).thenReturn(List.of(offScreen), List.of(onScreen));
+        doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
 
-        when(driver.findElements(any(By.class))).thenReturn(List.of(offScreen));
-        SHAFT.Validations.assertThat().object(visible.invoke(touchActions, By.id("tab12"))).isEqualTo(false).perform();
+        TouchActions touchActions = new TouchActions(new DriverFactoryHelper(driver));
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        injectElementActionsHelper(touchActions, elementActionsHelper);
 
-        when(driver.findElements(any(By.class))).thenReturn(List.of(onScreen));
-        SHAFT.Validations.assertThat().object(visible.invoke(touchActions, By.id("tab12"))).isEqualTo(true).perform();
+        // Presence in the native tree is not viewport membership (#5721). Public swipe
+        // must still scroll instead of treating the off-screen row as already in view.
+        touchActions.swipeElementIntoView(By.id("tab12"), TouchActions.SwipeDirection.RIGHT);
+
+        verify(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
     }
 
     private AndroidDriver createMockAndroidDriver() {

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -105,6 +105,11 @@ class VisualOcrWorkflowTest(unittest.TestCase):
         script = emulator["with"]["script"]
         self.assertNotRegex(script, r"(?m)^\s*set -[^\n]*pipefail")
         self.assertRegex(script, r"(?m)^\s*set -eu\s*$")
+        self.assertIn('working-directory', emulator["with"])
+        self.assertIn('cd "$GITHUB_WORKSPACE"', script)
+        self.assertIn("-Dallure.automaticallyOpen=false", script)
+        self.assertIn("-DheadlessExecution=true", script)
+        self.assertIn("shaft-engine/allure-results", script)
 
     def test_ios_visual_ocr_uses_shared_locators_and_opens_text_screen(self):
         ios_tests = IOS_TESTS.read_text(encoding="utf-8")
@@ -120,6 +125,8 @@ class VisualOcrWorkflowTest(unittest.TestCase):
         self.assertIn("tap(TEXT_BUTTON)", body)
         self.assertIn("findElement(TEXT_INPUT)", body)
         self.assertNotRegex(body, r'AppiumBy\.accessibilityId\("Text Input"\)')
+        self.assertIn("isAccessibilityFocused(TEXT_INPUT)", body)
+        self.assertNotIn("switchTo().activeElement()", body)
 
     def test_android_visual_ocr_avoids_ambiguous_auto_group1_image_target(self):
         android_tests = ANDROID_TESTS.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #5721

## Cause
Nightly run 34441782795 failed 3/30 jobs.

1. **Android_Flutter_Emulator_E2E** — Maven ran inside `android-emulator-runner`; Post-Test Report only reads `shaft-engine/allure-results`. Results were not there (`Total=0`).
2. **iOS_Visual_Ocr_BrowserStack** — real broken test: `switchTo().activeElement()` → Appium `getActiveElement` with `(null)` locators.
3. **Android_Visual_Ocr_BrowserStack** — real broken tests: `swipeElementIntoView` treated hierarchy presence as viewport membership. TAB 12 element screenshot cropped outside the bitmap; OCR swipe UP for Group 1 hit the scroll boundary.

## Fix
- Flutter job: `working-directory` + `cd $GITHUB_WORKSPACE`, `-f` repo POM, `-Dallure.automaticallyOpen=false -DheadlessExecution=true`, copy `*-result.json` into `shaft-engine/allure-results` if they landed elsewhere.
- Product: `isTargetVisibleInViewport` before stopping W3C swipe.
- iOS acceptance: accessibility `focused` instead of `activeElement`.
- Android acceptance: assert displayed before element screenshots.

## Proof
- `python3 -m unittest tests.scripts.test_visual_ocr_workflow` exit 0
- Maven focused TouchActions tests exit 0 (Temurin 25, Maven wrapper 3.9.10)

Did not start or rerun E2E Tests.