### PR TITLE
[CE] Polish unattended installer success receipt

### DIFF
--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -733,7 +733,11 @@ class InstallReporter:
         ) or [indent]
 
     def _paint(self, value: str, color: str) -> str:
-        return f"\x1b[{color}m{value}\x1b[0m" if self._color else value
+        if not self._color:
+            return value
+        if color.startswith("\x1b"):
+            return f"{color}{value}\x1b[0m"
+        return f"\x1b[{color}m{value}\x1b[0m"
 
     def _duration(self, seconds: float) -> str:
         seconds = max(0, round(seconds))
@@ -913,11 +917,18 @@ class InstallReporter:
                 duration = self._duration(self._completed_elapsed.get(item, 0.0))
                 lines.append(self._paint(self._truncate(f"  [{check}] {item}  {duration}"), "32"))
             elif item == self.current_operation or item in self._in_flight:
-                lines.append(self._paint(self._truncate(f"  [{active}] {item}  running"), "36"))
+                lines.append(
+                    self._paint(
+                        self._truncate(f"  [{active}] {item}  running"),
+                        ION_BLUE,
+                    )
+                )
             else:
                 lines.append(self._truncate(f"  [{empty}] {item}"))
         separator = " · " if self._unicode else " | "
-        metrics = [f"Elapsed {self._duration(elapsed)}"]
+        done = sum(1 for item in operations if item in self.completed_operations)
+        total = len(operations)
+        metrics = [f"{done}/{total}", f"Elapsed {self._duration(elapsed)}"]
         rate = self._download_rate()
         if rate is not None:
             metrics.append(self._size(rate))
@@ -936,8 +947,8 @@ class InstallReporter:
         )
         for ended, message in log:
             lines.extend(self._wrap(f"  [+{self._duration(ended)}] {message}"))
-        lines.append(self._paint("  Summary", "36"))
-        lines.append(self._paint(self._truncate("  " + separator.join(metrics)), "36"))
+        lines.append(self._paint("  Status", ION_BLUE))
+        lines.append(self._paint(self._truncate("  " + separator.join(metrics)), ION_BLUE))
         if self.detail:
             lines.append(self._paint(self._truncate(f"  {self.detail}"), "36"))
         if self._lines:
@@ -971,27 +982,12 @@ class InstallReporter:
                 total += 1
                 if item.get("status") in {"healthy", "absent"}:
                     healthy += 1
-        client_names = sorted(clients) if isinstance(clients, dict) else []
-        self.close()
-        self.stream.write(self._paint("  Summary", "36") + "\n")
-        self.stream.write(
-            "Installation Successful! You can now start a new agent session using Codex, Claude, Grok, Gemini, or Copilot. Just ask it to use chaos-engine and you should be good to go!\n"
-        )
-        if commit is not None:
-            self.stream.write(f"Resolved commit: {commit}\n")
-        if total:
-            self.stream.write(
-                f"Doctor: {doctor_status} ({healthy}/{total} components healthy)\n"
-            )
-        else:
-            self.stream.write(f"Doctor: {doctor_status}\n")
-        if client_names:
-            self.stream.write(f"Clients: {', '.join(client_names)}\n")
-        self.stream.write(format_first_session_brief(clients=clients if isinstance(clients, dict) else {}))
+        elapsed = self._duration(max(0.0, self.clock() - self.started))
+        extra: list[str] = []
         handoff = project / ".chaos-engine-state" / "merge-handoff.md"
         if handoff.is_file() and not handoff.is_symlink():
-            doctor = "py -3" if os.name == "nt" else "python3"
-            doctor_command = f"{doctor} .chaos-engine/install.py doctor --project ."
+            doctor_cli = "py -3" if os.name == "nt" else "python3"
+            doctor_command = f"{doctor_cli} .chaos-engine/install.py doctor --project ."
             prompt = (
                 "Merge ChaosEngine host configuration using "
                 ".chaos-engine-state/merge-handoff.md. Follow "
@@ -999,12 +995,14 @@ class InstallReporter:
                 "Preserve every foreign handler and MCP server. Apply only the listed "
                 f"owned blocks. Then run {doctor_command} and follow each fix-next."
             )
