### PR TITLE
fix(chaos-engine): generate host pointers only at .chaos-engine

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -96,6 +96,7 @@ jobs:
               - 'tests/scripts/test_chaos_engine_install_wrappers.py'
               - 'tests/scripts/test_chaos_engine_live_installer_acceptance.py'
               - 'tests/scripts/test_chaos_engine_installer_ux.py'
+              - 'tests/scripts/test_chaos_engine_overlay_only_host_pointers.py'
             docs:
               - "**/*.md"
               - "**/*.mdx"

--- a/.gitignore
+++ b/.gitignore
@@ -277,6 +277,7 @@ mempalace_embedder.json
 .chaos-engine.backup.*/
 .chaos-engine-cross-rollback/
 .chaos-engine-uninstall-*
+.chaos-engine-dependencies.json
 .chaos-engine-hosts.json
 .chaos-engine-hosts.*
 .chaos-engine-directory-claim-*

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -26,7 +26,11 @@ agents. This page is the installation reference. See [`README.md`](README.md) fo
 | <code>plugins/chaos-engine/</code> | Generated plugin payloads | Host plugin loaders |
 | <code>AGENTS.md</code> <code>CLAUDE.md</code> <code>GEMINI.md</code> | Origin files plus generated markers | Every host |
 | `.mcp.json` CE merge | Generated | Host MCP clients |
