### PR TITLE
feat(element): Wave C Playwright click/type strategies (#5732)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -3,11 +3,13 @@ package com.shaft.gui.element.internal.interaction;
 import org.openqa.selenium.WebElement;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * Cheap Selenium-path classifier: tagName, type, role/ARIA, contenteditable, disabled flags.
+ * Cheap classifier: tagName, type, role/ARIA, contenteditable, disabled flags.
  * Conservative by design — ambiguous custom widgets return {@link ElementKind#UNKNOWN}.
+ * Shared by Selenium Wave B and Playwright Wave C (#5732).
  */
 public final class ElementClassifier {
 
@@ -27,21 +29,32 @@ public final class ElementClassifier {
         if (element == null) {
             return ElementKind.UNKNOWN;
         }
+        return classify(fromWebElement(element));
+    }
 
-        if (isDisabled(element)) {
+    /**
+     * Classify from pre-read DOM signals (Playwright evaluate map or Selenium attribute reads).
+     */
+    public static ElementKind classify(ElementSignals signals) {
+        if (signals == null) {
+            return ElementKind.UNKNOWN;
+        }
+
+        if (isTruthyFlagValue(signals.disabled(), "disabled")
+                || "true".equals(safeLower(signals.ariaDisabled()))) {
             return ElementKind.DISABLED;
         }
-        // Readonly is classified before contenteditable/input kinds so type() can refuse
+        // Readonly before contenteditable/input kinds so type() can refuse
         // while click() still focuses (HTML readonly controls remain clickable).
-        if (isTruthyFlag(element, "readonly")) {
+        if (isTruthyFlagValue(signals.readonly(), "readonly")) {
             return ElementKind.READONLY;
         }
 
-        String tag = safeLower(safeTagName(element));
-        String type = safeLower(firstNonBlank(safeDom(element, "type"), safeProperty(element, "type")));
-        String role = safeLower(safeDom(element, "role"));
+        String tag = safeLower(signals.tagName());
+        String type = safeLower(signals.type());
+        String role = safeLower(signals.role());
 
-        if (isContentEditable(element)) {
+        if (isContentEditable(signals)) {
             return ElementKind.CONTENTEDITABLE;
         }
 
@@ -55,6 +68,73 @@ public final class ElementClassifier {
         }
 
         return classifyByRole(role);
+    }
+
+    /**
+     * Build signals from a Playwright-style evaluate result map (string keys, scalar values).
+     */
+    public static ElementSignals fromEvaluateMap(Map<?, ?> raw) {
+        if (raw == null) {
+            return null;
+        }
+        return new ElementSignals(
+                asString(raw.get("tagName")),
+                asString(raw.get("type")),
+                asString(raw.get("role")),
+                asString(raw.get("contentEditable")),
+                asString(raw.get("isContentEditable")),
+                asString(raw.get("disabled")),
+                asString(raw.get("readonly")),
+                asString(raw.get("ariaDisabled")),
+                asString(raw.get("dataMask")),
+                asString(raw.get("dataInputmask")),
+                asString(raw.get("mask")),
+                asString(raw.get("className")),
+                asString(raw.get("autocomplete")));
+    }
+
+    /**
+     * Conservative masked / OTP / input-mask heuristic for Playwright sequential typing.
+     * Prefer explicit data-* / mask attributes and known library class tokens over broad "mask" substrings.
+     */
+    public static boolean looksMasked(ElementSignals signals) {
+        if (signals == null) {
+            return false;
+        }
+        if (nonBlank(signals.dataMask())
+                || nonBlank(signals.dataInputmask())
+                || nonBlank(signals.mask())) {
+            return true;
+        }
+        String autocomplete = safeLower(signals.autocomplete());
+        if ("one-time-code".equals(autocomplete)) {
+            return true;
+        }
+        String className = safeLower(signals.className());
+        if (className == null) {
+            return false;
+        }
+        return className.contains("inputmask")
+                || className.contains("imask")
+                || className.contains("mask-input")
+                || className.contains("masked-input");
+    }
+
+    private static ElementSignals fromWebElement(WebElement element) {
+        return new ElementSignals(
+                safeTagName(element),
+                firstNonBlank(safeDom(element, "type"), safeProperty(element, "type")),
+                safeDom(element, "role"),
+                safeDom(element, "contenteditable"),
+                safeProperty(element, "isContentEditable"),
+                safeDom(element, "disabled"),
+                safeDom(element, "readonly"),
+                safeDom(element, "aria-disabled"),
+                safeDom(element, "data-mask"),
+                firstNonBlank(safeDom(element, "data-inputmask"), safeDom(element, "data-input-mask")),
+                safeDom(element, "mask"),
+                firstNonBlank(safeDom(element, "class"), safeProperty(element, "className")),
+                safeDom(element, "autocomplete"));
     }
 
     /**
@@ -151,20 +231,12 @@ public final class ElementClassifier {
         return ElementKind.UNKNOWN;
     }
 
-    private static boolean isDisabled(WebElement element) {
-        if (isTruthyFlag(element, "disabled")) {
-            return true;
-        }
-        String ariaDisabled = safeLower(safeDom(element, "aria-disabled"));
-        return "true".equals(ariaDisabled);
-    }
-
-    private static boolean isContentEditable(WebElement element) {
-        if (isContentEditableAttributeValue(safeDom(element, "contenteditable"))) {
+    private static boolean isContentEditable(ElementSignals signals) {
+        if (isContentEditableAttributeValue(signals.contentEditable())) {
             return true;
         }
         // Property path: only the boolean true string — mock junk like "dom-isContentEditable" must not match.
-        return "true".equalsIgnoreCase(safeProperty(element, "isContentEditable"));
+        return "true".equalsIgnoreCase(signals.isContentEditableProperty());
     }
 
     /**
@@ -190,7 +262,10 @@ public final class ElementClassifier {
      * Reject arbitrary non-empty strings so mocked defaults cannot false-positive.
      */
     static boolean isTruthyFlag(WebElement element, String attributeName) {
-        String value = safeDom(element, attributeName);
+        return isTruthyFlagValue(safeDom(element, attributeName), attributeName);
+    }
+
+    static boolean isTruthyFlagValue(String value, String attributeName) {
         if (value == null) {
             return false;
         }
@@ -242,5 +317,20 @@ public final class ElementClassifier {
             return second;
         }
         return first != null ? first : second;
+    }
+
+    private static boolean nonBlank(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Boolean bool) {
+            return bool ? "true" : "false";
+        }
+        String text = String.valueOf(value);
+        return "null".equals(text) ? null : text;
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementSignals.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementSignals.java
@@ -1,0 +1,35 @@
+package com.shaft.gui.element.internal.interaction;
+
+/**
+ * Cheap DOM signals for {@link ElementClassifier} — shared by Selenium {@code WebElement}
+ * and Playwright locator evaluate results (epic #5732).
+ */
+public record ElementSignals(
+        String tagName,
+        String type,
+        String role,
+        String contentEditable,
+        String isContentEditableProperty,
+        String disabled,
+        String readonly,
+        String ariaDisabled,
+        String dataMask,
+        String dataInputmask,
+        String mask,
+        String className,
+        String autocomplete
+) {
+    public static ElementSignals of(
+            String tagName,
+            String type,
+            String role,
+            String contentEditable,
+            String isContentEditableProperty,
+            String disabled,
+            String readonly,
+            String ariaDisabled) {
+        return new ElementSignals(
+                tagName, type, role, contentEditable, isContentEditableProperty,
+                disabled, readonly, ariaDisabled, null, null, null, null, null);
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -46,6 +46,19 @@ public final class TypeStrategies {
         REJECT
     }
 
+    /**
+     * Playwright {@code type()} routes (Wave C): plain inputs stay {@link PlaywrightTypeRoute#FILL};
+     * contenteditable / masked use {@link PlaywrightTypeRoute#PRESS_SEQUENTIALLY}.
+     */
+    public enum PlaywrightTypeRoute {
+        FILL,
+        PRESS_SEQUENTIALLY,
+        TOGGLE_CLICK,
+        SELECT_OPTION,
+        SET_FILES,
+        REJECT
+    }
+
     private TypeStrategies() {
     }
 
@@ -59,6 +72,24 @@ public final class TypeStrategies {
             // Readonly/disabled/iframe: refuse type. Button/link stay legacy (conservative).
             case DISABLED, READONLY, IFRAME -> TypeRoute.REJECT;
             case TEXT_LIKE, COMBOBOX, BUTTON, LINK, UNKNOWN -> TypeRoute.LEGACY_SEND_KEYS;
+        };
+    }
+
+    /**
+     * Playwright type routing. {@code masked} only affects text-like / combobox / unknown /
+     * button / link paths (contenteditable always sequential).
+     */
+    public static PlaywrightTypeRoute playwrightRouteFor(ElementKind kind, boolean masked) {
+        return switch (kind) {
+            case CHECKBOX, RADIO -> PlaywrightTypeRoute.TOGGLE_CLICK;
+            case SELECT -> PlaywrightTypeRoute.SELECT_OPTION;
+            case FILE -> PlaywrightTypeRoute.SET_FILES;
+            case CONTENTEDITABLE -> PlaywrightTypeRoute.PRESS_SEQUENTIALLY;
+            case DISABLED, READONLY, IFRAME -> PlaywrightTypeRoute.REJECT;
+            // date/range/color: Playwright fill is the fast, event-friendly default.
+            case DATE_LIKE, RANGE, COLOR -> PlaywrightTypeRoute.FILL;
+            case TEXT_LIKE, COMBOBOX, BUTTON, LINK, UNKNOWN ->
+                    masked ? PlaywrightTypeRoute.PRESS_SEQUENTIALLY : PlaywrightTypeRoute.FILL;
         };
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
@@ -629,6 +629,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
             case SET_FILES -> locator.setInputFiles(Path.of(text));
             case PRESS_SEQUENTIALLY -> pressSequentially(locator, text, append, kind);
             case FILL -> locator.fill(text == null ? "" : text);
+            default -> throw new IllegalStateException("Unhandled Playwright type route: " + route);
         }
     }
 
@@ -642,14 +643,18 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
                     // Focus best-effort before select-all / sequential keys.
                 }
                 locator.press("ControlOrMeta+A");
+                if (typed.isEmpty()) {
+                    locator.press("Backspace");
+                    return;
+                }
             } else {
                 try {
                     locator.clear();
-                } catch (RuntimeException clearFailed) {
+                } catch (RuntimeException ignored) {
                     try {
                         locator.click();
                         locator.press("ControlOrMeta+A");
-                    } catch (RuntimeException ignored) {
+                    } catch (RuntimeException ignoredAgain) {
                         // Best-effort replace; sequential keys still attempt to land.
                     }
                 }

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
@@ -6,6 +6,10 @@ import com.google.common.annotations.Beta;
 import com.shaft.gui.driver.ElementAssertions;
 import com.shaft.gui.driver.ElementTarget;
 import com.shaft.gui.driver.ShaftLocator;
+import com.shaft.gui.element.internal.interaction.ElementClassifier;
+import com.shaft.gui.element.internal.interaction.ElementKind;
+import com.shaft.gui.element.internal.interaction.ElementSignals;
+import com.shaft.gui.element.internal.interaction.TypeStrategies;
 import com.shaft.gui.internal.aria.AriaSnapshotHelper;
 import com.shaft.gui.internal.ocr.OcrCoordinateMapper;
 import com.shaft.gui.internal.ocr.OcrPoint;
@@ -32,7 +36,46 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Playwright element actions. Click uses Playwright actionability waits (visible, stable,
+ * enabled, receives events). {@code force}/{@code trial} click options are intentionally
+ * not exposed on the public API (default off); use {@link #clickUsingJavascript} only when
+ * an intentional bypass is required.
+ * <p>
+ * Open Shadow DOM is reachable via Playwright locator pierce (CSS/role locators). Closed
+ * shadow roots are unsupported for pierce — interact through the host's public API or
+ * accessibility tree instead.
+ * <p>
+ * {@link #type} chooses {@code fill} vs {@code pressSequentially} by element kind
+ * (epic #5732 Wave C): plain inputs stay {@code fill}; contenteditable / masked inputs
+ * use sequential key presses.
+ */
 public class ElementActions implements com.shaft.gui.driver.ElementActionsContract {
+
+    /**
+     * Single evaluate payload for Wave C classify + masked heuristic (keep in sync with
+     * {@link ElementClassifier#fromEvaluateMap}).
+     */
+    private static final String ELEMENT_SIGNALS_SCRIPT = """
+            el => ({
+              tagName: el.tagName || '',
+              type: el.getAttribute('type') || el.type || '',
+              role: el.getAttribute('role') || '',
+              contentEditable: el.getAttribute('contenteditable'),
+              isContentEditable: el.isContentEditable === true ? 'true' : 'false',
+              disabled: el.disabled === true ? 'true'
+                : (el.getAttribute('disabled') === null ? null : (el.getAttribute('disabled') || 'disabled')),
+              readonly: el.readOnly === true ? 'true'
+                : (el.getAttribute('readonly') === null ? null : (el.getAttribute('readonly') || 'readonly')),
+              ariaDisabled: el.getAttribute('aria-disabled'),
+              dataMask: el.getAttribute('data-mask'),
+              dataInputmask: el.getAttribute('data-inputmask') || el.getAttribute('data-input-mask'),
+              mask: el.getAttribute('mask'),
+              className: typeof el.className === 'string' ? el.className : (el.getAttribute('class') || ''),
+              autocomplete: el.getAttribute('autocomplete')
+            })
+            """;
+
     private final PlaywrightSession session;
 
     public ElementActions(PlaywrightSession session) {
@@ -132,6 +175,12 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
         return click(SmartLocators.clickableField(elementName));
     }
 
+    /**
+     * Clicks using Playwright actionability (waits until actionable). Does not set
+     * {@code force} or {@code trial} — both stay default-off and are not part of the
+     * public SHAFT API. Open shadow pierce works via the locator engine; closed shadow
+     * is unsupported (use host public API / a11y).
+     */
     public ElementActions click(Locator elementLocator) {
         return timed("playwright.element.click", elementLocator, () -> {
             elementLocator.click();
@@ -361,7 +410,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions type(Locator elementLocator, CharSequence... text) {
-        return timed("playwright.element.type", elementLocator, () -> elementLocator.fill(join(text)));
+        return timed("playwright.element.type", elementLocator, () -> typeByKind(elementLocator, join(text), false));
     }
 
     @Override
@@ -389,8 +438,24 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions typeAppend(Locator elementLocator, CharSequence... text) {
-        return timed("playwright.element.typeAppend", elementLocator,
-                () -> elementLocator.fill(readTextForAppend(elementLocator) + join(text)));
+        return timed("playwright.element.typeAppend", elementLocator, () -> {
+            ElementSignals signals = readSignals(elementLocator);
+            ElementKind kind = ElementClassifier.classify(signals);
+            boolean masked = ElementClassifier.looksMasked(signals);
+            TypeStrategies.PlaywrightTypeRoute route = TypeStrategies.playwrightRouteFor(kind, masked);
+            if (route == TypeStrategies.PlaywrightTypeRoute.PRESS_SEQUENTIALLY) {
+                typeByKind(elementLocator, join(text), true);
+                return;
+            }
+            if (route == TypeStrategies.PlaywrightTypeRoute.REJECT
+                    || route == TypeStrategies.PlaywrightTypeRoute.TOGGLE_CLICK
+                    || route == TypeStrategies.PlaywrightTypeRoute.SELECT_OPTION
+                    || route == TypeStrategies.PlaywrightTypeRoute.SET_FILES) {
+                typeByKind(elementLocator, join(text), false);
+                return;
+            }
+            elementLocator.fill(readTextForAppend(elementLocator) + join(text));
+        });
     }
 
     @Override
@@ -420,7 +485,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
 
     public ElementActions typeSecure(Locator elementLocator, CharSequence... text) {
         return timed("playwright.element.typeSecure", elementLocator, () -> {
-            elementLocator.fill(join(text));
+            typeByKind(elementLocator, join(text), false);
             ReportManager.log("Typed secure text into Playwright element.");
         });
     }
@@ -545,6 +610,67 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
 
     private Locator resolve(ShaftLocator locator) {
         return locator.toPlaywrightLocator(session.page());
+    }
+
+    private void typeByKind(Locator locator, String text, boolean append) {
+        ElementSignals signals = readSignals(locator);
+        ElementKind kind = ElementClassifier.classify(signals);
+        boolean masked = ElementClassifier.looksMasked(signals);
+        TypeStrategies.PlaywrightTypeRoute route = TypeStrategies.playwrightRouteFor(kind, masked);
+        switch (route) {
+            case REJECT -> throw new IllegalStateException(
+                    "type() is not supported for element kind " + kind
+                            + "; use click/select/upload APIs as appropriate.");
+            case TOGGLE_CLICK -> {
+                ReportManager.logDiscrete("type() on " + kind + " redirected to click (toggle); fill skipped.");
+                locator.click();
+            }
+            case SELECT_OPTION -> locator.selectOption(text);
+            case SET_FILES -> locator.setInputFiles(Path.of(text));
+            case PRESS_SEQUENTIALLY -> pressSequentially(locator, text, append, kind);
+            case FILL -> locator.fill(text == null ? "" : text);
+        }
+    }
+
+    private void pressSequentially(Locator locator, String text, boolean append, ElementKind kind) {
+        String typed = text == null ? "" : text;
+        if (!append) {
+            if (kind == ElementKind.CONTENTEDITABLE) {
+                try {
+                    locator.click();
+                } catch (RuntimeException ignored) {
+                    // Focus best-effort before select-all / sequential keys.
+                }
+                locator.press("ControlOrMeta+A");
+            } else {
+                try {
+                    locator.clear();
+                } catch (RuntimeException clearFailed) {
+                    try {
+                        locator.click();
+                        locator.press("ControlOrMeta+A");
+                    } catch (RuntimeException ignored) {
+                        // Best-effort replace; sequential keys still attempt to land.
+                    }
+                }
+            }
+        }
+        if (!typed.isEmpty()) {
+            locator.pressSequentially(typed);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private ElementSignals readSignals(Locator locator) {
+        try {
+            Object raw = locator.evaluate(ELEMENT_SIGNALS_SCRIPT);
+            if (raw instanceof Map<?, ?> map) {
+                return ElementClassifier.fromEvaluateMap(map);
+            }
+        } catch (RuntimeException ignored) {
+            // Conservative: unknown → fill path via TEXT_LIKE/UNKNOWN routing.
+        }
+        return ElementSignals.of(null, null, null, null, null, null, null, null);
     }
 
     private String readTextForAppend(Locator locator) {

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ElementClassifierTest.java
@@ -77,7 +77,8 @@ public class ElementClassifierTest {
 
     @Test
     public void nullElementIsUnknown() {
-        Assert.assertEquals(ElementClassifier.classify(null), ElementKind.UNKNOWN);
+        Assert.assertEquals(ElementClassifier.classify((WebElement) null), ElementKind.UNKNOWN);
+        Assert.assertEquals(ElementClassifier.classify((ElementSignals) null), ElementKind.UNKNOWN);
     }
 
     @Test

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/element/PlaywrightElementActionsUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/element/PlaywrightElementActionsUnitTest.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 import org.testng.annotations.AfterMethod;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -76,6 +77,11 @@ public class PlaywrightElementActionsUnitTest {
         when(session.page()).thenReturn(page);
         when(page.locator(anyString())).thenReturn(locator);
         when(locator.count()).thenReturn(1);
+        when(locator.evaluate(anyString())).thenReturn(Map.of(
+                "tagName", "INPUT",
+                "type", "email",
+                "role", "",
+                "isContentEditable", "false"));
 
         ElementActions actions = new ElementActions(session);
 
@@ -83,6 +89,7 @@ public class PlaywrightElementActionsUnitTest {
         Assert.assertSame(actions.type("Email", "user@example.com"), actions);
         verify(locator).click();
         verify(locator).fill("user@example.com");
+        verify(locator, never()).pressSequentially(anyString());
     }
 
     @Test

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/element/PlaywrightInteractionStrategiesUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/element/PlaywrightInteractionStrategiesUnitTest.java
@@ -1,0 +1,197 @@
+package com.shaft.gui.playwright.element;
+
+import com.microsoft.playwright.Locator;
+import com.shaft.gui.element.internal.interaction.ElementClassifier;
+import com.shaft.gui.element.internal.interaction.ElementKind;
+import com.shaft.gui.element.internal.interaction.ElementSignals;
+import com.shaft.gui.element.internal.interaction.TypeStrategies;
+import com.shaft.gui.playwright.internal.PlaywrightSession;
+import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.internal.TraceEventRecorder;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Wave C (#5732): Playwright type/click strategies mirroring Wave B kinds.
+ */
+@Test(singleThreaded = true)
+public class PlaywrightInteractionStrategiesUnitTest {
+
+    @AfterMethod(alwaysRun = true)
+    public void clearState() {
+        TraceEventRecorder.clear();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void typeTextLikeUsesFillNotPressSequentially() {
+        Locator locator = locatorWithSignals(signals("INPUT", "text"));
+        new ElementActions(mock(PlaywrightSession.class)).type(locator, "hello");
+        verify(locator).fill("hello");
+        verify(locator, never()).pressSequentially(anyString());
+        verify(locator, never()).click();
+    }
+
+    @Test
+    public void typeCheckboxClicksAndNeverFill() {
+        Locator locator = locatorWithSignals(signals("INPUT", "checkbox"));
+        new ElementActions(mock(PlaywrightSession.class)).type(locator, "ignored");
+        verify(locator).click();
+        verify(locator, never()).fill(anyString());
+        verify(locator, never()).pressSequentially(anyString());
+    }
+
+    @Test
+    public void typeSelectUsesSelectOptionNotFill() {
+        Locator locator = locatorWithSignals(signals("SELECT", ""));
+        new ElementActions(mock(PlaywrightSession.class)).type(locator, "Egypt");
+        verify(locator).selectOption("Egypt");
+        verify(locator, never()).fill(anyString());
+        verify(locator, never()).pressSequentially(anyString());
+    }
+
+    @Test
+    public void typeFileUsesSetInputFilesNotFill() {
+        Locator locator = locatorWithSignals(signals("INPUT", "file"));
+        new ElementActions(mock(PlaywrightSession.class)).type(locator, "/tmp/upload.txt");
+        verify(locator).setInputFiles(Path.of("/tmp/upload.txt"));
+        verify(locator, never()).fill(anyString());
+        verify(locator, never()).clear();
+    }
+
+    @Test
+    public void typeContentEditableUsesPressSequentiallyNotFill() {
+        Map<String, Object> map = signals("DIV", "");
+        map.put("contentEditable", "true");
+        map.put("isContentEditable", "true");
+        Locator locator = locatorWithSignals(map);
+        new ElementActions(mock(PlaywrightSession.class)).type(locator, "editor text");
+        verify(locator).press("ControlOrMeta+A");
+        verify(locator).pressSequentially("editor text");
+        verify(locator, never()).fill(anyString());
+    }
+
+    @Test
+    public void typeDateUsesFill() {
+        Locator locator = locatorWithSignals(signals("INPUT", "date"));
+        new ElementActions(mock(PlaywrightSession.class)).type(locator, "2024-01-15");
+        verify(locator).fill("2024-01-15");
+        verify(locator, never()).pressSequentially(anyString());
+    }
+
+    @Test
+    public void typeMaskedInputUsesPressSequentially() {
+        Map<String, Object> map = signals("INPUT", "text");
+        map.put("dataMask", "00/00/0000");
+        Locator locator = locatorWithSignals(map);
+        new ElementActions(mock(PlaywrightSession.class)).type(locator, "12/31/2024");
+        verify(locator).pressSequentially("12/31/2024");
+        verify(locator, never()).fill(anyString());
+    }
+
+    @Test
+    public void typeReadonlyRejects() {
+        Map<String, Object> map = signals("INPUT", "text");
+        map.put("readonly", "true");
+        Locator locator = locatorWithSignals(map);
+        Assert.expectThrows(IllegalStateException.class,
+                () -> new ElementActions(mock(PlaywrightSession.class)).type(locator, "nope"));
+        verify(locator, never()).fill(anyString());
+        verify(locator, never()).pressSequentially(anyString());
+    }
+
+    @Test
+    public void clickUsesDefaultActionabilityWithoutForceOptions() {
+        Locator locator = mock(Locator.class);
+        when(locator.toString()).thenReturn("getByRole(\"button\")");
+        new ElementActions(mock(PlaywrightSession.class)).click(locator);
+        // Default Locator.click() — no ClickOptions overload (force/trial stay off / unexposed).
+        verify(locator).click();
+    }
+
+    @Test
+    public void playwrightRoutesMatchWaveCMatrix() {
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.TEXT_LIKE, false),
+                TypeStrategies.PlaywrightTypeRoute.FILL);
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.TEXT_LIKE, true),
+                TypeStrategies.PlaywrightTypeRoute.PRESS_SEQUENTIALLY);
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.CONTENTEDITABLE, false),
+                TypeStrategies.PlaywrightTypeRoute.PRESS_SEQUENTIALLY);
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.CHECKBOX, false),
+                TypeStrategies.PlaywrightTypeRoute.TOGGLE_CLICK);
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.SELECT, false),
+                TypeStrategies.PlaywrightTypeRoute.SELECT_OPTION);
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.FILE, false),
+                TypeStrategies.PlaywrightTypeRoute.SET_FILES);
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.DATE_LIKE, false),
+                TypeStrategies.PlaywrightTypeRoute.FILL);
+        Assert.assertEquals(TypeStrategies.playwrightRouteFor(ElementKind.DISABLED, false),
+                TypeStrategies.PlaywrightTypeRoute.REJECT);
+    }
+
+    @Test
+    public void looksMaskedIsConservative() {
+        Assert.assertFalse(ElementClassifier.looksMasked(
+                ElementSignals.of("input", "text", null, null, null, null, null, null)));
+        Assert.assertTrue(ElementClassifier.looksMasked(new ElementSignals(
+                "input", "text", null, null, null, null, null, null,
+                "99/99/9999", null, null, null, null)));
+        Assert.assertTrue(ElementClassifier.looksMasked(new ElementSignals(
+                "input", "text", null, null, null, null, null, null,
+                null, null, null, "form-control imask", null)));
+        Assert.assertTrue(ElementClassifier.looksMasked(new ElementSignals(
+                "input", "text", null, null, null, null, null, null,
+                null, null, null, null, "one-time-code")));
+        Assert.assertFalse(ElementClassifier.looksMasked(new ElementSignals(
+                "input", "text", null, null, null, null, null, null,
+                null, null, null, "unmasked-field", null)));
+    }
+
+    @Test
+    public void classifyFromEvaluateMapMatchesWebKinds() {
+        Assert.assertEquals(ElementClassifier.classify(ElementClassifier.fromEvaluateMap(
+                signals("INPUT", "checkbox"))), ElementKind.CHECKBOX);
+        Assert.assertEquals(ElementClassifier.classify(ElementClassifier.fromEvaluateMap(
+                signals("SELECT", ""))), ElementKind.SELECT);
+        Map<String, Object> editable = signals("DIV", "");
+        editable.put("contentEditable", "true");
+        Assert.assertEquals(ElementClassifier.classify(ElementClassifier.fromEvaluateMap(editable)),
+                ElementKind.CONTENTEDITABLE);
+    }
+
+    private static Locator locatorWithSignals(Map<String, Object> signals) {
+        Locator locator = mock(Locator.class);
+        when(locator.evaluate(anyString())).thenReturn(signals);
+        when(locator.toString()).thenReturn("locator");
+        return locator;
+    }
+
+    private static Map<String, Object> signals(String tagName, String type) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("tagName", tagName);
+        map.put("type", type);
+        map.put("role", "");
+        map.put("contentEditable", null);
+        map.put("isContentEditable", "false");
+        map.put("disabled", null);
+        map.put("readonly", null);
+        map.put("ariaDisabled", null);
+        map.put("dataMask", null);
+        map.put("dataInputmask", null);
+        map.put("mask", null);
+        map.put("className", "");
+        map.put("autocomplete", null);
+        return map;
+    }
+}


### PR DESCRIPTION
## Summary
Implements **Wave C** of epic #5732: Playwright parity for click/type strategies using the shared Wave B classifier package.

- Reuses `ElementKind` / `ElementClassifier` / `TypeStrategies` via new `ElementSignals` + Playwright evaluate map
- `type()` routes by kind: plain input → `fill`; contenteditable / masked → `pressSequentially`; checkbox/radio → click; select → `selectOption`; file → `setInputFiles`; date/range/color → `fill`
- Click keeps Playwright actionability; `force`/`trial` remain default-off and undocumented as public API (class/method Javadoc)
- Open Shadow DOM: locator pierce; closed shadow: documented unsupported / host API
- Public fluent API unchanged; no new Flags

## Test plan
- [x] `PlaywrightInteractionStrategiesUnitTest` (text, checkbox, select, file, contenteditable, date, masked, readonly reject, click actionability, route matrix)
- [x] `PlaywrightElementActionsUnitTest` (existing + fill path stub)
- [x] `ElementClassifierTest` + `InteractionStrategiesActionsTest` (Wave B regression)

```bash
mvn -pl shaft-engine -Dtest=PlaywrightInteractionStrategiesUnitTest,PlaywrightElementActionsUnitTest,ElementClassifierTest,InteractionStrategiesActionsTest -Dallure.automaticallyOpen=false -DheadlessExecution=true test
```

## Out of scope
Mobile (D), desktop (E), microbench (F), Headroom, FreeToken, docs companion PR.

Tracks epic #5732 Wave C.