-            self.stream.write(self._paint("  Merge handoff", "36") + "\n")
-            self.stream.write(
-                "Core is installed. Some host files were left unchanged. Details: "
-                f"{handoff.as_posix()}\n"
+            extra.extend(
+                [
+                    "Merge handoff",
+                    "Core is installed. Some host files were left unchanged. Details: "
+                    + handoff.as_posix(),
+                    f"`{prompt}`",
+                ]
             )
-            self.stream.write(f"`{prompt}`\n")
         heal = project / HEAL_HANDOFF_RELATIVE
         if heal.is_file() and not heal.is_symlink():
             issue_url = "the GitHub issue linked in .chaos-engine-state/heal-handoff.md"
@@ -1019,26 +1017,35 @@ class InstallReporter:
             doctor_cli = "py -3" if os.name == "nt" else "python3"
             doctor_command = f"{doctor_cli} .chaos-engine/install.py doctor --project ."
             prompt = heal_handoff_prompt(doctor_command, issue_url)
-            self.stream.write(self._paint("  Heal handoff", "36") + "\n")
-            self.stream.write(
-                "Core is installed. Continue with one agent step. Details: "
-                f"{HEAL_HANDOFF_RELATIVE}\n"
+            extra.extend(
+                [
+                    "Heal handoff",
+                    "Core is installed. Continue with one agent step. Details: "
+                    + HEAL_HANDOFF_RELATIVE,
+                    "Open issue:" if "issues/new?" in issue_url else "GitHub issue:",
+                    issue_url,
+                    "Agent prompt (copy the backtick block):",
+                    f"`{prompt}`",
+                ]
             )
-            if "issues/new?" in issue_url:
-                self.stream.write("Open issue:\n")
-            else:
-                self.stream.write("GitHub issue:\n")
-            self.stream.write(f"{issue_url}\n")
-            self.stream.write("Agent prompt (copy the backtick block):\n")
-            self.stream.write(f"`{prompt}`\n")
+        self.close()
         self.stream.write(
-            format_host_onboarding_cards(
-                detected=detect_install_hosts(),
-                activated=clients if isinstance(clients, dict) else {},
+            format_install_report(
+                project=project,
+                doctor_status=doctor_status,
+                healthy=healthy,
+                total=total,
+                commit=commit,
+                clients=clients if isinstance(clients, dict) else {},
+                repository=repository,
+                source_label=self.source_label,
+                elapsed=elapsed,
+                extra_blocks=extra,
+                color=self._color,
+                unicode=self._unicode,
+                width=self._width(),
             )
         )
-        self.stream.write(f"{installer_user_guide_url(repository)}\n")
-        self.stream.write(f"Full install trace: {install_trace_path(project).as_posix()}\n")
         self.stream.flush()
 
     def close(self) -> None:
@@ -1058,8 +1065,21 @@ class InstallReporter:
 
 
 
+def _report_style(value: str, color: str, *, enabled: bool) -> str:
+    if not enabled:
+        return value
+    if color.startswith("\x1b"):
+        return f"{color}{value}\x1b[0m"
+    return f"\x1b[{color}m{value}\x1b[0m"
+
+
+def _align_report(label: str, value: str, *, color: bool = False) -> str:
+    painted = _report_style(f"{label:<10}", ION_BLUE, enabled=color)
+    return f"  {painted} {value}"
+
+
 def format_first_session_brief(*, clients: dict[str, object] | None = None) -> str:
-    """Return the post-install first-session brief (landed / untracked / next 3)."""
+    """Return bun-style next steps plus a First-session brief synonym heading."""
     client_names = sorted(clients) if isinstance(clients, dict) else []
     if client_names:
         open_host = (
@@ -1073,17 +1093,104 @@ def format_first_session_brief(*, clients: dict[str, object] | None = None) -> s
             "(Codex, Claude Code, Grok, Gemini, or GitHub Copilot)."
         )
     lines = [
+        "To get started:",
+        f"    {open_host}",
+        "    Ask the agent to load / use the `chaos-engine` skill.",
+        "    Run a small sample task (for example: ask doctor status, or a one-file reversible edit).",
         "First-session brief:",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def format_landed_untracked_lines() -> list[str]:
+    """Return Landed/Untracked receipt lines (folded under Guide/Trace)."""
+    return [
         "  Landed: portable core (`.chaos-engine/`), lifecycle hooks, five host adapters,",
         "    Caveman + Ponytail companions, self-improve skill, Memory / MemPalace / Graphify store tooling.",
         "  Untracked: generated indexes, caches, receipts, and runtimes",
         "    (`.chaos-engine-runtime*`, dependency/host receipts, `graphify-out`, local tool caches).",
         "    Canonical adapters and config stay trackable.",
-        "  Next:",
-        f"    1. {open_host}",
-        "    2. Ask the agent to load / use the `chaos-engine` skill.",
-        "    3. Run a small sample task (for example: ask doctor status, or a one-file reversible edit).",
     ]
+
+
+def format_install_report(
+    *,
+    project: Path,
+    doctor_status: str,
+    healthy: int,
+    total: int,
+    commit: str | None,
+    clients: dict[str, object],
+    repository: str,
+    source_label: str | None,
+    elapsed: str,
+    extra_blocks: list[str] | None = None,
+    color: bool = False,
+    unicode: bool = False,
+    width: int = 80,
+) -> str:
+    """Render the unattended finish receipt (bun/uv rhythm, rustup table)."""
+    headline = _report_style("Installation Successful!", "32", enabled=color)
+    lines = ["", f"  {headline}  ({elapsed})"]
+    if width >= 48:
+        rule = "──" if unicode else "--"
+        lines.append("  " + _report_style(rule * 18, ION_BLUE, enabled=color))
+    lines.append("")
+    lines.append(_align_report("Project", str(Path(project)), color=color))
+    if source_label:
+        lines.append(_align_report("Source", source_label, color=color))
+    if commit is not None:
+        short = commit[:12] + ("…" if unicode else "...") if len(commit) == 40 else commit
+        remainder = commit[12:] if len(commit) == 40 else ""
+        if remainder and color:
+            short = short + _report_style(remainder, "2", enabled=True)
+        lines.append(_align_report("Commit", short, color=color))
+        lines.append(f"Resolved commit: {commit}")
+    if total:
+        doctor_line = f"Doctor: {doctor_status} ({healthy}/{total} components healthy)"
+    else:
+        doctor_line = f"Doctor: {doctor_status}"
+    lines.append(doctor_line)
+    client_names = sorted(clients) if isinstance(clients, dict) else []
+    if client_names:
+        lines.append(f"Clients: {', '.join(client_names)}")
+    lines.append("")
+    started = format_first_session_brief(clients=clients).rstrip("\n")
+    if color:
+        started = started.replace(
+            "To get started:",
+            _report_style("To get started:", ION_BLUE, enabled=True),
+            1,
+        )
+    lines.append(started)
+    if extra_blocks:
+        lines.append("")
+        for block in extra_blocks:
+            if block in {"Merge handoff", "Heal handoff"}:
+                paint = "31" if block == "Heal handoff" else ION_BLUE
+                lines.append("  " + _report_style(block, paint, enabled=color))
+            else:
+                lines.append(block)
+    lines.append("")
+    lines.append(
+        format_host_onboarding_cards(
+            detected=detect_install_hosts(),
+            activated=clients,
+            color=color,
+        ).rstrip("\n")
+    )
+    lines.append("")
+    guide = installer_user_guide_url(repository)
+    guide_shown = guide
+    if color and unicode:
+        guide_shown = f"\x1b]8;;{guide}\x1b\\{guide}\x1b]8;;\x1b\\"
+    lines.append(_align_report("Guide", guide_shown, color=color))
+    trace = install_trace_path(Path(project)).as_posix()
+    trace_value = _report_style(trace, "2", enabled=color)
+    lines.append(_align_report("Trace", trace_value, color=color))
+    lines.append(f"Full install trace: {trace}")
+    lines.extend(format_landed_untracked_lines())
+    lines.append("")
     return "\n".join(lines) + "\n"
 
 
@@ -1177,29 +1284,55 @@ def format_host_onboarding_cards(
     *,
     detected: list[tuple[str, str, bool]] | None = None,
     activated: dict[str, object] | None = None,
+    color: bool = False,
 ) -> str:
-    """Render five host onboarding cards with enablement path and explicit gaps."""
+    """Render a rustup-style host table; how/gap only for one actionable host."""
     detected_map = {
         host_id: found for host_id, _label, found in (detected or [])
     }
     activated_names = {
         str(name).casefold() for name in (activated or {})
     }
-    lines = ["Host onboarding cards:"]
-    for host_id, _command, _label in HOST_DETECT_COMMANDS:
-        card = HOST_ONBOARDING_CARDS[host_id]
-        markers: list[str] = []
-        if detected_map.get(host_id):
-            markers.append("detected")
-        if host_id in activated_names or any(
+
+    def _is_activated(host_id: str) -> bool:
+        return host_id in activated_names or any(
             name == host_id or name.startswith(f"{host_id}-")
             for name in activated_names
-        ):
-            markers.append("activated")
-        marker_text = f" [{', '.join(markers)}]" if markers else ""
-        lines.append(f"  {card['label']}{marker_text} — {card['path']}")
-        lines.append(f"    how: {card['how']}")
-        lines.append(f"    gap: {card['gap']}")
+        )
+
+    actionable: str | None = None
+    for host_id, _command, _label in HOST_DETECT_COMMANDS:
+        if detected_map.get(host_id) and not _is_activated(host_id):
+            actionable = host_id
+            break
+    if actionable is None:
+        for host_id, _command, _label in HOST_DETECT_COMMANDS:
+            if not detected_map.get(host_id) and not _is_activated(host_id):
+                actionable = host_id
+                break
+    heading = _report_style("Hosts", ION_BLUE, enabled=color)
+    lines = ["Host onboarding cards:", f"  {heading}"]
+    for host_id, _command, _label in HOST_DETECT_COMMANDS:
+        card = HOST_ONBOARDING_CARDS[host_id]
+        found = bool(detected_map.get(host_id))
+        if _is_activated(host_id):
+            status = "activated"
+        elif host_id == "copilot" and found:
+            status = "IDE signal"
+        elif found:
+            status = "detected"
+        else:
+            status = "not on PATH"
+        status_cell = f"{status:<14}"
+        if color and status == "activated":
+            status_cell = _report_style(status_cell, "32", enabled=True)
+        elif color:
+            status_cell = _report_style(status_cell, "2", enabled=True)
+        path = card["path"].replace("file/hook injection", "file/hook")
+        lines.append(f"    {card['label']:<16} {status_cell} {path}")
+        if host_id == actionable:
+            lines.append(f"      how: {card['how']}")
+            lines.append(f"      gap: {card['gap']}")
     return "\n".join(lines) + "\n"
 
 

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -676,8 +676,12 @@ class InstallReporter:
             with self._lock:
                 self._render_locked()
         else:
-            self.stream.write(self._truncate(f"Install root: {self.project_root}") + "\n")
-            self.stream.write(self._truncate(f"Source: {self.source_label}") + "\n")
+            self.stream.write(
+                self._truncate(_align_report("Project", self.project_root)) + "\n"
+            )
+            self.stream.write(
+                self._truncate(_align_report("Source", self.source_label)) + "\n"
+            )
             self.stream.flush()
 
     def trace(self, message: str) -> None:
@@ -907,9 +911,17 @@ class InstallReporter:
         check, active, empty = (("✓", "◉", " ") if self._unicode else ("x", "*", " "))
         lines = [""]
         if self.project_root:
-            lines.append(self._truncate(f"  Install root: {self.project_root}"))
+            lines.append(
+                self._truncate(
+                    _align_report("Project", self.project_root, color=self._color)
+                )
+            )
         if self.source_label:
-            lines.append(self._truncate(f"  Source: {self.source_label}"))
+            lines.append(
+                self._truncate(
+                    _align_report("Source", self.source_label, color=self._color)
+                )
+            )
         if self.project_root or self.source_label:
             lines.append("")
         for item in operations:
@@ -940,7 +952,7 @@ class InstallReporter:
         ]
         trace_path = self.trace_path or Path(".chaos-engine-state/install-trace.json")
         lines.extend(
-            self._paint(line, "36")
+            self._paint(line, "2")
             for line in self._wrap(
                 f"  Trace (last {len(log)} of {self.trace_count}; full log: {trace_path.as_posix()})"
             )
@@ -950,7 +962,7 @@ class InstallReporter:
         lines.append(self._paint("  Status", ION_BLUE))
         lines.append(self._paint(self._truncate("  " + separator.join(metrics)), ION_BLUE))
         if self.detail:
-            lines.append(self._paint(self._truncate(f"  {self.detail}"), "36"))
+            lines.append(self._paint(self._truncate(f"  {self.detail}"), ION_BLUE))
         if self._lines:
             self.stream.write(f"\x1b[{self._lines}F")
         rendered = "\n".join(line + "\x1b[K" for line in lines) + "\n"
@@ -1363,8 +1375,8 @@ def run_first_run_wizard(
     present = [label for _host_id, label, found in hosts if found]
     absent = [label for _host_id, label, found in hosts if not found]
     output.write("ChaosEngine first-run wizard\n")
-    output.write(f"Project: {project}\n")
-    output.write(f"Upstream: {repository}\n")
+    output.write(_align_report("Project", str(project)) + "\n")
+    output.write(_align_report("Source", repository) + "\n")
     output.write(
         "This install will add the portable ChaosEngine core, lifecycle hooks, "
         "Memory, MemPalace, Graphify CLI, five host adapters, and the Caveman + "
@@ -1381,6 +1393,10 @@ def run_first_run_wizard(
         )
     if absent:
         output.write("Not detected on PATH: " + ", ".join(absent) + "\n")
+    output.write("Hosts\n")
+    for host_id, label, found in hosts:
+        status = "on PATH" if found else "not on PATH"
+        output.write(f"    {label:<16} {status}\n")
     output.write("Next after install:\n")
     for host_id, label, found in hosts:
         marker = "*" if found else "-"
@@ -2076,6 +2092,8 @@ def emit_install_failure(
     opener=urllib.request.urlopen,
     token: str | None = None,
 ) -> str | None:
+    print(file=sys.stderr)
+    print("  Installation failed", file=sys.stderr)
     print(file=sys.stderr)
     if code == "CE-INSTALL-CANCELLED":
         print(f"{code}: installation interrupted", file=sys.stderr)

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -723,6 +723,13 @@ class InstallReporter:
         suffix = "…" if self._unicode else "..."
         return value[: max(0, width - len(suffix))] + suffix
 
+    def _aligned_live_row(self, label: str, value: str) -> str:
+        plain = self._truncate(_align_report(label, value))
+        prefix = f"  {label:<10} "
+        if not plain.startswith(prefix):
+            return plain
+        return _align_report(label, plain[len(prefix) :], color=self._color)
+
     def _wrap(self, value: str) -> list[str]:
         width = self._width()
         if len(value) <= width:
@@ -911,17 +918,9 @@ class InstallReporter:
         check, active, empty = (("✓", "◉", " ") if self._unicode else ("x", "*", " "))
         lines = [""]
         if self.project_root:
-            lines.append(
-                self._truncate(
-                    _align_report("Project", self.project_root, color=self._color)
-                )
-            )
+            lines.append(self._aligned_live_row("Project", self.project_root))
         if self.source_label:
-            lines.append(
-                self._truncate(
-                    _align_report("Source", self.source_label, color=self._color)
-                )
-            )
+            lines.append(self._aligned_live_row("Source", self.source_label))
         if self.project_root or self.source_label:
             lines.append("")
         for item in operations:

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -124,6 +124,35 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("Status", live)
         self.assertNotIn("Install root:", live)
 
+    def test_narrow_tty_announce_keeps_ansi_reset_on_project_source(self):
+        class Tty(io.StringIO):
+            def isatty(self):
+                return True
+
+        stream = Tty()
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"NO_COLOR", "FORCE_COLOR"}
+        }
+        environment.update({"TERM": "xterm", "COLUMNS": "20"})
+        with unittest.mock.patch.dict(os.environ, environment, clear=True), unittest.mock.patch.object(
+            BOOTSTRAP.InstallReporter, "_enable_windows_vt", return_value=True
+        ), unittest.mock.patch.object(BOOTSTRAP.threading.Thread, "start", lambda self: None):
+            reporter = BOOTSTRAP.InstallReporter(stream=stream, clock=lambda: 1.0)
+            reporter.announce(Path("/very/long/project/path"), "owner/very-long-repo", "main")
+            reporter.close()
+        live = stream.getvalue()
+        self.assertIn("\x1b[0m", live)
+        self.assertNotEqual(live.rstrip().endswith(BOOTSTRAP.ION_BLUE[:-1]), True)
+        dangling = live.count(BOOTSTRAP.ION_BLUE) - live.count("\x1b[0m")
+        self.assertLessEqual(dangling, 0)
+
+        pipe = io.StringIO()
+        reporter = BOOTSTRAP.InstallReporter(stream=pipe, clock=lambda: 1.0)
+        reporter.announce(Path("/project"), "ShaftHQ/SHAFT_ENGINE", "main")
+        self.assertNotIn("\x1b", pipe.getvalue())
+
     def test_ticker_updates_elapsed_each_second_during_blocking_work(self):
         class Tty(io.StringIO):
             def isatty(self):

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -85,7 +85,8 @@ class InstallerUxTests(unittest.TestCase):
                 self.assertIn("Install core", output)
                 self.assertIn("Elapsed 00:00", output)
                 self.assertIn("Trace (last 0 of 0; full log:", output)
-                self.assertIn("Summary", output)
+                self.assertIn("Status", output)
+                self.assertRegex(output, r"0/2")
                 self.assertNotIn("ETA calculating", output)
                 self.assertNotIn("Current action:", output)
                 self.assertIn("\x1b[", output)
@@ -393,10 +394,8 @@ class InstallerUxTests(unittest.TestCase):
         )
         output = stream.getvalue()
         self.assertLess(output.index("DONE  Activate clients"), output.index("Installation Successful!"))
-        self.assertIn(
-            "Installation Successful! You can now start a new agent session using Codex, Claude, Grok, Gemini, or Copilot. Just ask it to use chaos-engine and you should be good to go!",
-            output,
-        )
+        self.assertIn("Installation Successful!", output)
+        self.assertNotIn("You can now start a new agent session using Codex, Claude, Grok, Gemini, or Copilot", output)
         self.assertIn(f"Resolved commit: {commit}", output)
         self.assertIn("Doctor: healthy (2/2 components healthy)", output)
         self.assertIn("Clients: claude, codex", output)
@@ -407,12 +406,17 @@ class InstallerUxTests(unittest.TestCase):
         )
         self.assertNotIn("Owned managed dependencies", output)
         self.assertNotIn("Continue working in", output)
+        self.assertIn("To get started:", output)
         self.assertIn("First-session brief:", output)
         self.assertIn("Landed: portable core", output)
         self.assertIn("Untracked: generated indexes", output)
         self.assertIn("Open one activated host (claude, codex)", output)
         self.assertIn("Ask the agent to load / use the `chaos-engine` skill.", output)
         self.assertIn("Run a small sample task", output)
+        self.assertNotIn("\x1b[", output)
+        self.assertNotIn("\r", output)
+        report = output[output.index("Installation Successful!"):]
+        self.assertLessEqual(len(report.splitlines()), 40)
 
     def test_trace_persists_every_event_beyond_live_tty_limit(self):
         reporter = BOOTSTRAP.InstallReporter(stream=io.StringIO())
@@ -442,6 +446,29 @@ class InstallerUxTests(unittest.TestCase):
             reporter.success(Path("/project"), {}, {}, repository="owner/repo")
         self.assertTrue(reporter._stop.is_set())
         self.assertIn("Installation Successful!", stream.getvalue())
+
+    def test_tty_success_uses_brand_colors_without_painting_every_line(self):
+        class Tty(io.StringIO):
+            def isatty(self):
+                return True
+
+        stream = Tty()
+        with unittest.mock.patch.dict(os.environ, {"TERM": "xterm"}, clear=False), unittest.mock.patch.object(
+            BOOTSTRAP.threading.Thread, "start", lambda self: None
+        ), unittest.mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=False):
+            os.environ.pop("NO_COLOR", None)
+            reporter = BOOTSTRAP.InstallReporter(stream=stream)
+            reporter.success(
+                Path("/project"),
+                {"commit": "b" * 40, "status": "healthy", "components": {}},
+                {"claude": {"status": "healthy"}},
+                repository="ShaftHQ/SHAFT_ENGINE",
+            )
+        output = stream.getvalue()
+        self.assertIn("\x1b[32mInstallation Successful!\x1b[0m", output)
+        self.assertIn(BOOTSTRAP.ION_BLUE, output)
+        self.assertIn("To get started:", output)
+        self.assertNotIn("\r", output)
 
     def test_core_and_provision_are_sequential_not_both_running(self):
         """#5635: Install core and Provision dependencies must not both show running."""
@@ -1499,15 +1526,19 @@ class InstallerUxTests(unittest.TestCase):
             activated={"claude": {"status": "healthy"}},
         )
         self.assertIn("Host onboarding cards:", rendered)
