### PR TITLE
fix: navigation DOM quiet wait without SSE/WebSocket hang (#5731)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -1224,7 +1224,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
                 case TAB -> driverFactoryHelper.getDriver().switchTo().newWindow(WindowType.TAB).navigate().to(targetUrl);
                 case WINDOW -> driverFactoryHelper.getDriver().switchTo().newWindow(WindowType.WINDOW).navigate().to(targetUrl);
             }
-            JavaScriptWaitManager.waitForLazyLoading(driverFactoryHelper.getDriver());
+            JavaScriptWaitManager.waitForLazyLoadingAfterNavigation(driverFactoryHelper.getDriver());
             var handleAfterNavigation = driverFactoryHelper.getDriver().getWindowHandle();
             if (!handleBeforeNavigation.equals(handleAfterNavigation)) {
                 ReportManager.logDiscrete("Old Tab Handle: \"" + handleBeforeNavigation + "\", New Tab handle : \"" + handleAfterNavigation + "\"");

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -1330,7 +1330,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
             } else
                 // navigate to new url
                 browserActionsHelper.navigateToNewUrl(driverFactoryHelper.getDriver(), null, modifiedTargetUrl, targetUrlAfterRedirection);
-            JavaScriptWaitManager.waitForLazyLoading(driverFactoryHelper.getDriver());
+            JavaScriptWaitManager.waitForLazyLoadingAfterNavigation(driverFactoryHelper.getDriver());
 
             // validate successful navigation
             if (!targetUrl.contains("\n")) {
@@ -1483,7 +1483,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
                 case BACK -> driverFactoryHelper.getDriver().navigate().back();
                 case REFRESH -> driverFactoryHelper.getDriver().navigate().refresh();
             }
