### PR TITLE
feat(element): Wave B click/type strategies (#5732)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -9,6 +9,10 @@ import com.shaft.enums.internal.Screenshots;
 import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.element.ElementActions;
 import com.shaft.gui.element.TouchActions;
+import com.shaft.gui.element.internal.interaction.ClickStrategies;
+import com.shaft.gui.element.internal.interaction.ElementClassifier;
+import com.shaft.gui.element.internal.interaction.ElementKind;
+import com.shaft.gui.element.internal.interaction.TypeStrategies;
 import com.shaft.gui.internal.exceptions.MultipleElementsFoundException;
 import com.shaft.gui.internal.healing.HealingManager;
 import com.shaft.gui.internal.healing.HealingResolution;
@@ -664,20 +668,13 @@ public class Actions extends ElementActions {
                         WebElement targetElement = isMobileNativeExecution
                                 ? chooseBestEffortDisplayedElement(foundElements.get())
                                 : foundElements.get().getFirst();
-                        try {
-                            screenshot.set(0, takeActionScreenshot(targetElement));
-                            targetElement.click();
-                        } catch (InvalidElementStateException exception) {
-                            if (SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails()) {
-                                ((JavascriptExecutor) d).executeScript("arguments[0].click();", targetElement);
-                                ReportManager.logDiscrete("Performed Click using JavaScript; If the report is showing that the click passed but you observe that no action was taken, we recommend trying a different element locator.");
-                            } else {
-                                // These exceptions are normally retryable for visibility-aware waits;
-                                // when JavaScript fallback is disabled, report the native click failure immediately
-                                // so the original Selenium exception is not replaced by a FluentWait timeout.
-                                throw exception;
-                            }
-                        }
+                        screenshot.set(0, takeActionScreenshot(targetElement));
+                        // Wave B (#5732): native → scroll/stabilize retry → flagged JS; preserve exception when JS off.
+                        ClickStrategies.click(
+                                d,
+                                targetElement,
+                                ElementClassifier.classify(targetElement),
+                                SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails());
                     }
                     case JAVASCRIPT_CLICK -> {
                         screenshot.set(0, takeActionScreenshot(foundElements.get().getFirst()));
@@ -723,18 +720,36 @@ public class Actions extends ElementActions {
                     case TYPE, TYPE_SECURELY -> {
                         WebElement targetElement = foundElements.get().getFirst();
                         CharSequence[] text = (CharSequence[]) data;
-                        String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
-                        String typedText = stringifyTypedValue(text);
-                        boolean shouldValidateTypedText = shouldValidateTypedText(text);
-                        String expectedText = shouldValidateTypedText && "off".equals(clearMode)
-                                ? readElementValueForTyping(targetElement) + typedText
-                                : typedText;
-                        if (SHAFT.Properties.flags.attemptToClickBeforeTyping() && !"native".equals(clearMode)) {
-                            targetElement.click();
+                        ElementKind kind = ElementClassifier.classify(targetElement);
+                        TypeStrategies.TypeRoute typeRoute = TypeStrategies.routeFor(kind);
+                        if (typeRoute == TypeStrategies.TypeRoute.REJECT) {
+                            TypeStrategies.rejectUnsupported(kind);
+                        } else if (typeRoute == TypeStrategies.TypeRoute.TOGGLE_CLICK) {
+                            TypeStrategies.toggleInsteadOfTyping(targetElement, kind);
+                        } else if (typeRoute == TypeStrategies.TypeRoute.SELECT_OPTION) {
+                            selectValue(targetElement, locator, stringifyTypedValue(text));
+                        } else if (typeRoute == TypeStrategies.TypeRoute.SET_FILES) {
+                            typeFileLocationForUpload(targetElement, locator, stringifyTypedValue(text));
+                        } else if (typeRoute == TypeStrategies.TypeRoute.SET_VALUE_WITH_EVENTS) {
+                            TypeStrategies.setValueWithEvents(d, targetElement, stringifyTypedValue(text));
+                        } else if (typeRoute == TypeStrategies.TypeRoute.CONTENTEDITABLE) {
+                            boolean clearBefore = !"off".equals(SHAFT.Properties.flags.clearBeforeTypingMode());
+                            TypeStrategies.typeContentEditable(d, targetElement, text, clearBefore);
+                        } else {
+                            // TEXT_LIKE / COMBOBOX / UNKNOWN — legacy clear+sendKeys honors existing flags.
+                            String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
+                            String typedText = stringifyTypedValue(text);
+                            boolean shouldValidateTypedText = shouldValidateTypedText(text);
+                            String expectedText = shouldValidateTypedText && "off".equals(clearMode)
+                                    ? readElementValueForTyping(targetElement) + typedText
+                                    : typedText;
+                            if (SHAFT.Properties.flags.attemptToClickBeforeTyping() && !"native".equals(clearMode)) {
+                                targetElement.click();
+                            }
+                            executeClearBasedOnClearMode(targetElement, clearMode);
+                            targetElement.sendKeys(text);
+                            validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
                         }
-                        executeClearBasedOnClearMode(targetElement, clearMode);
-                        targetElement.sendKeys(text);
-                        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
                     }
                     case TYPE_APPEND -> {
                         WebElement targetElement = foundElements.get().getFirst();

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
@@ -1,0 +1,54 @@
+package com.shaft.gui.element.internal.interaction;
+
+import com.shaft.tools.io.ReportManager;
+import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Selenium click ladder: native click → optional scroll/stabilize retry → flagged JS fallback.
+ * When JS fallback is off, the native {@link InvalidElementStateException} is preserved.
+ */
+public final class ClickStrategies {
+
+    private static final String JS_CLICK = "arguments[0].click();";
+    private static final String JS_SCROLL_CENTER = """
+            arguments[0].scrollIntoView({behavior: "auto", block: "center", inline: "center"});""";
+
+    private ClickStrategies() {
+    }
+
+    public static void click(WebDriver driver, WebElement element, ElementKind kind, boolean javascriptFallbackEnabled) {
+        if (kind == ElementKind.DISABLED) {
+            throw new InvalidElementStateException(
+                    "Refusing to click a disabled/readonly/aria-disabled element.");
+        }
+        try {
+            element.click();
+        } catch (InvalidElementStateException firstFailure) {
+            stabilize(driver, element);
+            try {
+                element.click();
+            } catch (InvalidElementStateException retryFailure) {
+                if (javascriptFallbackEnabled && driver instanceof JavascriptExecutor executor) {
+                    executor.executeScript(JS_CLICK, element);
+                    ReportManager.logDiscrete(
+                            "Performed Click using JavaScript; If the report is showing that the click passed but you observe that no action was taken, we recommend trying a different element locator.");
+                } else {
+                    throw retryFailure;
+                }
+            }
+        }
+    }
+
+    private static void stabilize(WebDriver driver, WebElement element) {
+        if (driver instanceof JavascriptExecutor executor) {
+            try {
+                executor.executeScript(JS_SCROLL_CENTER, element);
+            } catch (RuntimeException ignored) {
+                // Best-effort scroll before retry; native exception still drives fallback/fail.
+            }
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -45,6 +45,23 @@ public final class ElementClassifier {
             return ElementKind.CONTENTEDITABLE;
         }
 
+        ElementKind byTag = classifyByTag(tag, role);
+        if (byTag != null) {
+            return byTag;
+        }
+
+        if ("input".equals(tag)) {
+            return classifyInput(type, role);
+        }
+
+        return classifyByRole(role);
+    }
+
+    /**
+     * Tag-driven kinds (and tag/role pairs that are decided before input handling).
+     * Returns null when the tag does not decide the kind.
+     */
+    private static ElementKind classifyByTag(String tag, String role) {
         if ("select".equals(tag)) {
             return ElementKind.SELECT;
         }
@@ -60,36 +77,39 @@ public final class ElementClassifier {
         if ("button".equals(tag) || "button".equals(role)) {
             return ElementKind.BUTTON;
         }
+        return null;
+    }
 
-        if ("input".equals(tag)) {
-            if ("checkbox".equals(type) || "checkbox".equals(role)) {
-                return ElementKind.CHECKBOX;
-            }
-            if ("radio".equals(type) || "radio".equals(role)) {
-                return ElementKind.RADIO;
-            }
-            if ("file".equals(type)) {
-                return ElementKind.FILE;
-            }
-            if (DATE_INPUT_TYPES.contains(type)) {
-                return ElementKind.DATE_LIKE;
-            }
-            if ("range".equals(type) || "slider".equals(role)) {
-                return ElementKind.RANGE;
-            }
-            if ("color".equals(type)) {
-                return ElementKind.COLOR;
-            }
-            if (BUTTON_INPUT_TYPES.contains(type)) {
-                return ElementKind.BUTTON;
-            }
-            if (TEXT_INPUT_TYPES.contains(type) || type == null) {
-                return ElementKind.TEXT_LIKE;
-            }
-            // Unknown input type (e.g. custom) — do not guess.
-            return ElementKind.UNKNOWN;
+    private static ElementKind classifyInput(String type, String role) {
+        if ("checkbox".equals(type) || "checkbox".equals(role)) {
+            return ElementKind.CHECKBOX;
         }
+        if ("radio".equals(type) || "radio".equals(role)) {
+            return ElementKind.RADIO;
+        }
+        if ("file".equals(type)) {
+            return ElementKind.FILE;
+        }
+        if (DATE_INPUT_TYPES.contains(type)) {
+            return ElementKind.DATE_LIKE;
+        }
+        if ("range".equals(type) || "slider".equals(role)) {
+            return ElementKind.RANGE;
+        }
+        if ("color".equals(type)) {
+            return ElementKind.COLOR;
+        }
+        if (BUTTON_INPUT_TYPES.contains(type)) {
+            return ElementKind.BUTTON;
+        }
+        if (TEXT_INPUT_TYPES.contains(type) || type == null) {
+            return ElementKind.TEXT_LIKE;
+        }
+        // Unknown input type (e.g. custom) — do not guess.
+        return ElementKind.UNKNOWN;
+    }
 
+    private static ElementKind classifyByRole(String role) {
         if ("checkbox".equals(role) || "switch".equals(role)) {
             return ElementKind.CHECKBOX;
         }
@@ -105,7 +125,6 @@ public final class ElementClassifier {
         if (role != null && TEXT_ROLES.contains(role)) {
             return ElementKind.TEXT_LIKE;
         }
-
         return ElementKind.UNKNOWN;
     }
 
@@ -119,11 +138,9 @@ public final class ElementClassifier {
 
     private static boolean isContentEditable(WebElement element) {
         String raw = safeDom(element, "contenteditable");
-        if (raw != null) {
-            // HTML allows "", "true", and "plaintext-only"; "false" is not editable.
-            if (!"false".equalsIgnoreCase(raw.trim())) {
-                return true;
-            }
+        // HTML allows "", "true", and "plaintext-only"; "false" is not editable.
+        if (raw != null && !"false".equalsIgnoreCase(raw.trim())) {
+            return true;
         }
         return "true".equalsIgnoreCase(safeProperty(element, "isContentEditable"));
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -28,15 +28,20 @@ public final class ElementClassifier {
             return ElementKind.UNKNOWN;
         }
 
-        if (isDisabledOrReadonly(element)) {
+        if (isDisabled(element)) {
             return ElementKind.DISABLED;
+        }
+        // Readonly is classified before contenteditable/input kinds so type() can refuse
+        // while click() still focuses (HTML readonly controls remain clickable).
+        if (isTruthyFlag(element, "readonly")) {
+            return ElementKind.READONLY;
         }
 
         String tag = safeLower(safeTagName(element));
         String type = safeLower(firstNonBlank(safeDom(element, "type"), safeProperty(element, "type")));
         String role = safeLower(safeDom(element, "role"));
 
-        if (isTruthyFlag(element, "contenteditable") || "true".equalsIgnoreCase(safeProperty(element, "isContentEditable"))) {
+        if (isContentEditable(element)) {
             return ElementKind.CONTENTEDITABLE;
         }
 
@@ -104,12 +109,23 @@ public final class ElementClassifier {
         return ElementKind.UNKNOWN;
     }
 
-    private static boolean isDisabledOrReadonly(WebElement element) {
-        if (isTruthyFlag(element, "disabled") || isTruthyFlag(element, "readonly")) {
+    private static boolean isDisabled(WebElement element) {
+        if (isTruthyFlag(element, "disabled")) {
             return true;
         }
         String ariaDisabled = safeLower(safeDom(element, "aria-disabled"));
         return "true".equals(ariaDisabled);
+    }
+
+    private static boolean isContentEditable(WebElement element) {
+        String raw = safeDom(element, "contenteditable");
+        if (raw != null) {
+            // HTML allows "", "true", and "plaintext-only"; "false" is not editable.
+            if (!"false".equalsIgnoreCase(raw.trim())) {
+                return true;
+            }
+        }
+        return "true".equalsIgnoreCase(safeProperty(element, "isContentEditable"));
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -1,0 +1,173 @@
+package com.shaft.gui.element.internal.interaction;
+
+import org.openqa.selenium.WebElement;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Cheap Selenium-path classifier: tagName, type, role/ARIA, contenteditable, disabled flags.
+ * Conservative by design — ambiguous custom widgets return {@link ElementKind#UNKNOWN}.
+ */
+public final class ElementClassifier {
+
+    private static final Set<String> TEXT_INPUT_TYPES = Set.of(
+            "text", "password", "email", "search", "tel", "url", "number", "");
+    private static final Set<String> DATE_INPUT_TYPES = Set.of(
+            "date", "time", "month", "week", "datetime-local");
+    private static final Set<String> BUTTON_INPUT_TYPES = Set.of(
+            "button", "submit", "reset", "image");
+    private static final Set<String> TEXT_ROLES = Set.of(
+            "textbox", "searchbox", "spinbutton");
+
+    private ElementClassifier() {
+    }
+
+    public static ElementKind classify(WebElement element) {
+        if (element == null) {
+            return ElementKind.UNKNOWN;
+        }
+
+        if (isDisabledOrReadonly(element)) {
+            return ElementKind.DISABLED;
+        }
+
+        String tag = safeLower(safeTagName(element));
+        String type = safeLower(firstNonBlank(safeDom(element, "type"), safeProperty(element, "type")));
+        String role = safeLower(safeDom(element, "role"));
+
+        if (isTruthyFlag(element, "contenteditable") || "true".equalsIgnoreCase(safeProperty(element, "isContentEditable"))) {
+            return ElementKind.CONTENTEDITABLE;
+        }
+
+        if ("select".equals(tag)) {
+            return ElementKind.SELECT;
+        }
+        if ("textarea".equals(tag)) {
+            return ElementKind.TEXT_LIKE;
+        }
+        if ("iframe".equals(tag) || "frame".equals(tag)) {
+            return ElementKind.IFRAME;
+        }
+        if ("a".equals(tag) || "link".equals(role)) {
+            return ElementKind.LINK;
+        }
+        if ("button".equals(tag) || "button".equals(role)) {
+            return ElementKind.BUTTON;
+        }
+
+        if ("input".equals(tag)) {
+            if ("checkbox".equals(type) || "checkbox".equals(role)) {
+                return ElementKind.CHECKBOX;
+            }
+            if ("radio".equals(type) || "radio".equals(role)) {
+                return ElementKind.RADIO;
+            }
+            if ("file".equals(type)) {
+                return ElementKind.FILE;
+            }
+            if (DATE_INPUT_TYPES.contains(type)) {
+                return ElementKind.DATE_LIKE;
+            }
+            if ("range".equals(type) || "slider".equals(role)) {
+                return ElementKind.RANGE;
+            }
+            if ("color".equals(type)) {
+                return ElementKind.COLOR;
+            }
+            if (BUTTON_INPUT_TYPES.contains(type)) {
+                return ElementKind.BUTTON;
+            }
+            if (TEXT_INPUT_TYPES.contains(type) || type == null) {
+                return ElementKind.TEXT_LIKE;
+            }
+            // Unknown input type (e.g. custom) — do not guess.
+            return ElementKind.UNKNOWN;
+        }
+
+        if ("checkbox".equals(role) || "switch".equals(role)) {
+            return ElementKind.CHECKBOX;
+        }
+        if ("radio".equals(role)) {
+            return ElementKind.RADIO;
+        }
+        if ("slider".equals(role)) {
+            return ElementKind.RANGE;
+        }
+        if ("combobox".equals(role) || "listbox".equals(role)) {
+            return ElementKind.COMBOBOX;
+        }
+        if (role != null && TEXT_ROLES.contains(role)) {
+            return ElementKind.TEXT_LIKE;
+        }
+
+        return ElementKind.UNKNOWN;
+    }
+
+    private static boolean isDisabledOrReadonly(WebElement element) {
+        if (isTruthyFlag(element, "disabled") || isTruthyFlag(element, "readonly")) {
+            return true;
+        }
+        String ariaDisabled = safeLower(safeDom(element, "aria-disabled"));
+        return "true".equals(ariaDisabled);
+    }
+
+    /**
+     * HTML boolean attributes are present as "" or the attribute name; ARIA uses "true"/"false".
+     * Reject arbitrary non-empty strings so mocked defaults cannot false-positive.
+     */
+    static boolean isTruthyFlag(WebElement element, String attributeName) {
+        String value = safeDom(element, attributeName);
+        if (value == null) {
+            return false;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        String lower = trimmed.toLowerCase(Locale.ROOT);
+        return "true".equals(lower) || attributeName.equalsIgnoreCase(trimmed);
+    }
+
+    private static String safeTagName(WebElement element) {
+        try {
+            return element.getTagName();
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static String safeDom(WebElement element, String name) {
+        try {
+            return element.getDomAttribute(name);
+        } catch (RuntimeException ignored) {
+            try {
+                return element.getAttribute(name);
+            } catch (RuntimeException ignoredAgain) {
+                return null;
+            }
+        }
+    }
+
+    private static String safeProperty(WebElement element, String name) {
+        try {
+            return element.getDomProperty(name);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static String safeLower(String value) {
+        return value == null ? null : value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        if (second != null && !second.isBlank()) {
+            return second;
+        }
+        return first != null ? first : second;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -160,12 +160,29 @@ public final class ElementClassifier {
     }
 
     private static boolean isContentEditable(WebElement element) {
-        String raw = safeDom(element, "contenteditable");
-        // HTML allows "", "true", and "plaintext-only"; "false" is not editable.
-        if (raw != null && !"false".equalsIgnoreCase(raw.trim())) {
+        if (isContentEditableAttributeValue(safeDom(element, "contenteditable"))) {
             return true;
         }
+        // Property path: only the boolean true string — mock junk like "dom-isContentEditable" must not match.
         return "true".equalsIgnoreCase(safeProperty(element, "isContentEditable"));
+    }
+
+    /**
+     * HTML contenteditable is on for "", "true", "plaintext-only", or the attribute name itself.
+     * Reject arbitrary non-empty strings so mocked getDomAttribute defaults cannot false-positive.
+     */
+    static boolean isContentEditableAttributeValue(String raw) {
+        if (raw == null) {
+            return false;
+        }
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        String lower = trimmed.toLowerCase(Locale.ROOT);
+        return "true".equals(lower)
+                || "plaintext-only".equals(lower)
+                || "contenteditable".equals(lower);
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -81,12 +81,30 @@ public final class ElementClassifier {
     }
 
     private static ElementKind classifyInput(String type, String role) {
+        ElementKind toggle = classifyToggleInput(type, role);
+        if (toggle != null) {
+            return toggle;
+        }
+        ElementKind special = classifySpecialInput(type, role);
+        if (special != null) {
+            return special;
+        }
+        return classifyButtonOrTextInput(type);
+    }
+
+    /** Checkbox / radio input type or role. Returns null when not a toggle. */
+    private static ElementKind classifyToggleInput(String type, String role) {
         if ("checkbox".equals(type) || "checkbox".equals(role)) {
             return ElementKind.CHECKBOX;
         }
         if ("radio".equals(type) || "radio".equals(role)) {
             return ElementKind.RADIO;
         }
+        return null;
+    }
+
+    /** File / date / range / color. Returns null when not a special input. */
+    private static ElementKind classifySpecialInput(String type, String role) {
         if ("file".equals(type)) {
             return ElementKind.FILE;
         }
@@ -99,10 +117,15 @@ public final class ElementClassifier {
         if ("color".equals(type)) {
             return ElementKind.COLOR;
         }
+        return null;
+    }
+
+    /** Button-like or text-like input types; unknown types stay UNKNOWN. */
+    private static ElementKind classifyButtonOrTextInput(String type) {
         if (BUTTON_INPUT_TYPES.contains(type)) {
             return ElementKind.BUTTON;
         }
-        if (TEXT_INPUT_TYPES.contains(type) || type == null) {
+        if (type == null || TEXT_INPUT_TYPES.contains(type)) {
             return ElementKind.TEXT_LIKE;
         }
         // Unknown input type (e.g. custom) — do not guess.

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementKind.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementKind.java
@@ -18,6 +18,9 @@ public enum ElementKind {
     CONTENTEDITABLE,
     COMBOBOX,
     IFRAME,
+    /** Disabled or aria-disabled — refuse click and type. */
     DISABLED,
+    /** Readonly — click allowed (focus); type refused. */
+    READONLY,
     UNKNOWN
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementKind.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementKind.java
@@ -1,0 +1,23 @@
+package com.shaft.gui.element.internal.interaction;
+
+/**
+ * Conservative element kinds for Selenium click/type strategy selection (epic #5732 Wave B).
+ * Unknown or ambiguous nodes stay {@link #UNKNOWN} and keep the legacy Actions path.
+ */
+public enum ElementKind {
+    TEXT_LIKE,
+    CHECKBOX,
+    RADIO,
+    SELECT,
+    FILE,
+    DATE_LIKE,
+    RANGE,
+    COLOR,
+    BUTTON,
+    LINK,
+    CONTENTEDITABLE,
+    COMBOBOX,
+    IFRAME,
+    DISABLED,
+    UNKNOWN
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -1,0 +1,125 @@
+package com.shaft.gui.element.internal.interaction;
+
+import com.shaft.tools.io.ReportManager;
+import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Routes {@code type} by {@link ElementKind} so checkbox/radio/select/file/date/contenteditable
+ * never take the blind clear+sendKeys path. Unknown kinds stay on the legacy caller path.
+ */
+public final class TypeStrategies {
+
+    private static final String JS_SET_VALUE_WITH_EVENTS = """
+            arguments[0].value = arguments[1];
+            arguments[0].dispatchEvent(new Event('input', {bubbles: true}));
+            arguments[0].dispatchEvent(new Event('change', {bubbles: true}));
+            """;
+
+    /**
+     * Contenteditable clear+insert via execCommand when available; falls back to select-all + keys.
+     * Avoids {@link WebElement#clear()} which targets value-backed controls and can wipe the wrong node.
+     */
+    private static final String JS_CONTENTEDITABLE_SET_TEXT = """
+            var el = arguments[0];
+            var text = arguments[1];
+            el.focus();
+            try {
+              document.execCommand('selectAll', false, null);
+              document.execCommand('insertText', false, text);
+            } catch (e) {
+              el.textContent = text;
+              el.dispatchEvent(new Event('input', {bubbles: true}));
+            }
+            """;
+
+    public enum TypeRoute {
+        LEGACY_SEND_KEYS,
+        TOGGLE_CLICK,
+        SELECT_OPTION,
+        SET_FILES,
+        SET_VALUE_WITH_EVENTS,
+        CONTENTEDITABLE,
+        REJECT
+    }
+
+    private TypeStrategies() {
+    }
+
+    public static TypeRoute routeFor(ElementKind kind) {
+        return switch (kind) {
+            case CHECKBOX, RADIO -> TypeRoute.TOGGLE_CLICK;
+            case SELECT -> TypeRoute.SELECT_OPTION;
+            case FILE -> TypeRoute.SET_FILES;
+            case DATE_LIKE, RANGE, COLOR -> TypeRoute.SET_VALUE_WITH_EVENTS;
+            case CONTENTEDITABLE -> TypeRoute.CONTENTEDITABLE;
+            case DISABLED, IFRAME, BUTTON, LINK -> TypeRoute.REJECT;
+            case TEXT_LIKE, COMBOBOX, UNKNOWN -> TypeRoute.LEGACY_SEND_KEYS;
+        };
+    }
+
+    public static void rejectUnsupported(ElementKind kind) {
+        throw new InvalidElementStateException(
+                "type() is not supported for element kind " + kind
+                        + "; use click/select/upload APIs as appropriate.");
+    }
+
+    public static void toggleInsteadOfTyping(WebElement element, ElementKind kind) {
+        ReportManager.logDiscrete("type() on " + kind + " redirected to click (toggle); sendKeys skipped.");
+        element.click();
+    }
+
+    public static void setValueWithEvents(WebDriver driver, WebElement element, String text) {
+        if (!(driver instanceof JavascriptExecutor executor)) {
+            throw new InvalidElementStateException(
+                    "Cannot set value with events: driver does not execute JavaScript.");
+        }
+        executor.executeScript(JS_SET_VALUE_WITH_EVENTS, element, text == null ? "" : text);
+    }
+
+    /**
+     * Focus then insert text without {@link WebElement#clear()}. When {@code clearBefore} is true,
+     * replaces existing content via documented JS insert; otherwise appends with sendKeys.
+     */
+    public static void typeContentEditable(WebDriver driver, WebElement element, CharSequence[] text,
+                                           boolean clearBefore) {
+        String typed = stringify(text);
+        if (clearBefore && driver instanceof JavascriptExecutor executor) {
+            executor.executeScript(JS_CONTENTEDITABLE_SET_TEXT, element, typed);
+            return;
+        }
+        try {
+            element.click();
+        } catch (RuntimeException ignored) {
+            // Focus best-effort; keys may still land on the active editable.
+        }
+        if (clearBefore) {
+            element.sendKeys(Keys.chord(Keys.CONTROL, "a"));
+            element.sendKeys(Keys.BACK_SPACE);
+        }
+        if (!typed.isEmpty()) {
+            // Sequential keys (not clear()+value): preserves key handlers / editor contracts.
+            for (int i = 0; i < typed.length(); i++) {
+                element.sendKeys(String.valueOf(typed.charAt(i)));
+            }
+        }
+    }
+
+    public static void sendKeysFilePath(WebElement element, String absoluteFilePath) {
+        element.sendKeys(absoluteFilePath);
+    }
+
+    private static String stringify(CharSequence[] text) {
+        if (text == null) {
+            return "";
+        }
+        StringBuilder value = new StringBuilder();
+        for (CharSequence sequence : text) {
+            value.append(sequence == null ? "" : sequence);
+        }
+        return value.toString();
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -56,8 +56,9 @@ public final class TypeStrategies {
             case FILE -> TypeRoute.SET_FILES;
             case DATE_LIKE, RANGE, COLOR -> TypeRoute.SET_VALUE_WITH_EVENTS;
             case CONTENTEDITABLE -> TypeRoute.CONTENTEDITABLE;
-            case DISABLED, IFRAME, BUTTON, LINK -> TypeRoute.REJECT;
-            case TEXT_LIKE, COMBOBOX, UNKNOWN -> TypeRoute.LEGACY_SEND_KEYS;
+            // Readonly/disabled/iframe: refuse type. Button/link stay legacy (conservative).
+            case DISABLED, READONLY, IFRAME -> TypeRoute.REJECT;
+            case TEXT_LIKE, COMBOBOX, BUTTON, LINK, UNKNOWN -> TypeRoute.LEGACY_SEND_KEYS;
         };
     }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
@@ -60,8 +60,9 @@ public class ElementClassifierTest {
                 {element("iframe", null, null, null), ElementKind.IFRAME},
                 // case 20
                 {disabled("input", "text"), ElementKind.DISABLED},
-                {readonly("input", "text"), ElementKind.DISABLED},
+                {readonly("input", "text"), ElementKind.READONLY},
                 {ariaDisabled("div"), ElementKind.DISABLED},
+                {contentEditablePlaintext("div"), ElementKind.CONTENTEDITABLE},
                 // unknown conservative
                 {element("div", null, null, null), ElementKind.UNKNOWN},
                 {element("custom-widget", null, null, null), ElementKind.UNKNOWN},
@@ -103,6 +104,18 @@ public class ElementClassifierTest {
         Assert.assertEquals(TypeStrategies.routeFor(ElementKind.TEXT_LIKE), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
         Assert.assertEquals(TypeStrategies.routeFor(ElementKind.UNKNOWN), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
         Assert.assertEquals(TypeStrategies.routeFor(ElementKind.COMBOBOX), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.BUTTON), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.LINK), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.READONLY), TypeStrategies.TypeRoute.REJECT);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.DISABLED), TypeStrategies.TypeRoute.REJECT);
+    }
+
+    @Test
+    public void clickAllowsReadonlyButRefusesDisabled() {
+        Assert.assertNotEquals(ElementKind.READONLY, ElementKind.DISABLED);
+        // Readonly must not share DISABLED click refusal — covered by ClickStrategies.DISABLED check.
+        WebElement readonlyInput = readonly("input", "text");
+        Assert.assertEquals(ElementClassifier.classify(readonlyInput), ElementKind.READONLY);
     }
 
     private static WebElement element(String tag, String type, String role, String unused) {
@@ -123,6 +136,12 @@ public class ElementClassifierTest {
     private static WebElement contentEditable(String tag) {
         WebElement element = element(tag, null, null, null);
         when(element.getDomAttribute("contenteditable")).thenReturn("true");
+        return element;
+    }
+
+    private static WebElement contentEditablePlaintext(String tag) {
+        WebElement element = element(tag, null, null, null);
+        when(element.getDomAttribute("contenteditable")).thenReturn("plaintext-only");
         return element;
     }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
@@ -94,6 +94,28 @@ public class ElementClassifierTest {
     }
 
     @Test
+    public void contentEditableRejectsArbitraryMockStrings() {
+        Assert.assertFalse(ElementClassifier.isContentEditableAttributeValue(null));
+        Assert.assertFalse(ElementClassifier.isContentEditableAttributeValue("false"));
+        Assert.assertFalse(ElementClassifier.isContentEditableAttributeValue("dom-contenteditable"));
+        Assert.assertFalse(ElementClassifier.isContentEditableAttributeValue("yes"));
+        Assert.assertTrue(ElementClassifier.isContentEditableAttributeValue(""));
+        Assert.assertTrue(ElementClassifier.isContentEditableAttributeValue("true"));
+        Assert.assertTrue(ElementClassifier.isContentEditableAttributeValue("TRUE"));
+        Assert.assertTrue(ElementClassifier.isContentEditableAttributeValue("plaintext-only"));
+        Assert.assertTrue(ElementClassifier.isContentEditableAttributeValue("contenteditable"));
+
+        WebElement mockedInput = mock(WebElement.class);
+        when(mockedInput.getTagName()).thenReturn("input");
+        when(mockedInput.getDomAttribute(anyString())).thenAnswer(invocation -> "dom-" + invocation.getArgument(0));
+        when(mockedInput.getDomAttribute("type")).thenReturn("text");
+        when(mockedInput.getDomProperty(anyString())).thenAnswer(invocation -> "dom-" + invocation.getArgument(0));
+        when(mockedInput.getAttribute(anyString())).thenAnswer(invocation -> "attr-" + invocation.getArgument(0));
+        // Coverage-style mocks must stay TEXT_LIKE / UNKNOWN, never CONTENTEDITABLE.
+        Assert.assertEquals(ElementClassifier.classify(mockedInput), ElementKind.TEXT_LIKE);
+    }
+
+    @Test
     public void typeRoutesDoNotBlindSendKeysForSpecialKinds() {
         Assert.assertEquals(TypeStrategies.routeFor(ElementKind.CHECKBOX), TypeStrategies.TypeRoute.TOGGLE_CLICK);
         Assert.assertEquals(TypeStrategies.routeFor(ElementKind.RADIO), TypeStrategies.TypeRoute.TOGGLE_CLICK);

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
@@ -15,58 +15,58 @@ public class ElementClassifierTest {
     public Object[][] webKinds() {
         return new Object[][]{
                 // cases 1–2 text-like
-                {element("input", "text", null, null), ElementKind.TEXT_LIKE},
-                {element("input", "password", null, null), ElementKind.TEXT_LIKE},
-                {element("input", "email", null, null), ElementKind.TEXT_LIKE},
-                {element("input", "search", null, null), ElementKind.TEXT_LIKE},
-                {element("input", "tel", null, null), ElementKind.TEXT_LIKE},
-                {element("input", "url", null, null), ElementKind.TEXT_LIKE},
-                {element("input", "number", null, null), ElementKind.TEXT_LIKE},
-                {element("textarea", null, null, null), ElementKind.TEXT_LIKE},
+                {element("input", "text", null), ElementKind.TEXT_LIKE},
+                {element("input", "password", null), ElementKind.TEXT_LIKE},
+                {element("input", "email", null), ElementKind.TEXT_LIKE},
+                {element("input", "search", null), ElementKind.TEXT_LIKE},
+                {element("input", "tel", null), ElementKind.TEXT_LIKE},
+                {element("input", "url", null), ElementKind.TEXT_LIKE},
+                {element("input", "number", null), ElementKind.TEXT_LIKE},
+                {element("textarea", null, null), ElementKind.TEXT_LIKE},
                 // case 3
-                {element("input", "checkbox", null, null), ElementKind.CHECKBOX},
-                {element("input", "radio", null, null), ElementKind.RADIO},
-                {element("div", null, "checkbox", null), ElementKind.CHECKBOX},
-                {element("div", null, "switch", null), ElementKind.CHECKBOX},
+                {element("input", "checkbox", null), ElementKind.CHECKBOX},
+                {element("input", "radio", null), ElementKind.RADIO},
+                {element("div", null, "checkbox"), ElementKind.CHECKBOX},
+                {element("div", null, "switch"), ElementKind.CHECKBOX},
                 // case 4
-                {element("select", null, null, null), ElementKind.SELECT},
-                {element("SELECT", null, null, null), ElementKind.SELECT},
+                {element("select", null, null), ElementKind.SELECT},
+                {element("SELECT", null, null), ElementKind.SELECT},
                 // case 5
-                {element("input", "file", null, null), ElementKind.FILE},
+                {element("input", "file", null), ElementKind.FILE},
                 // case 6
-                {element("input", "date", null, null), ElementKind.DATE_LIKE},
-                {element("input", "time", null, null), ElementKind.DATE_LIKE},
-                {element("input", "datetime-local", null, null), ElementKind.DATE_LIKE},
+                {element("input", "date", null), ElementKind.DATE_LIKE},
+                {element("input", "time", null), ElementKind.DATE_LIKE},
+                {element("input", "datetime-local", null), ElementKind.DATE_LIKE},
                 // case 7
-                {element("input", "range", null, null), ElementKind.RANGE},
-                {element("input", "color", null, null), ElementKind.COLOR},
-                {element("div", null, "slider", null), ElementKind.RANGE},
+                {element("input", "range", null), ElementKind.RANGE},
+                {element("input", "color", null), ElementKind.COLOR},
+                {element("div", null, "slider"), ElementKind.RANGE},
                 // case 8–9
-                {element("button", null, null, null), ElementKind.BUTTON},
-                {element("input", "submit", null, null), ElementKind.BUTTON},
-                {element("a", null, null, null), ElementKind.LINK},
-                {element("div", null, "button", null), ElementKind.BUTTON},
-                {element("div", null, "link", null), ElementKind.LINK},
+                {element("button", null, null), ElementKind.BUTTON},
+                {element("input", "submit", null), ElementKind.BUTTON},
+                {element("a", null, null), ElementKind.LINK},
+                {element("div", null, "button"), ElementKind.BUTTON},
+                {element("div", null, "link"), ElementKind.LINK},
                 // case 10
                 {contentEditable("div"), ElementKind.CONTENTEDITABLE},
                 // case 11
-                {element("div", null, "textbox", null), ElementKind.TEXT_LIKE},
-                {element("div", null, "searchbox", null), ElementKind.TEXT_LIKE},
-                {element("div", null, "spinbutton", null), ElementKind.TEXT_LIKE},
-                {element("div", null, "combobox", null), ElementKind.COMBOBOX},
+                {element("div", null, "textbox"), ElementKind.TEXT_LIKE},
+                {element("div", null, "searchbox"), ElementKind.TEXT_LIKE},
+                {element("div", null, "spinbutton"), ElementKind.TEXT_LIKE},
+                {element("div", null, "combobox"), ElementKind.COMBOBOX},
                 // case 12 masked/react — still text-like input
-                {element("input", "text", null, null), ElementKind.TEXT_LIKE},
+                {element("input", "text", null), ElementKind.TEXT_LIKE},
                 // case 15
-                {element("iframe", null, null, null), ElementKind.IFRAME},
+                {element("iframe", null, null), ElementKind.IFRAME},
                 // case 20
                 {disabled("input", "text"), ElementKind.DISABLED},
                 {readonly("input", "text"), ElementKind.READONLY},
                 {ariaDisabled("div"), ElementKind.DISABLED},
                 {contentEditablePlaintext("div"), ElementKind.CONTENTEDITABLE},
                 // unknown conservative
-                {element("div", null, null, null), ElementKind.UNKNOWN},
-                {element("custom-widget", null, null, null), ElementKind.UNKNOWN},
-                {element(null, null, null, null), ElementKind.UNKNOWN},
+                {element("div", null, null), ElementKind.UNKNOWN},
+                {element("custom-widget", null, null), ElementKind.UNKNOWN},
+                {element(null, null, null), ElementKind.UNKNOWN},
         };
     }
 
@@ -118,7 +118,7 @@ public class ElementClassifierTest {
         Assert.assertEquals(ElementClassifier.classify(readonlyInput), ElementKind.READONLY);
     }
 
-    private static WebElement element(String tag, String type, String role, String unused) {
+    private static WebElement element(String tag, String type, String role) {
         WebElement element = mock(WebElement.class);
         when(element.getTagName()).thenReturn(tag);
         when(element.getDomAttribute(anyString())).thenReturn(null);
@@ -134,31 +134,31 @@ public class ElementClassifierTest {
     }
 
     private static WebElement contentEditable(String tag) {
-        WebElement element = element(tag, null, null, null);
+        WebElement element = element(tag, null, null);
         when(element.getDomAttribute("contenteditable")).thenReturn("true");
         return element;
     }
 
     private static WebElement contentEditablePlaintext(String tag) {
-        WebElement element = element(tag, null, null, null);
+        WebElement element = element(tag, null, null);
         when(element.getDomAttribute("contenteditable")).thenReturn("plaintext-only");
         return element;
     }
 
     private static WebElement disabled(String tag, String type) {
-        WebElement element = element(tag, type, null, null);
+        WebElement element = element(tag, type, null);
         when(element.getDomAttribute("disabled")).thenReturn("");
         return element;
     }
 
     private static WebElement readonly(String tag, String type) {
-        WebElement element = element(tag, type, null, null);
+        WebElement element = element(tag, type, null);
         when(element.getDomAttribute("readonly")).thenReturn("true");
         return element;
     }
 
     private static WebElement ariaDisabled(String tag) {
-        WebElement element = element(tag, null, null, null);
+        WebElement element = element(tag, null, null);
         when(element.getDomAttribute("aria-disabled")).thenReturn("true");
         return element;
     }

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
@@ -1,0 +1,146 @@
+package com.shaft.gui.element.internal.interaction;
+
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ElementClassifierTest {
+
+    @DataProvider(name = "webKinds")
+    public Object[][] webKinds() {
+        return new Object[][]{
+                // cases 1–2 text-like
+                {element("input", "text", null, null), ElementKind.TEXT_LIKE},
+                {element("input", "password", null, null), ElementKind.TEXT_LIKE},
+                {element("input", "email", null, null), ElementKind.TEXT_LIKE},
+                {element("input", "search", null, null), ElementKind.TEXT_LIKE},
+                {element("input", "tel", null, null), ElementKind.TEXT_LIKE},
+                {element("input", "url", null, null), ElementKind.TEXT_LIKE},
+                {element("input", "number", null, null), ElementKind.TEXT_LIKE},
+                {element("textarea", null, null, null), ElementKind.TEXT_LIKE},
+                // case 3
+                {element("input", "checkbox", null, null), ElementKind.CHECKBOX},
+                {element("input", "radio", null, null), ElementKind.RADIO},
+                {element("div", null, "checkbox", null), ElementKind.CHECKBOX},
+                {element("div", null, "switch", null), ElementKind.CHECKBOX},
+                // case 4
+                {element("select", null, null, null), ElementKind.SELECT},
+                {element("SELECT", null, null, null), ElementKind.SELECT},
+                // case 5
+                {element("input", "file", null, null), ElementKind.FILE},
+                // case 6
+                {element("input", "date", null, null), ElementKind.DATE_LIKE},
+                {element("input", "time", null, null), ElementKind.DATE_LIKE},
+                {element("input", "datetime-local", null, null), ElementKind.DATE_LIKE},
+                // case 7
+                {element("input", "range", null, null), ElementKind.RANGE},
+                {element("input", "color", null, null), ElementKind.COLOR},
+                {element("div", null, "slider", null), ElementKind.RANGE},
+                // case 8–9
+                {element("button", null, null, null), ElementKind.BUTTON},
+                {element("input", "submit", null, null), ElementKind.BUTTON},
+                {element("a", null, null, null), ElementKind.LINK},
+                {element("div", null, "button", null), ElementKind.BUTTON},
+                {element("div", null, "link", null), ElementKind.LINK},
+                // case 10
+                {contentEditable("div"), ElementKind.CONTENTEDITABLE},
+                // case 11
+                {element("div", null, "textbox", null), ElementKind.TEXT_LIKE},
+                {element("div", null, "searchbox", null), ElementKind.TEXT_LIKE},
+                {element("div", null, "spinbutton", null), ElementKind.TEXT_LIKE},
+                {element("div", null, "combobox", null), ElementKind.COMBOBOX},
+                // case 12 masked/react — still text-like input
+                {element("input", "text", null, null), ElementKind.TEXT_LIKE},
+                // case 15
+                {element("iframe", null, null, null), ElementKind.IFRAME},
+                // case 20
+                {disabled("input", "text"), ElementKind.DISABLED},
+                {readonly("input", "text"), ElementKind.DISABLED},
+                {ariaDisabled("div"), ElementKind.DISABLED},
+                // unknown conservative
+                {element("div", null, null, null), ElementKind.UNKNOWN},
+                {element("custom-widget", null, null, null), ElementKind.UNKNOWN},
+                {element(null, null, null, null), ElementKind.UNKNOWN},
+        };
+    }
+
+    @Test(dataProvider = "webKinds")
+    public void classifyCoversWebCatalogCases(WebElement element, ElementKind expected) {
+        Assert.assertEquals(ElementClassifier.classify(element), expected);
+    }
+
+    @Test
+    public void nullElementIsUnknown() {
+        Assert.assertEquals(ElementClassifier.classify(null), ElementKind.UNKNOWN);
+    }
+
+    @Test
+    public void truthyFlagRejectsArbitraryMockStrings() {
+        WebElement element = mock(WebElement.class);
+        when(element.getDomAttribute("disabled")).thenReturn("dom-disabled");
+        Assert.assertFalse(ElementClassifier.isTruthyFlag(element, "disabled"));
+        when(element.getDomAttribute("disabled")).thenReturn("");
+        Assert.assertTrue(ElementClassifier.isTruthyFlag(element, "disabled"));
+        when(element.getDomAttribute("disabled")).thenReturn("true");
+        Assert.assertTrue(ElementClassifier.isTruthyFlag(element, "disabled"));
+        when(element.getDomAttribute("disabled")).thenReturn("disabled");
+        Assert.assertTrue(ElementClassifier.isTruthyFlag(element, "disabled"));
+    }
+
+    @Test
+    public void typeRoutesDoNotBlindSendKeysForSpecialKinds() {
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.CHECKBOX), TypeStrategies.TypeRoute.TOGGLE_CLICK);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.RADIO), TypeStrategies.TypeRoute.TOGGLE_CLICK);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.SELECT), TypeStrategies.TypeRoute.SELECT_OPTION);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.FILE), TypeStrategies.TypeRoute.SET_FILES);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.DATE_LIKE), TypeStrategies.TypeRoute.SET_VALUE_WITH_EVENTS);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.CONTENTEDITABLE), TypeStrategies.TypeRoute.CONTENTEDITABLE);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.TEXT_LIKE), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.UNKNOWN), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
+        Assert.assertEquals(TypeStrategies.routeFor(ElementKind.COMBOBOX), TypeStrategies.TypeRoute.LEGACY_SEND_KEYS);
+    }
+
+    private static WebElement element(String tag, String type, String role, String unused) {
+        WebElement element = mock(WebElement.class);
+        when(element.getTagName()).thenReturn(tag);
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getAttribute(anyString())).thenReturn(null);
+        if (type != null) {
+            when(element.getDomAttribute("type")).thenReturn(type);
+        }
+        if (role != null) {
+            when(element.getDomAttribute("role")).thenReturn(role);
+        }
+        return element;
+    }
+
+    private static WebElement contentEditable(String tag) {
+        WebElement element = element(tag, null, null, null);
+        when(element.getDomAttribute("contenteditable")).thenReturn("true");
+        return element;
+    }
+
+    private static WebElement disabled(String tag, String type) {
+        WebElement element = element(tag, type, null, null);
+        when(element.getDomAttribute("disabled")).thenReturn("");
+        return element;
+    }
+
+    private static WebElement readonly(String tag, String type) {
+        WebElement element = element(tag, type, null, null);
+        when(element.getDomAttribute("readonly")).thenReturn("true");
+        return element;
+    }
+
+    private static WebElement ariaDisabled(String tag) {
+        WebElement element = element(tag, null, null, null);
+        when(element.getDomAttribute("aria-disabled")).thenReturn("true");
+        return element;
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/InteractionStrategiesActionsTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/InteractionStrategiesActionsTest.java
@@ -1,0 +1,245 @@
+package com.shaft.gui.element.internal.interaction;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.gui.browser.internal.JavaScriptWaitManager;
+import com.shaft.gui.element.internal.Actions;
+import com.shaft.gui.internal.locator.LocatorBuilder;
+import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
+import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.internal.FlakeProfiler;
+import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Test(singleThreaded = true)
+public class InteractionStrategiesActionsTest {
+    private static final By LOCATOR = By.id("target");
+    private static final byte[] PNG = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+
+    @BeforeMethod
+    public void configureFastMockFriendlyProperties() {
+        SHAFT.Properties.reporting.set().captureElementName(false);
+        SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(false);
+        SHAFT.Properties.flags.set().scrollingMode("legacy");
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
+        SHAFT.Properties.flags.set().forceCheckTextWasTypedCorrectly(false);
+        SHAFT.Properties.flags.set().attemptToClickBeforeTyping(false);
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
+        SHAFT.Properties.visuals.set().createAnimatedGif(false);
+        SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("ValidationPointsOnly");
+        SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
+        SHAFT.Properties.platform.set().targetPlatform(org.openqa.selenium.Platform.LINUX.name());
+        SHAFT.Properties.mobile.set().browserName("chrome");
+        LocatorBuilder.cleanup();
+        ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanupThreadLocalState() {
+        LocatorBuilder.cleanup();
+        ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void typeTextLikeUsesSendKeys() {
+        WebDriver driver = mockDriver();
+        WebElement element = textInput();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "hello");
+            verify(element).sendKeys(eq("hello"));
+            verify(element, never()).click();
+        }
+    }
+
+    @Test
+    public void typeCheckboxClicksAndNeverSendKeys() {
+        WebDriver driver = mockDriver();
+        WebElement element = inputOfType("checkbox");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "ignored");
+            verify(element).click();
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+            verify(element, never()).sendKeys(anyString());
+            verify(element, never()).clear();
+        }
+    }
+
+    @Test
+    public void typeSelectUsesNativeSelectApiNotBlindSendKeys() {
+        SHAFT.Properties.flags.set().handleNonSelectDropDown(false);
+        WebDriver driver = mockDriver();
+        WebElement dropdown = baseElement();
+        when(dropdown.getTagName()).thenReturn("select");
+        when(dropdown.getDomAttribute("multiple")).thenReturn(null);
+        WebElement option = baseElement();
+        when(option.getText()).thenReturn("Egypt");
+        when(option.getDomProperty("value")).thenReturn("eg");
+        when(option.getAttribute("index")).thenReturn("0");
+        when(dropdown.findElements(By.tagName("option"))).thenReturn(List.of(option));
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(dropdown));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "Egypt");
+            verify(option).click();
+            verify(dropdown, never()).sendKeys(any(CharSequence[].class));
+            verify(dropdown, never()).sendKeys(anyString());
+        }
+    }
+
+    @Test
+    public void typeFileUsesSendKeysPathWithoutClear() {
+        WebDriver driver = mockDriver();
+        WebElement element = inputOfType("file");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "/tmp/upload.txt");
+            verify(element).sendKeys("/tmp/upload.txt");
+            verify(element, never()).clear();
+        }
+    }
+
+    @Test
+    public void typeContentEditableUsesJsInsertNotClear() {
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("native");
+        WebDriver driver = mockDriver();
+        WebElement element = baseElement();
+        when(element.getTagName()).thenReturn("div");
+        when(element.getDomAttribute("contenteditable")).thenReturn("true");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "editor text");
+            verify((JavascriptExecutor) driver).executeScript(contains("insertText"), eq(element), eq("editor text"));
+            verify(element, never()).clear();
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+        }
+    }
+
+    @Test
+    public void typeDateSetsValueWithEventsNotClearSendKeys() {
+        WebDriver driver = mockDriver();
+        WebElement element = inputOfType("date");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "2024-01-15");
+            verify((JavascriptExecutor) driver).executeScript(contains("arguments[0].value"), eq(element), eq("2024-01-15"));
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+            verify(element, never()).clear();
+        }
+    }
+
+    @Test
+    public void clickLadderRetriesAfterScrollThenUsesFlaggedJs() {
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
+        WebDriver driver = mockDriver();
+        WebElement element = baseElement();
+        when(element.getTagName()).thenReturn("button");
+        doThrow(new InvalidElementStateException("blocked")).when(element).click();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).click(LOCATOR);
+            verify((JavascriptExecutor) driver, atLeastOnce()).executeScript(contains("scrollIntoView"), eq(element));
+            verify((JavascriptExecutor) driver).executeScript(eq("arguments[0].click();"), eq(element));
+        }
+    }
+
+    @Test
+    public void clickPreservesExceptionWhenJsFallbackDisabled() {
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(false);
+        WebDriver driver = mockDriver();
+        WebElement element = baseElement();
+        when(element.getTagName()).thenReturn("button");
+        doThrow(new InvalidElementStateException("blocked")).when(element).click();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            RuntimeException exception = Assert.expectThrows(RuntimeException.class,
+                    () -> new Actions(helperFor(driver)).click(LOCATOR));
+            Assert.assertTrue(hasCause(exception, InvalidElementStateException.class));
+            verify((JavascriptExecutor) driver, never()).executeScript(eq("arguments[0].click();"), eq(element));
+        }
+    }
+
+    private static WebDriver mockDriver() {
+        return mock(WebDriver.class, org.mockito.Mockito.withSettings()
+                .extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
+    }
+
+    private DriverFactoryHelper helperFor(WebDriver driver) {
+        DriverFactoryHelper helper = mock(DriverFactoryHelper.class);
+        when(helper.getDriver()).thenReturn(driver);
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        return helper;
+    }
+
+    private WebElement baseElement() {
+        WebElement element = mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.isSelected()).thenReturn(false);
+        when(element.getAccessibleName()).thenReturn("accessible target");
+        when(element.getText()).thenReturn("");
+        when(element.getAttribute(anyString())).thenReturn(null);
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getCssValue(anyString())).thenReturn("");
+        when(element.getRect()).thenReturn(new Rectangle(10, 20, 30, 40));
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        return element;
+    }
+
+    private WebElement textInput() {
+        return inputOfType("text");
+    }
+
+    private WebElement inputOfType(String type) {
+        WebElement element = baseElement();
+        when(element.getTagName()).thenReturn("input");
+        when(element.getDomAttribute("type")).thenReturn(type);
+        return element;
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> expectedCause) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (expectedCause.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
Implements **Wave B** of epic #5732 for the Selenium WebDriver path only: a small interaction strategy layer used by `Actions` for click/type.

`resolve → classify(element) → pickStrategy(kind, flags) → execute → optional verify`

- New package `com.shaft.gui.element.internal.interaction` (`ElementKind`, `ElementClassifier`, `ClickStrategies`, `TypeStrategies`)
- Wired into `Actions` CLICK / TYPE / TYPE_SECURELY; public API unchanged
- Honors existing flags: `clearBeforeTypingMode`, `attemptToClickBeforeTyping`, `clickUsingJavascriptWhenWebDriverClickFails` (no new Flags)
- Unknown / ambiguous kinds stay on the legacy clear+sendKeys path (conservative classifier)

### Behavior
| Kind | `type()` route |
|------|----------------|
| text-like / combobox / unknown | legacy clear+sendKeys |
| checkbox / radio | click (toggle); no sendKeys |
| select | existing `Select` API |
| file | existing upload sendKeys(path) |
| date / range / color | JS value + input/change events |
| contenteditable | JS insertText (or sequential keys); **not** `clear()` |
| disabled / iframe / button / link | reject with clear exception |

**Click ladder:** native → scroll/stabilize retry → flagged JS; preserves `InvalidElementStateException` when JS fallback is off.

## Test plan
- [x] `ElementClassifierTest` (catalog cases 1–12, 15, 18–20 signals)
- [x] `InteractionStrategiesActionsTest` (text, checkbox, select, file, contenteditable, date, click ladder)
- [x] Impacted `ActionsCoverageUnitTest` click/type/select methods

```bash
mvn -pl shaft-engine -Dtest=ElementClassifierTest,InteractionStrategiesActionsTest -Dallure.automaticallyOpen=false -DheadlessExecution=true test
```

## Out of scope
Playwright (Wave C), mobile (D), desktop (E), microbench (F), docs PR.

Closes nothing yet — tracks epic #5732 Wave B.