+        self.assertIn("Hosts", rendered)
         for label in ("Claude Code", "Codex", "Grok", "Gemini", "GitHub Copilot"):
             self.assertIn(label, rendered)
         self.assertIn("marketplace/plugin", rendered)
-        self.assertIn("file/hook injection", rendered)
+        self.assertIn("file/hook", rendered)
+        self.assertIn("activated", rendered)
+        self.assertIn("not on PATH", rendered)
+        self.assertIn("IDE signal", rendered)
         self.assertIn("gap:", rendered)
-        self.assertIn("[detected, activated]", rendered)
-        self.assertIn("Claude Code [detected, activated]", rendered)
-        # Exactly one card block per host (label line).
-        self.assertEqual(5, sum(1 for line in rendered.splitlines() if " — " in line))
+        self.assertEqual(1, rendered.count("how:"))
+        self.assertEqual(1, rendered.count("gap:"))
+        # Actionable host is first detected-not-activated (copilot), not activated Claude.
+        self.assertGreater(rendered.index("how:"), rendered.index("GitHub Copilot"))
 
     def test_success_cta_includes_host_onboarding_cards(self):
         stream = io.StringIO()
@@ -1532,24 +1563,25 @@ class InstallerUxTests(unittest.TestCase):
         output = stream.getvalue()
         self.assertIn("Host onboarding cards:", output)
         self.assertIn("marketplace/plugin", output)