-            JavaScriptWaitManager.waitForLazyLoading(driverFactoryHelper.getDriver());
+            JavaScriptWaitManager.waitForLazyLoadingAfterNavigation(driverFactoryHelper.getDriver());
             if (!navigationAction.equals(NavigationAction.REFRESH)) {
                 browserActionsHelper.waitUntilUrlIsNot(driverFactoryHelper.getDriver(), initialURL);
                 newURL = driverFactoryHelper.getDriver().getCurrentUrl();
@@ -2334,7 +2334,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
      */
     @Override
     public BrowserActions waitForLazyLoading() {
-        JavaScriptWaitManager.waitForLazyLoading(driverFactoryHelper.getDriver());
+        JavaScriptWaitManager.waitForLazyLoadingAfterNavigation(driverFactoryHelper.getDriver());
         return this;
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java
@@ -9,13 +9,10 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public class JavaScriptWaitManager {
-    private static final List<String> COMPLETE_READY_STATES = List.of("loaded", "complete");
-    private static final Duration ACTIVE_REQUEST_POLLING_INTERVAL = Duration.ofMillis(200);
     private static final long IDLE_WINDOW_NOT_STARTED = -1L;
 
     private JavaScriptWaitManager() {
@@ -23,10 +20,19 @@ public class JavaScriptWaitManager {
     }
 
     /**
-     * Waits for jQuery, Angular, and/or Javascript if present on the current page.
+     * Cheap per-action wait: network/framework readiness, plus DOM quiet only when
+     * {@code lazyLoadingDomStabilityQuietWindowMillis} is greater than zero (default {@code 0}).
      */
     public static void waitForLazyLoading(WebDriver driver) {
         waitForLazyLoadingAndDetectActivity(driver);
+    }
+
+    /**
+     * Post-navigation wait: cheap wait plus the navigation DOM quiet window
+     * ({@code lazyLoadingDomStabilityOnNavigationQuietWindowMillis}, default {@code 300}).
+     */
+    public static void waitForLazyLoadingAfterNavigation(WebDriver driver) {
+        waitForLazyLoadingAndDetectActivity(driver, navigationDomQuietMillis());
     }
 
     /**
@@ -36,10 +42,15 @@ public class JavaScriptWaitManager {
      * @return {@code true} when document, framework, or network activity was observed during the wait
      */
     public static boolean waitForLazyLoadingAndDetectActivity(WebDriver driver) {
+        return waitForLazyLoadingAndDetectActivity(driver,
+                SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis());
+    }
+
+    private static boolean waitForLazyLoadingAndDetectActivity(WebDriver driver, int domQuietMillis) {
         if (SHAFT.Properties.timeouts.waitForLazyLoading()
                 && !DriverFactoryHelper.isMobileNativeExecution()) {
             try {
-                return waitForBrowserReadiness(driver);
+                return waitForBrowserReadiness(driver, Math.max(0, domQuietMillis));
             } catch (Exception ignored) {
                 return true;
             }
@@ -47,7 +58,13 @@ public class JavaScriptWaitManager {
         return false;
     }
 
-    private static boolean waitForBrowserReadiness(WebDriver driver) {
+    private static int navigationDomQuietMillis() {
+        return Math.max(
+                Math.max(0, SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis()),
+                Math.max(0, SHAFT.Properties.timeouts.lazyLoadingDomStabilityOnNavigationQuietWindowMillis()));
+    }
+
+    private static boolean waitForBrowserReadiness(WebDriver driver, int domQuietMillis) {
         final long[] idleSinceMillis = {IDLE_WINDOW_NOT_STARTED};
         final String[] lastNetworkActivityMarker = {null};
         final boolean[] networkActivityObserved = {false};
@@ -78,7 +95,8 @@ public class JavaScriptWaitManager {
                                     String.valueOf(readiness.domMutationMarker()),
                                     domIdleSinceMillis,
                                     lastDomMutationMarker,
-                                    nowMillis);
+                                    nowMillis,
+                                    domQuietMillis);
                             return readiness.documentReady()
                                     && readiness.jqueryActive() == 0L
                                     && readiness.angularActive() == 0L
@@ -101,32 +119,6 @@ public class JavaScriptWaitManager {
      */
     private static Duration pollingInterval() {
         return Duration.ofMillis(Math.max(1, SHAFT.Properties.timeouts.lazyLoadingPollingIntervalMillis()));
-    }
-
-    private static void waitUntilNoActiveNetworkRequests(WebDriver driver) {
-        //Wait for active XHR/fetch requests to remain idle for the minimum quiet window
-        final long[] idleSinceMillis = {IDLE_WINDOW_NOT_STARTED};
-        final boolean[] networkActivityObserved = {false};
-        new SynchronizationManager(driver).fluentWait().pollingEvery(ACTIVE_REQUEST_POLLING_INTERVAL).until(f -> {
-            if (f instanceof JavascriptExecutor javascriptExecutor) {
-                try {
-                    var returnedValue = javascriptExecutor.executeScript(JavaScriptHelper.ACTIVE_NETWORK_REQUESTS_COUNT.getValue());
-                    long activeRequests = 0L;
-                    if (returnedValue instanceof Number numberValue) {
-                        activeRequests = numberValue.longValue();
-                    } else if (returnedValue != null) {
-                        activeRequests = Long.parseLong(returnedValue.toString());
-                    }
-                    return hasMetMinimumIdleWindow(activeRequests, idleSinceMillis, networkActivityObserved, System.currentTimeMillis());
-                } catch (Exception exception) {
-                    // force return in case of unexpected exception
-                    // e.g. org.openqa.selenium.JavascriptException if the script cannot execute
-                    ReportManagerHelper.logDiscrete(exception);
-                    return true;
-                }
-            }
-            return true;
-        });
     }
 
     /**
@@ -241,12 +233,18 @@ public class JavaScriptWaitManager {
      */
     private static boolean isDomStable(String domMutationMarker, long[] domIdleSinceMillis,
                                         String[] lastDomMutationMarker, long nowMillis) {
-        int quietWindowMillis = Math.max(0, SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis());
-        if (quietWindowMillis <= 0) {
+        return isDomStable(domMutationMarker, domIdleSinceMillis, lastDomMutationMarker, nowMillis,
+                SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis());
+    }
+
+    private static boolean isDomStable(String domMutationMarker, long[] domIdleSinceMillis,
+                                        String[] lastDomMutationMarker, long nowMillis, int quietWindowMillis) {
+        int resolvedQuietWindowMillis = Math.max(0, quietWindowMillis);
+        if (resolvedQuietWindowMillis <= 0) {
             return true;
         }
         return hasMetDomStabilityQuietWindow(domMutationMarker, domIdleSinceMillis, lastDomMutationMarker,
-                quietWindowMillis, nowMillis);
+                resolvedQuietWindowMillis, nowMillis);
     }
 
     /**
@@ -281,57 +279,6 @@ public class JavaScriptWaitManager {
 
     private static Duration minimumIdleWindow() {
         return Duration.ofMillis(Math.max(0, SHAFT.Properties.timeouts.lazyLoadingNetworkIdleQuietWindowMillis()));
-    }
-
-    private static void waitForDocumentReadyState(WebDriver driver) {
-        new SynchronizationManager(driver).fluentWait().until(f -> {
-            if (f instanceof JavascriptExecutor javascriptExecutor) {
-                try {
-                    return COMPLETE_READY_STATES.contains(String.valueOf(javascriptExecutor.executeScript(JavaScriptHelper.DOCUMENT_READY_STATE.getValue())));
-                } catch (Exception exception) {
-                    // force return in case of unexpected exception
-                    return true;
-                }
-            }
-            return true;
-        });
-    }
-
-    private static void waitForJQuery(WebDriver driver) {
-        new SynchronizationManager(driver).fluentWait().until(f -> {
-            if (f instanceof JavascriptExecutor javascriptExecutor) {
-                try {
-                    return Long.parseLong(String.valueOf(javascriptExecutor.executeScript(JavaScriptHelper.JQUERY_ACTIVE_STATE.getValue()))) == 0;
-                } catch (Exception exception) {
-                    // force return in case of unexpected exception
-                    // org.openqa.selenium.JavascriptException: javascript error: jQuery is not defined
-                    return true;
-                }
-            }
-            return true;
-        });
-    }
-
-    private static void waitForAngular(WebDriver driver) {
-        new SynchronizationManager(driver).fluentWait().until(f -> {
-            if (f instanceof JavascriptExecutor javascriptExecutor) {
-                try {
-                    // Try AngularJS (1.x) first
-                    return Long.parseLong(String.valueOf(javascriptExecutor.executeScript(JavaScriptHelper.ANGULAR_READY_STATE.getValue()))) == 0;
-                } catch (Exception exception) {
-                    // AngularJS not found on this page; try Angular 2+
-                    // org.openqa.selenium.JavascriptException: javascript error: angular is not defined
-                    try {
-                        // Try Angular 2+ if AngularJS is not available on the page
-                        return Long.parseLong(String.valueOf(javascriptExecutor.executeScript(JavaScriptHelper.ANGULAR2_READY_STATE.getValue()))) == 0;
-                    } catch (Exception angularException) {
-                        // force return if Angular is not present on this page
-                        return true;
-                    }
-                }
-            }
-            return true;
-        });
     }
 
     private record BrowserReadinessState(boolean documentReady, long activeRequests, String networkActivityMarker,

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java
@@ -232,12 +232,6 @@ public class JavaScriptWaitManager {
      * @return {@code true} when DOM stability is disabled or its quiet window has been satisfied
      */
     private static boolean isDomStable(String domMutationMarker, long[] domIdleSinceMillis,
-                                        String[] lastDomMutationMarker, long nowMillis) {
-        return isDomStable(domMutationMarker, domIdleSinceMillis, lastDomMutationMarker, nowMillis,
-                SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis());
-    }
-
-    private static boolean isDomStable(String domMutationMarker, long[] domIdleSinceMillis,
                                         String[] lastDomMutationMarker, long nowMillis, int quietWindowMillis) {
         int resolvedQuietWindowMillis = Math.max(0, quietWindowMillis);
         if (resolvedQuietWindowMillis <= 0) {

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -78,6 +78,16 @@ public interface Timeouts extends EngineProperties<Timeouts> {
     int lazyLoadingDomStabilityQuietWindowMillis();
 
     /**
+     * Required DOM-mutation quiet window in milliseconds applied after navigation
+     * ({@code waitForLazyLoadingAfterNavigation} / public {@code BrowserActions.waitForLazyLoading}).
+     * Independent of {@link #lazyLoadingDomStabilityQuietWindowMillis()}, which stays {@code 0}
+     * so cheap per-action waits do not fold DOM stability by default.
+     */
+    @Key("lazyLoadingDomStabilityOnNavigationQuietWindowMillis")
+    @DefaultValue("300")
+    int lazyLoadingDomStabilityOnNavigationQuietWindowMillis();
+
+    /**
      * Maximum number of progressive-scroll steps that {@code BrowserActions.scrollToLoadAll()}
      * will perform while sweeping a page for scroll-triggered lazy content, bounding its
      * worst-case cost regardless of how far the page keeps growing.
@@ -244,6 +254,11 @@ public interface Timeouts extends EngineProperties<Timeouts> {
 
         public SetProperty lazyLoadingDomStabilityQuietWindowMillis(int value) {
             setProperty("lazyLoadingDomStabilityQuietWindowMillis", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty lazyLoadingDomStabilityOnNavigationQuietWindowMillis(int value) {
+            setProperty("lazyLoadingDomStabilityOnNavigationQuietWindowMillis", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Web.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Web.java
@@ -79,12 +79,12 @@ public interface Web extends EngineProperties<Web> {
 
     // none, eager, or normal
     @Key("pageLoadStrategy")
-    @DefaultValue("none")
+    @DefaultValue("eager")
     String pageLoadStrategy();
 
     // interactive, none, or complete
     @Key("readinessState")
-    @DefaultValue("none")
+    @DefaultValue("interactive")
     String readinessState();
 
     /**

--- a/shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java
@@ -335,6 +335,14 @@ public class JavaScriptWaitManagerUnitTest {
         Assert.assertTrue(afterSecondWindowEnds, "Should pass again once the quiet window elapses after the marker change");
     }
 
+    @Test(description = "Verify lazyLoadingDomStabilityQuietWindowMillis defaults to 0 and navigation DOM quiet defaults to 300")
+    public void testDomStabilityPropertyDefaults() {
+        Assert.assertEquals(SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis(), 0,
+                "cheap per-action DOM quiet window stays disabled by default");
+        Assert.assertEquals(SHAFT.Properties.timeouts.lazyLoadingDomStabilityOnNavigationQuietWindowMillis(), 300,
+                "navigation DOM quiet window defaults to 300ms");
+    }
+
     @Test(description = "Verify DOM stability is a no-op (always stable) when lazyLoadingDomStabilityQuietWindowMillis is 0 (default = today's behavior)")
     public void testDomStabilityDisabledWhenPropertyIsZero() throws Exception {
         int original = SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis();

--- a/shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java
@@ -311,7 +311,7 @@ public class JavaScriptWaitManagerUnitTest {
 
     private static Method getIsDomStableMethod() throws Exception {
         Method method = Class.forName("com.shaft.gui.browser.internal.JavaScriptWaitManager")
-                .getDeclaredMethod("isDomStable", String.class, long[].class, String[].class, long.class);
+                .getDeclaredMethod("isDomStable", String.class, long[].class, String[].class, long.class, int.class);
         method.setAccessible(true);
         return method;
     }
@@ -352,8 +352,8 @@ public class JavaScriptWaitManagerUnitTest {
             long[] idleSinceMillis = {getIdleWindowNotStartedMarker()};
             String[] lastMarker = {null};
 
-            boolean stableOnFirstPoll = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1000L);
-            boolean stableAfterImmediateMarkerChange = (boolean) method.invoke(null, "2", idleSinceMillis, lastMarker, 1001L);
+            boolean stableOnFirstPoll = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1000L, 0);
+            boolean stableAfterImmediateMarkerChange = (boolean) method.invoke(null, "2", idleSinceMillis, lastMarker, 1001L, 0);
 
             Assert.assertTrue(stableOnFirstPoll, "DOM stability must default to true (no-op) when the property is 0");
             Assert.assertTrue(stableAfterImmediateMarkerChange,
@@ -372,9 +372,9 @@ public class JavaScriptWaitManagerUnitTest {
             long[] idleSinceMillis = {getIdleWindowNotStartedMarker()};
             String[] lastMarker = {null};
 
-            boolean firstPoll = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1000L);
-            boolean beforeWindowEnds = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1200L);
-            boolean afterWindowEnds = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1300L);
+            boolean firstPoll = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1000L, 300);
+            boolean beforeWindowEnds = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1200L, 300);
+            boolean afterWindowEnds = (boolean) method.invoke(null, "1", idleSinceMillis, lastMarker, 1300L, 300);
 
             Assert.assertFalse(firstPoll, "Enabling DOM stability should require an observation baseline first");
             Assert.assertFalse(beforeWindowEnds, "Enabling DOM stability should require the configured quiet window to elapse");

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
@@ -93,8 +93,8 @@ public class AllureActionStepReportingTest extends Tests {
 
     @Test
     public void failedNavigateStillWritesExactlyOneFailedOrBrokenAllureStep() throws IOException {
-        // SHAFT defaults pageLoadStrategy=none and readinessState=none, so get()
-        // returns before the document exists. Recreate a driver that waits, then
+        // Hang-path coverage still forces pageLoadStrategy=normal and readinessState=complete
+        // so get() waits for a full document load. Recreate a driver that waits, then
         // hit the local TestPageServer never-respond URL (no live network). That
         // is a navigation the driver cannot complete, not a 200 page whose body is
         // "Invalid URL". Bound the withheld response: Safari forever mid-load made

--- a/shaft-engine/src/test/java/testPackage/TestPageServer.java
+++ b/shaft-engine/src/test/java/testPackage/TestPageServer.java
@@ -88,6 +88,24 @@ public final class TestPageServer {
         return sanitized.isBlank() ? "shaft-download.bin" : sanitized;
     }
 
+    private static void serveSse(HttpExchange exchange) {
+        try {
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream; charset=utf-8");
+            exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+            exchange.sendResponseHeaders(200, 0);
+            OutputStream responseBody = exchange.getResponseBody();
+            responseBody.write("data: shaft-sse\n\n".getBytes(StandardCharsets.UTF_8));
+            responseBody.flush();
+            Thread.sleep(30_000L);
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+        } catch (IOException ignored) {
+            // client disconnected
+        } finally {
+            exchange.close();
+        }
+    }
+
     private static void neverRespond(HttpExchange exchange) {
         try {
             // Hold past typical pageLoadTimeout used by failed-navigate proofs (2s) so
@@ -117,6 +135,7 @@ public final class TestPageServer {
                 newServer.createContext("/__never_respond", TestPageServer::neverRespond);
                 newServer.createContext("/__download", TestPageServer::serveDownload);
                 newServer.createContext("/__download_page", TestPageServer::serveDownloadPage);
+                newServer.createContext("/__sse", TestPageServer::serveSse);
                 newServer.setExecutor(Executors.newCachedThreadPool(runnable -> {
                     Thread thread = new Thread(runnable, "test-page-server");
                     thread.setDaemon(true);

--- a/shaft-engine/src/test/java/testPackage/mockedTests/LazyLoadingFixtureLiveTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/LazyLoadingFixtureLiveTest.java
@@ -51,24 +51,25 @@ public class LazyLoadingFixtureLiveTest {
             + "in the DOM-mutation-observer signal, and IntersectionObserver-driven hydration of content already "
             + "in the initial viewport is present by the time navigateToURL returns.")
     public void domStabilityQuietWindowHoldsForInViewportHydration() {
-        // Note on timing: the DOM-stability quiet window can only ever *extend* a wait for a mutation
-        // it has already observed -- once a poll finds the mutation marker unchanged, that counts as
-        // "stable" immediately, even if an application is about to mutate the DOM a moment later. So a
-        // fixture cannot deterministically prove "the wait held *for* a not-yet-happened mutation"
-        // without racing the quiet window against the mutation's own delay. To keep this test
-        // non-flaky, the hero section hydrates essentially immediately (data-hydrate-delay-ms="0" in
-        // the fixture) rather than racing a longer delay against the quiet window.
-        SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityQuietWindowMillis(300);
-        try {
-            driver.get().browser().navigateToURL(FIXTURE_URL);
+        // Navigation applies lazyLoadingDomStabilityOnNavigationQuietWindowMillis (default 300)
+        // without requiring the global per-action DOM quiet window.
+        driver.get().browser().navigateToURL(FIXTURE_URL);
 
-            // Non-retrying rationale as above: a polling assertion here would mask an early return.
-            Assert.assertTrue(elementExistsNow("hero-section-content"),
-                    "the hero section's IntersectionObserver hydration (DOM mutation, no network signal) must "
-                            + "already have completed the instant navigateToURL returns");
-        } finally {
-            SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityQuietWindowMillis(0);
-        }
+        Assert.assertTrue(elementExistsNow("hero-section-content"),
+                "the hero section's IntersectionObserver hydration (DOM mutation, no network signal) must "
+                        + "already have completed the instant navigateToURL returns");
+    }
+
+    @Test(description = "Navigating to a page with long-lived EventSource and WebSocket connections "
+            + "must not hang for waitForLazyLoadingTimeout (30s).")
+    public void navigateToSseAndWebSocketPageDoesNotHang() {
+        long started = System.currentTimeMillis();
+        driver.get().browser().navigateToURL(TestPageServer.url("lazyLoadingSseWsFixture.html"));
+        long elapsed = System.currentTimeMillis() - started;
+        Assert.assertTrue(elapsed < 15_000L,
+                "SSE/WebSocket navigation must not wait out the 30s lazy-loading timeout, elapsed=" + elapsed);
+        Assert.assertTrue(elementExistsNow("sse-ws-ready"),
+                "SSE/WS fixture marker must exist after navigateToURL returns");
     }
 
     @Test(description = "scrollToLoadAll() must bound-progressively scroll the page until the infinite list's "

--- a/shaft-engine/src/test/java/testPackage/mockedTests/LazyLoadingFixtureLiveTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/LazyLoadingFixtureLiveTest.java
@@ -60,6 +60,22 @@ public class LazyLoadingFixtureLiveTest {
                         + "already have completed the instant navigateToURL returns");
     }
 
+    @Test(description = "With both DOM quiet windows at 0, navigateToURL must not wait for delayed in-viewport hydration.")
+    public void navigationWithoutDomQuietDoesNotWaitForDelayedHydration() {
+        int originalNav = SHAFT.Properties.timeouts.lazyLoadingDomStabilityOnNavigationQuietWindowMillis();
+        int originalGlobal = SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis();
+        SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityOnNavigationQuietWindowMillis(0);
+        SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityQuietWindowMillis(0);
+        try {
+            driver.get().browser().navigateToURL(TestPageServer.url("lazyLoadingDomHydrationFixture.html"));
+            Assert.assertFalse(elementExistsNow("delayed-hero-section-content"),
+                    "1500ms hydration must still be absent when both DOM quiet windows are 0");
+        } finally {
+            SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityOnNavigationQuietWindowMillis(originalNav);
+            SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityQuietWindowMillis(originalGlobal);
+        }
+    }
+
     @Test(description = "Navigating to a page with long-lived EventSource and WebSocket connections "
             + "must not hang for waitForLazyLoadingTimeout (30s).")
     public void navigateToSseAndWebSocketPageDoesNotHang() {

--- a/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
@@ -19,6 +19,7 @@ public class TimeoutsTests {
     int lazyLoadingNetworkIdleQuietWindowMillis;
     int lazyLoadingPollingIntervalMillis;
     int lazyLoadingDomStabilityQuietWindowMillis;
+    int lazyLoadingDomStabilityOnNavigationQuietWindowMillis;
     int lazyLoadingScrollSweepMaxSteps;
     double defaultElementIdentificationTimeout;
     int waitForUiStateTimeout;
@@ -48,6 +49,7 @@ public class TimeoutsTests {
         lazyLoadingNetworkIdleQuietWindowMillis = SHAFT.Properties.timeouts.lazyLoadingNetworkIdleQuietWindowMillis();
         lazyLoadingPollingIntervalMillis = SHAFT.Properties.timeouts.lazyLoadingPollingIntervalMillis();
         lazyLoadingDomStabilityQuietWindowMillis = SHAFT.Properties.timeouts.lazyLoadingDomStabilityQuietWindowMillis();
+        lazyLoadingDomStabilityOnNavigationQuietWindowMillis = SHAFT.Properties.timeouts.lazyLoadingDomStabilityOnNavigationQuietWindowMillis();
         lazyLoadingScrollSweepMaxSteps = SHAFT.Properties.timeouts.lazyLoadingScrollSweepMaxSteps();
         defaultElementIdentificationTimeout = SHAFT.Properties.timeouts.defaultElementIdentificationTimeout();
         waitForUiStateTimeout = SHAFT.Properties.timeouts.waitForUiStateTimeout();
@@ -97,6 +99,7 @@ public class TimeoutsTests {
         SHAFT.Properties.timeouts.set().lazyLoadingNetworkIdleQuietWindowMillis(lazyLoadingNetworkIdleQuietWindowMillis);
         SHAFT.Properties.timeouts.set().lazyLoadingPollingIntervalMillis(lazyLoadingPollingIntervalMillis);
         SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityQuietWindowMillis(lazyLoadingDomStabilityQuietWindowMillis);
+        SHAFT.Properties.timeouts.set().lazyLoadingDomStabilityOnNavigationQuietWindowMillis(lazyLoadingDomStabilityOnNavigationQuietWindowMillis);
         SHAFT.Properties.timeouts.set().lazyLoadingScrollSweepMaxSteps(lazyLoadingScrollSweepMaxSteps);
         SHAFT.Properties.timeouts.set().lazyLoadingTimeout(waitForLazyLoadingTimeout + 1);
         SHAFT.Validations.assertThat().object(SHAFT.Properties.timeouts.waitForLazyLoadingTimeout()).isEqualTo(waitForLazyLoadingTimeout + 1).perform();

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
@@ -173,7 +173,8 @@ public class BrowserActionsCoverageUnitTest {
 
             // Once from forceStopCurrentNavigation() (pre-navigation), and once more after the
             // null-initialURL navigation completes -- matching the non-null branch's post-navigation wait.
-            javaScriptWaitManagerMocked.verify(() -> JavaScriptWaitManager.waitForLazyLoading(driver), Mockito.times(2));
+            javaScriptWaitManagerMocked.verify(() -> JavaScriptWaitManager.waitForLazyLoading(driver), Mockito.times(1));
+            javaScriptWaitManagerMocked.verify(() -> JavaScriptWaitManager.waitForLazyLoadingAfterNavigation(driver), Mockito.times(1));
         }
     }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
@@ -178,6 +178,19 @@ public class BrowserActionsCoverageUnitTest {
         }
     }
 
+    @Test(description = "navigateToURL(url, WindowType) must use waitForLazyLoadingAfterNavigation, not the cheap wait")
+    public void navigateToURLInNewTabShouldWaitAfterNavigation() {
+        when(driver.getWindowHandle()).thenReturn("window-1", "window-2");
+        when(targetLocator.newWindow(WindowType.TAB)).thenReturn(driver);
+
+        try (MockedStatic<JavaScriptWaitManager> javaScriptWaitManagerMocked = Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            browserActions.navigateToURL("https://example.com/new-tab", WindowType.TAB);
+
+            javaScriptWaitManagerMocked.verify(() -> JavaScriptWaitManager.waitForLazyLoadingAfterNavigation(driver), Mockito.times(1));
+            javaScriptWaitManagerMocked.verify(() -> JavaScriptWaitManager.waitForLazyLoading(driver), Mockito.never());
+        }
+    }
+
     @Test
     public void shouldCoverCookieAndCaptureMethods() {
         browserActions.addCookie("key", "value");

--- a/shaft-engine/src/test/resources/testDataFiles/lazyLoadingDomHydrationFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/lazyLoadingDomHydrationFixture.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Delayed In-Viewport Hydration Fixture</title>
+</head>
+<body>
+<div id="immediately-present">Immediately present content</div>
+<!-- DOM-only hydration: no XHR/fetch. Delay must exceed network idle (500ms quiet after
+     navigation resource timing / BiDi) so a wait with both DOM windows at 0 can return first. -->
+<div id="delayed-hero-section" class="lazy-section" data-hydrate-delay-ms="1500">Hero placeholder</div>
+<script>
+(function () {
+    'use strict';
+    document.querySelectorAll('.lazy-section').forEach(function (section) {
+        var hydrateDelayMs = Number(section.getAttribute('data-hydrate-delay-ms') || '0');
+        var observer = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (!entry.isIntersecting) {
+                    return;
+                }
+                observer.unobserve(entry.target);
+                setTimeout(function () {
+                    var content = document.createElement('div');
+                    content.id = entry.target.id + '-content';
+                    entry.target.appendChild(content);
+                }, hydrateDelayMs);
+            });
+        }, {threshold: 0.1});
+        observer.observe(section);
+    });
+})();
+</script>
+</body>
+</html>

--- a/shaft-engine/src/test/resources/testDataFiles/lazyLoadingSseWsFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/lazyLoadingSseWsFixture.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT SSE/WS Lazy Loading Fixture</title>
+</head>
+<body>
+<div id="sse-ws-ready">ready</div>
+<script>
+(function () {
+    try {
+        new EventSource('/__sse');
+    } catch (ignored) {
+    }
+    try {
+        new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/__ws');
+    } catch (ignored) {
+    }
+})();
+</script>
+</body>
+</html>

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
@@ -125,8 +125,10 @@ class CaptureServiceApiToolsTest {
                 McpWorkspacePolicy.of(temp),
                 new McpCaptureCodeBlockService());
         try {
+            // Blank target becomes about:blank (no DNS). Eager pageLoad on example.test would fail
+            // before capture_api_start can assert the shared single-session lock.
             manager.start(new CaptureStartRequest(
-                    "https://example.test",
+                    "",
                     CaptureBrowser.CHROME,
                     temp.resolve("first.json"),
                     temp.resolve("runtime"),


### PR DESCRIPTION
Closes #5731

Cheap per-action waitForLazyLoading still skips DOM folding unless lazyLoadingDomStabilityQuietWindowMillis is greater than 0 (default 0). After successful navigation, and on public BrowserActions.waitForLazyLoading(), SHAFT also applies lazyLoadingDomStabilityOnNavigationQuietWindowMillis (default 300).

Defaults: pageLoadStrategy=eager, readinessState=interactive. Allure hang-path tests still force normal plus complete. BiDi in-flight, EventSource, WebSocket, and mainThreadIdleSeen stay advisory. scrollToLoadAll is never automatic. Unused private wait helpers removed.

Docs companion: https://github.com/ShaftHQ/shafthq.github.io/pull/1066