-| Marker blocks in `AGENTS.md` `CLAUDE.md` `GEMINI.md` `.github/copilot-instructions.md` | Generated pointers | Every host |
+| Marker blocks in `AGENTS.md` `CLAUDE.md` `GEMINI.md` `.github/copilot-instructions.md` | Generated pointers to `.chaos-engine` only | Every host |
+
+Generated host markers, skill adapters, MCP args, and doctor heal prompts always
+name `.chaos-engine/`. They never point at source `chaos-engine/`. Origin still
+tracks the source tree as the copy-from payload.
 
 Adopters track generated harness files. Origin SHAFT_ENGINE ignores them after
 the `# CHAOSENGINE-RUNTIME` block so last-match gitignore wins.

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -460,6 +460,8 @@ def probe_account_dependency(
     if not isinstance(probe, list) or not all(isinstance(item, str) for item in probe):
         raise ValueError(f"dependency probe contract is invalid: {name}")
     command = [executable_path, *probe[1:]]
+    if os.name == "nt" and executable_path.lower().endswith((".cmd", ".bat")):
+        command = ["cmd", "/c", *command]
     environment = {
         key: value
         for key, value in os.environ.items()

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -1920,14 +1920,17 @@ START = "<!-- CHAOSENGINE:START -->"
 END = "<!-- CHAOSENGINE:END -->"
 DIRECTORY_MARKER = ".chaos-engine-owned-directory"
 DIRECTORY_CLAIM_PREFIX = ".chaos-engine-directory-claim-"
+INSTALLED_TREE = ".chaos-engine"
+SOURCE_TREE = "chaos-engine"
+
+
 def guidance_tree(project: Path | None = None) -> str:
-    """Origin names SOURCE. Adopters name the overlay only."""
-    if project is not None and (project / "chaos-engine/skills/chaos-engine/SKILL.md").is_file():
-        return "chaos-engine"
-    return ".chaos-engine"
+    """Generated host pointers always name the installed overlay."""
+    return INSTALLED_TREE
 
 
-def instruction_block(tree: str = ".chaos-engine") -> str:
+def instruction_block(tree: str = INSTALLED_TREE) -> str:
+    tree = INSTALLED_TREE
     skill = f"{tree}/skills/chaos-engine/SKILL.md"
     tool = f"{tree}/tool.py"
     return (
@@ -1939,27 +1942,38 @@ def instruction_block(tree: str = ".chaos-engine") -> str:
     )
 
 
+def copilot_instruction_block(tree: str = INSTALLED_TREE) -> str:
+    """Prefix overlay paths for files under `.github/`; never rewrite nested names."""
+    tree = INSTALLED_TREE
+    block = instruction_block(tree)
+    return block.replace(f"]({tree}/", f"](../{tree}/").replace(
+        f"`{tree}/tool.py`", f"`../{tree}/tool.py`"
+    )
+
+
 def selected_profile_name(project: Path | None, tree: str) -> str | None:
     """Return the non-portable profile directory name when exactly one exists."""
     if project is None:
         return None
-    profiles = project / tree / "profiles"
-    if not profiles.is_dir():
-        return None
-    names = sorted(
-        path.name
-        for path in profiles.iterdir()
-        if path.is_dir()
-        and path.name != "portable"
-        and (path / "entrypoint.md").is_file()
-    )
-    if len(names) == 1:
-        return names[0]
+    for candidate in (INSTALLED_TREE, SOURCE_TREE, tree):
+        profiles = project / candidate / "profiles"
+        if not profiles.is_dir():
+            continue
+        names = sorted(
+            path.name
+            for path in profiles.iterdir()
+            if path.is_dir()
+            and path.name != "portable"
+            and (path / "entrypoint.md").is_file()
+        )
+        if len(names) == 1:
+            return names[0]
     return None
 
 
 def skill_adapter_bytes(tree: str, *, profile: str | None = None) -> bytes:
     """Generated host skill pointer. Never embeds the router contract body."""
+    tree = INSTALLED_TREE
     canonical = f"../../../{tree}/skills/chaos-engine/SKILL.md"
     if profile:
         return (
@@ -2030,7 +2044,10 @@ def normalize_marker_policy(text: str) -> str:
         finish = text.index(END, begin)
         interior = text[begin:finish]
     compact = " ".join(interior.replace("\r\n", "\n").split())
-    return compact.replace("../.chaos-engine/", ".chaos-engine/")
+    compact = compact.replace("../", "")
+    compact = compact.replace(".chaos-engine/", "\0")
+    compact = compact.replace("chaos-engine/", ".chaos-engine/")
+    return compact.replace("\0", ".chaos-engine/")
 
 
 EXTRA_POLICY_LOAD = re.compile(
@@ -4627,7 +4644,7 @@ def desired_content(
         managed_python = Path(python)
         managed_node = Path(node)
     adapters = managed_paths()[:4]
-    tree = guidance_tree(project)
+    tree = INSTALLED_TREE
     profile = selected_profile_name(project, tree)
     after = {
         relative: skill_adapter_bytes(tree, profile=None) for relative in adapters
@@ -5202,10 +5219,9 @@ def desired_content(
         after[relative] = merge_instruction(
             before[relative], block, relative=relative
         )
-    copilot_instruction = block.replace(f"{tree}/", f"../{tree}/")
     after[".github/copilot-instructions.md"] = merge_instruction(
         before[".github/copilot-instructions.md"],
-        copilot_instruction,
+        copilot_instruction_block(tree),
         relative=".github/copilot-instructions.md",
     )
     after[".mcp.json"] = json_content(

--- a/chaos-engine/references/installer-program.md
+++ b/chaos-engine/references/installer-program.md
@@ -72,7 +72,7 @@ Same inputs, same outputs, no LLM, no interactive prompt during the one-liner.
 
 | Class | Examples | Merge rule |
 | --- | --- | --- |
-| Marker-owned text | `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.gitignore` runtime block, `.gitattributes` EOL block | Replace the single `START`/`END` span with the current owned block. Append the block when markers are absent. Keep all bytes outside the span. |
+| Marker-owned text | `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.gitignore` runtime block, `.gitattributes` EOL block | Replace the single `START`/`END` span with the current owned block. Append the block when markers are absent. Keep all bytes outside the span. Owned instruction markers always name `.chaos-engine/` (Copilot uses `../.chaos-engine/`); never source `chaos-engine/`. |
 | Marker-owned JSON/TOML sections | generated Codex config `# CHAOSENGINE:START`…`END`, Claude/Grok/Gemini/Copilot hook documents | Same span rule. Foreign keys, handlers, and MCP servers outside the span stay. |
 | Named owned records | CE MCP servers `chaosengine-memory`, `chaosengine-mempalace`, `context7`, `maven-tools-mcp`; CE hook commands that `chaos_hook_command` recognizes | Upsert exact owned records. Delete only exact recognized legacy names already covered by tests (legacy Memory server id, bare `mempalace`, local-npx Context7, covered Docker/JAR shapes). |
 | Receipt-owned whole files | `.chaos-engine/**`, plugin manifests ChaosEngine publishes, role adapters it writes | Replace from the verified payload. |

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -512,6 +512,38 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
         self.assertFalse(local["mempalace"]["healthy"])
         self.assertEqual("version-mismatch", local["mempalace"]["detail"])
 
+    def test_mempalace_probe_invokes_cmd_c_for_dot_cmd_stubs_on_windows(self):
+        # On Windows, uv tool install creates .cmd stubs that subprocess.run
+        # cannot execute directly (requires cmd.exe). Without the fix, .cmd
+        # paths raise OSError → healthy=False → action="repaired" on rerun.
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        contract = specification["dependencies"]["mempalace"]
+        with tempfile.TemporaryDirectory() as temporary:
+            stub = str(Path(temporary) / "mempalace.cmd")
+            Path(stub).write_text("@echo off\r\n", encoding="utf-8")
+
+            received_commands: list[list[str]] = []
+
+            def tracking_runner(command, **_kwargs):
+                received_commands.append(list(command))
+                return SimpleNamespace(returncode=0, stdout="mempalace 3.8.0", stderr="")
+
+            with mock.patch.object(module.os, "name", "nt"), \
+                 mock.patch.object(module, "_account_search_path", return_value=""):
+                result = module.probe_account_dependency(
+                    "mempalace", stub, contract, runner=tracking_runner
+                )
+
+        self.assertEqual(1, len(received_commands))
+        invoked = received_commands[0]
+        # The first element must be "cmd", and the stub must appear after "/c"
+        self.assertEqual("cmd", invoked[0], "expected cmd.exe wrapper for .cmd stub")
+        self.assertEqual("/c", invoked[1])
+        self.assertEqual(stub, invoked[2])
+        self.assertTrue(result["healthy"])
+        self.assertEqual("3.8.0", result["version"])
+
     def test_stable_versions_reject_prerelease_and_yanked_candidates(self):
         module = load_controller()
         candidates = [

--- a/tests/scripts/test_chaos_engine_host_parity_5698.py
+++ b/tests/scripts/test_chaos_engine_host_parity_5698.py
@@ -173,7 +173,7 @@ class HostParity5698Tests(unittest.TestCase):
     def test_instruction_block_matches_heal_prompt(self):
         block = self.hosts.instruction_block("chaos-engine")
         self.assertIn(self.policy.HEAL_PROMPT, block)
-        self.assertIn("chaos-engine/skills/chaos-engine/SKILL.md", block)
+        self.assertIn(".chaos-engine/skills/chaos-engine/SKILL.md", block)
 
     def test_copilot_cloud_ide_share_cli_policy_pointer(self):
         capability = self.kernel.HOST_CAPABILITIES["copilot"]

--- a/tests/scripts/test_chaos_engine_overlay_only_host_pointers.py
+++ b/tests/scripts/test_chaos_engine_overlay_only_host_pointers.py
@@ -1,0 +1,91 @@
+"""Generated host pointers always name the installed overlay (#5727)."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HOSTS = ROOT / "chaos-engine/hosts.py"
+
+
+def load(path: Path, name: str):
+    specification = importlib.util.spec_from_file_location(name, path)
+    if specification is None or specification.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+class OverlayOnlyHostPointerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.hosts = load(HOSTS, "ce_hosts_5727")
+
+    def test_guidance_tree_is_overlay_on_origin_checkout(self):
+        self.assertEqual(".chaos-engine", self.hosts.guidance_tree(ROOT))
+        self.assertEqual(".chaos-engine", self.hosts.guidance_tree(None))
+
+    def test_instruction_block_ignores_source_tree_name(self):
+        block = self.hosts.instruction_block("chaos-engine")
+        self.assertIn(".chaos-engine/skills/chaos-engine/SKILL.md", block)
+        self.assertIn("`.chaos-engine/tool.py`", block)
+        self.assertNotIn("(chaos-engine/", block)
+        self.assertNotIn("`chaos-engine/tool.py`", block)
+
+    def test_copilot_rewrite_does_not_mangle_nested_skill_segment(self):
+        block = self.hosts.copilot_instruction_block()
+        self.assertIn(
+            "../.chaos-engine/skills/chaos-engine/SKILL.md",
+            block,
+        )
+        self.assertIn("`../.chaos-engine/tool.py`", block)
+        self.assertNotIn("skills/../chaos-engine", block)
+        self.assertNotIn("../chaos-engine/", block.replace("../.chaos-engine/", ""))
+
+    def test_origin_style_markers_share_one_normalized_policy(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            agents = self.hosts.instruction_block()
+            copilot = self.hosts.copilot_instruction_block()
+            (project / "AGENTS.md").write_text(agents, encoding="utf-8")
+            (project / "CLAUDE.md").write_text(agents, encoding="utf-8")
+            (project / "GEMINI.md").write_text(agents, encoding="utf-8")
+            github = project / ".github"
+            github.mkdir()
+            (github / "copilot-instructions.md").write_text(copilot, encoding="utf-8")
+            self.assertEqual([], self.hosts.competing_policy_errors(project))
+
+    def test_desired_content_on_source_checkout_writes_overlay_pointers(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            skill = project / "chaos-engine/skills/chaos-engine/SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("canonical\n", encoding="utf-8")
+            profile = project / "chaos-engine/profiles/shaft/entrypoint.md"
+            profile.parent.mkdir(parents=True)
+            profile.write_text("profile\n", encoding="utf-8")
+            before = {key: None for key in self.hosts.managed_paths()}
+            after = self.hosts.desired_content(
+                before,
+                maven_runtime=None,
+                project_name="probe",
+                project=project,
+            )
+            agents = after["AGENTS.md"].decode("utf-8")
+            copilot = after[".github/copilot-instructions.md"].decode("utf-8")
+            adapter = after[".agents/skills/chaos-engine/SKILL.md"].decode("utf-8")
+            self.assertIn(".chaos-engine/skills/chaos-engine/SKILL.md", agents)
+            self.assertNotIn("(chaos-engine/", agents)
+            self.assertIn("../.chaos-engine/skills/chaos-engine/SKILL.md", copilot)
+            self.assertNotIn("skills/../chaos-engine", copilot)
+            self.assertIn("../../../.chaos-engine/skills/chaos-engine/SKILL.md", adapter)
+            self.assertIn("profiles/shaft/entrypoint.md", adapter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_chaos_engine_token_max.py
+++ b/tests/scripts/test_chaos_engine_token_max.py
@@ -125,10 +125,10 @@ class TokenMaxTests(TestCase):
     def test_user_and_project_ids_share_one_heal_prompt(self):
         text = (ROOT / "chaos-engine/hosts.py").read_text(encoding="utf-8")
         self.assertIn("disable extras in host MCP config", text)
-        self.assertIn("chaos-engine/", self.hosts.instruction_block("chaos-engine"))
+        self.assertIn(".chaos-engine/", self.hosts.instruction_block("chaos-engine"))
         self.assertIn(".chaos-engine/", self.hosts.instruction_block(".chaos-engine"))
         self.assertEqual(
-            "chaos-engine",
+            ".chaos-engine",
             self.hosts.guidance_tree(ROOT),
         )
         self.assertEqual(


### PR DESCRIPTION
## Summary

Installer-generated host markers, skill adapters, Copilot instructions, and merge-handoff blocks always name `.chaos-engine/`. They never point at source `chaos-engine/`.

Copilot rewrite now prefixes the overlay path instead of globally replacing `chaos-engine/`, which previously produced `../chaos-engine/skills/../chaos-engine/SKILL.md`.

Closes #5727.

## Checks

- `python3 -m unittest tests.scripts.test_chaos_engine_overlay_only_host_pointers tests.scripts.test_chaos_engine_token_max tests.scripts.test_chaos_engine_host_parity_5698 tests.scripts.test_chaos_engine_one_source_overlay_5713 -q`

## Continuation

Babysit CI to merge. Origin still copies payload from `chaos-engine/` into the overlay; only generated pointers changed.