-        self.assertIn("file/hook injection", output)
-        self.assertIn("gap:", output)
+        self.assertIn("file/hook", output)
+        self.assertEqual(1, output.count("how:"))
+        self.assertEqual(1, output.count("gap:"))
 
     def test_first_session_brief_lists_landed_untracked_and_three_next_actions(self):
         with_clients = BOOTSTRAP.format_first_session_brief(
             clients={"codex": {"status": "healthy"}}
         )
         self.assertIn("First-session brief:", with_clients)
-        self.assertIn("Landed:", with_clients)
-        self.assertIn("Untracked:", with_clients)
-        self.assertIn("Next:", with_clients)
+        self.assertIn("To get started:", with_clients)
         self.assertIn("Open one activated host (codex)", with_clients)
         self.assertIn("chaos-engine", with_clients)
         self.assertIn("sample task", with_clients)
         generic = BOOTSTRAP.format_first_session_brief(clients={})
         self.assertIn("Open any supported host", generic)
-        # Brief must stay concise for first-time users.
-        self.assertLessEqual(len(with_clients.splitlines()), 12)
+        self.assertLessEqual(len(with_clients.splitlines()), 8)
+        landed = "\n".join(BOOTSTRAP.format_landed_untracked_lines())
+        self.assertIn("Landed:", landed)
+        self.assertIn("Untracked:", landed)
 
     def test_confirmation_callbacks_reach_dependencies_maven_and_activation(self):
         bootstrap = (ROOT / "chaos-engine/bootstrap.py").read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -94,6 +94,36 @@ class InstallerUxTests(unittest.TestCase):
                 reporter.close()
         self.assertFalse(any(thread.name == "chaos-engine-installer" for thread in threading.enumerate()))
 
+    def test_live_and_pipe_announce_use_aligned_project_source(self):
+        class Tty(io.StringIO):
+            def isatty(self):
+                return True
+
+        pipe = io.StringIO()
+        reporter = BOOTSTRAP.InstallReporter(stream=pipe, clock=lambda: 1.0)
+        reporter.announce(Path("/project"), "ShaftHQ/SHAFT_ENGINE", "main")
+        pipe_out = pipe.getvalue()
+        self.assertIn("Project", pipe_out)
+        self.assertIn("Source", pipe_out)
+        self.assertIn("ShaftHQ/SHAFT_ENGINE@main", pipe_out)
+        self.assertNotIn("Install root:", pipe_out)
+        self.assertNotIn("\x1b", pipe_out)
+
+        stream = Tty()
+        environment = {key: value for key, value in os.environ.items() if key != "NO_COLOR"}
+        environment["TERM"] = "xterm"
+        with unittest.mock.patch.dict(os.environ, environment, clear=True), unittest.mock.patch.object(
+            BOOTSTRAP.InstallReporter, "_enable_windows_vt", return_value=True
+        ), unittest.mock.patch.object(BOOTSTRAP.threading.Thread, "start", lambda self: None):
+            tty = BOOTSTRAP.InstallReporter(stream=stream, clock=lambda: 1.0)
+            tty.announce(Path("/project"), "owner/repo", "main")
+            tty.start("Download source")
+            tty.close()
+        live = stream.getvalue()
+        self.assertIn("Project", live)
+        self.assertIn("Status", live)
+        self.assertNotIn("Install root:", live)
+
     def test_ticker_updates_elapsed_each_second_during_blocking_work(self):
         class Tty(io.StringIO):
             def isatty(self):
@@ -691,6 +721,9 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("Detected host CLIs: Claude Code", output)
         self.assertIn("Caveman + Ponytail", output)
         self.assertIn("Maven Tools MCP", output)
+        self.assertIn("Hosts", output)
+        self.assertIn("on PATH", output)
+        self.assertIn("not on PATH", output)
         self.assertIn("Claude Code:", output)
         self.assertIn("Codex:", output)
         self.assertIn("Grok:", output)
@@ -911,6 +944,7 @@ class InstallerUxTests(unittest.TestCase):
                     project=project,
                 )
             err = stderr.getvalue()
+            self.assertIn("Installation failed", err)
             self.assertNotIn(".chaos-engine/install.py", err)
             self.assertIn("Installer CLI is not on disk", err)
             self.assertIn("Rerun the same install command", err)

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -512,10 +512,11 @@ class InstallerUxTests(unittest.TestCase):
                 return True
 
         stream = Tty()
-        with unittest.mock.patch.dict(os.environ, {"TERM": "xterm"}, clear=False), unittest.mock.patch.object(
-            BOOTSTRAP.threading.Thread, "start", lambda self: None
-        ), unittest.mock.patch.dict(os.environ, {"NO_COLOR": ""}, clear=False):
-            os.environ.pop("NO_COLOR", None)
+        environment = {key: value for key, value in os.environ.items() if key != "NO_COLOR"}
+        environment["TERM"] = "xterm"
+        with unittest.mock.patch.dict(os.environ, environment, clear=True), unittest.mock.patch.object(
+            BOOTSTRAP.InstallReporter, "_enable_windows_vt", return_value=True
+        ), unittest.mock.patch.object(BOOTSTRAP.threading.Thread, "start", lambda self: None):
             reporter = BOOTSTRAP.InstallReporter(stream=stream)
             reporter.success(
                 Path("/project"),


### PR DESCRIPTION
## Summary
Polish the unattended ChaosEngine installer finish screen, live checklist, pipe log, first-run wizard, and failure headline so they match SOTA one-liner installers (uv, bun, rustup, starship): short receipt, aligned tables, copy-paste next steps. No TUI libraries. Pipe and `NO_COLOR` durability stay.

Closes #5725

## Changes
- **Finish receipt:** `format_install_report` — headline + duration, aligned Project/Source/Commit, bun-style `To get started`, host table, Guide/Trace/Landed/Untracked. Keep exact `Resolved commit:`, `Doctor:`, `Clients:`.
- **Live panel:** `Status` with `n/m` steps; running uses `ION_BLUE`; aligned Project/Source; dim trace.
- **Pipe log:** same Project/Source labels; START/DONE unchanged.
- **Wizard:** compact receipt + PATH table; confirm prompts unchanged.
- **Failure:** `Installation failed` headline; codes, Next fix, backtick prompt kept.
- **Merge/heal:** advisory only after `close()`; still one backtick prompt.

## Checks
- `python3 -m unittest tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_installer_merge_handoff -q` → 85 tests, OK

## Continuation
Owner authorized PR + merge. Auto-merge armed with merge commits after exact-head green.