### PR TITLE
feat(element): Wave F click/type proof — microbench + flake N-run (#5732)

### DIFF
--- a/scripts/ci/run_click_type_wave_f_proof.sh
+++ b/scripts/ci/run_click_type_wave_f_proof.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Wave F (#5732) proof runner: flake-prone Wave B/C unit subset N times + microbench.
+# Usage:
+#   scripts/ci/run_click_type_wave_f_proof.sh [N]
+# Default N=3. Headless Chrome required for ClickTypeMicrobenchTest browser cases.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+N="${1:-3}"
+if ! [[ "$N" =~ ^[0-9]+$ ]] || [[ "$N" -lt 1 ]]; then
+  echo "N must be a positive integer (got: $N)" >&2
+  exit 2
+fi
+
+MVN_BIN="${MVN_BIN:-mvn}"
+COMMON_ARGS=(
+  -pl shaft-engine
+  -Dallure.automaticallyOpen=false
+  -DheadlessExecution=true
+  -DfailIfNoTests=false
+)
+
+UNIT_TESTS="ElementClassifierTest,InteractionStrategiesActionsTest,PlaywrightInteractionStrategiesUnitTest"
+MICRO_TESTS="ClickTypeMicrobenchTest"
+
+echo "=== Wave F flake proof: unit subset x${N} (${UNIT_TESTS}) ==="
+for ((i = 1; i <= N; i++)); do
+  echo "--- unit run ${i}/${N} ---"
+  "${MVN_BIN}" "${COMMON_ARGS[@]}" -Dtest="${UNIT_TESTS}" test
+done
+
+echo "=== Wave F microbench (strategy path + classifier overhead) ==="
+"${MVN_BIN}" "${COMMON_ARGS[@]}" -Dtest="${MICRO_TESTS}" test
+
+echo "=== Wave F proof complete (N=${N}) ==="
+echo "Waves D (mobile) / E (desktop UIA matrix): N/A for this PR — web proof only; see epic #5732."

--- a/scripts/ci/run_click_type_wave_f_proof.sh
+++ b/scripts/ci/run_click_type_wave_f_proof.sh
@@ -15,24 +15,68 @@ if ! [[ "$N" =~ ^[0-9]+$ ]] || [[ "$N" -lt 1 ]]; then
 fi
 
 MVN_BIN="${MVN_BIN:-mvn}"
+# Fail closed: shaft-engine Surefire hardcodes testFailureIgnore=true so JaCoCo can
+# still report; Maven exit 0 alone is not proof. We also parse Surefire/TestNG XML.
 COMMON_ARGS=(
   -pl shaft-engine
   -Dallure.automaticallyOpen=false
   -DheadlessExecution=true
+  -DexecutionAddress=local
+  -DtargetBrowserName=chrome
   -DfailIfNoTests=false
+  -Dmaven.test.failure.ignore=false
 )
 
 UNIT_TESTS="ElementClassifierTest,InteractionStrategiesActionsTest,PlaywrightInteractionStrategiesUnitTest"
 MICRO_TESTS="ClickTypeMicrobenchTest"
+REPORT_ROOT="${ROOT}/shaft-engine/target/surefire-reports"
+
+assert_surefire_green() {
+  local label="$1"
+  python3 - "$REPORT_ROOT" "$label" <<'PY'
+import pathlib
+import re
+import sys
+
+report_root = pathlib.Path(sys.argv[1])
+label = sys.argv[2]
+failures = 0
+errors = 0
+
+surefire = list(report_root.glob("TEST-*.xml"))
+if surefire:
+    for path in surefire:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        fm = re.search(r'\bfailures="(\d+)"', text)
+        em = re.search(r'\berrors="(\d+)"', text)
+        failures += int(fm.group(1)) if fm else 0
+        errors += int(em.group(1)) if em else 0
+else:
+    testng = report_root / "testng-results.xml"
+    if not testng.is_file():
+        print(f"FAIL: {label} produced no Surefire/TestNG report under {report_root}", file=sys.stderr)
+        sys.exit(1)
+    text = testng.read_text(encoding="utf-8", errors="replace")
+    fm = re.search(r'<testng-results[^>]*\bfailed="(\d+)"', text)
+    failures = int(fm.group(1)) if fm else 0
+
+if failures or errors:
+    print(f"FAIL: {label} reported failures={failures} errors={errors}", file=sys.stderr)
+    sys.exit(1)
+print(f"OK: {label} green (failures=0 errors=0)")
+PY
+}
 
 echo "=== Wave F flake proof: unit subset x${N} (${UNIT_TESTS}) ==="
 for ((i = 1; i <= N; i++)); do
   echo "--- unit run ${i}/${N} ---"
   "${MVN_BIN}" "${COMMON_ARGS[@]}" -Dtest="${UNIT_TESTS}" test
+  assert_surefire_green "unit run ${i}/${N}"
 done
 
 echo "=== Wave F microbench (strategy path + classifier overhead) ==="
 "${MVN_BIN}" "${COMMON_ARGS[@]}" -Dtest="${MICRO_TESTS}" test
+assert_surefire_green "ClickTypeMicrobenchTest"
 
 echo "=== Wave F proof complete (N=${N}) ==="
 echo "Waves D (mobile) / E (desktop UIA matrix): N/A for this PR — web proof only; see epic #5732."

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ClickTypeMicrobenchTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/ClickTypeMicrobenchTest.java
@@ -1,0 +1,194 @@
+package com.shaft.gui.element.internal.interaction;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.ReportManager;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import testPackage.TestPageServer;
+
+import java.lang.reflect.Method;
+
+/**
+ * Wave F (#5732): headless microbench for default happy-path text type + button click,
+ * including an overlay-intercepted click recovered by the Wave B click ladder (JS fallback).
+ *
+ * <p>Baseline vs Wave B/C tradeoff (documented, not a historical checkout):
+ * pre-strategy Selenium TYPE/CLICK for text-like inputs and buttons already used
+ * {@code sendKeys}/{@code WebElement.click()}. Wave B/C add a cheap
+ * {@link ElementClassifier#classify} attribute read before routing; TEXT_LIKE and BUTTON
+ * still execute the same native primitives. Measured classifier overhead is asserted below;
+ * end-to-end SHAFT timings include existing sync/screenshot budget and are logged for CI.
+ */
+@Test(singleThreaded = true)
+public class ClickTypeMicrobenchTest {
+    private static final By NAME = By.id("name");
+    private static final By GO = By.id("go");
+    private static final By RESULT = By.id("result");
+    private static final String SAMPLE = "wave-f-proof";
+    private static final int CLASSIFIER_ITERATIONS = 50_000;
+    /** Pure classify(ElementSignals) budget — excludes Mockito/WebElement I/O. */
+    private static final long CLASSIFIER_BUDGET_NANOS = 100_000_000L; // 100ms for 100k classifications
+    private static final long ACTION_BUDGET_MILLIS = 15_000L;
+
+    private final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
+
+    @BeforeMethod(alwaysRun = true)
+    public void init(Method method) {
+        if ("classifierOverheadStaysNegligibleVersusPreStrategy".equals(method.getName())) {
+            return;
+        }
+        if (!"local".equalsIgnoreCase(SHAFT.Properties.platform.executionAddress())
+                || !"chrome".equalsIgnoreCase(SHAFT.Properties.web.targetBrowserName())) {
+            throw new SkipException("Wave F microbench requires local Chrome.");
+        }
+        SHAFT.Properties.web.set().headlessExecution(true).targetBrowserName("chrome");
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
+        SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(false);
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
+        SHAFT.Properties.flags.set().forceCheckTextWasTypedCorrectly(false);
+        SHAFT.Properties.flags.set().attemptToClickBeforeTyping(false);
+        SHAFT.Properties.visuals.set().createAnimatedGif(false);
+        SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("Never");
+        SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
+        driver.set(new SHAFT.GUI.WebDriver());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tear() {
+        try {
+            if (driver.get() != null) {
+                driver.get().quit();
+            }
+        } finally {
+            driver.remove();
+            Properties.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    public void classifierOverheadStaysNegligibleVersusPreStrategy() {
+        // Measure pure routing cost (ElementSignals), not WebElement attribute I/O / Mockito.
+        ElementSignals text = new ElementSignals(
+                "input", "text", null, null, null, null, null, null, null, null, null, null, null);
+        ElementSignals button = new ElementSignals(
+                "button", "button", null, null, null, null, null, null, null, null, null, null, null);
+
+        ElementClassifier.classify(text);
+        ElementClassifier.classify(button);
+
+        long start = System.nanoTime();
+        for (int i = 0; i < CLASSIFIER_ITERATIONS; i++) {
+            if (ElementClassifier.classify(text) != ElementKind.TEXT_LIKE
+                    || ElementClassifier.classify(button) != ElementKind.BUTTON) {
+                Assert.fail("Unexpected classify result during microbench loop");
+            }
+        }
+        long elapsedNanos = System.nanoTime() - start;
+        double perCallNanos = elapsedNanos / (double) (CLASSIFIER_ITERATIONS * 2L);
+
+        ReportManager.log("Wave F classifier overhead: " + elapsedNanos + " ns for "
+                + (CLASSIFIER_ITERATIONS * 2) + " classify(ElementSignals) calls ("
+                + String.format("%.2f", perCallNanos) + " ns/call)");
+        Assert.assertTrue(elapsedNanos < CLASSIFIER_BUDGET_NANOS,
+                "Classifier overhead exceeded budget: " + elapsedNanos + " ns");
+    }
+
+    @Test
+    public void strategyPathHappyPathTypeAndClickWithinBudget() {
+        SHAFT.GUI.WebDriver shaft = driver.get();
+        shaft.browser().navigateToURL(TestPageServer.url("clickTypeMicrobenchFixture.html"));
+        dismissOverlay(shaft.getDriver());
+
+        // Warm once so the timed section is action-dominated (sync/screenshot already paid).
+        shaft.element().type(NAME, "warmup");
+        shaft.element().click(GO);
+        Assert.assertEquals(shaft.getDriver().findElement(RESULT).getAttribute("data-status"), "clicked");
+
+        shaft.browser().navigateToURL(TestPageServer.url("clickTypeMicrobenchFixture.html"));
+        dismissOverlay(shaft.getDriver());
+
+        long typeStart = System.nanoTime();
+        shaft.element().type(NAME, SAMPLE);
+        long typeMillis = (System.nanoTime() - typeStart) / 1_000_000L;
+
+        long clickStart = System.nanoTime();
+        shaft.element().click(GO);
+        long clickMillis = (System.nanoTime() - clickStart) / 1_000_000L;
+
+        WebElement result = shaft.getDriver().findElement(RESULT);
+        Assert.assertEquals(result.getAttribute("data-status"), "clicked");
+        Assert.assertEquals(result.getText(), "clicked:" + SAMPLE);
+
+        ReportManager.log("Wave F strategy happy-path timing (headless Chrome, overlay dismissed): type="
+                + typeMillis + " ms, click=" + clickMillis + " ms, total="
+                + (typeMillis + clickMillis) + " ms");
+        Assert.assertTrue(typeMillis < ACTION_BUDGET_MILLIS,
+                "Happy-path type exceeded budget: " + typeMillis + " ms");
+        Assert.assertTrue(clickMillis < ACTION_BUDGET_MILLIS,
+                "Happy-path click exceeded budget: " + clickMillis + " ms");
+    }
+
+    @Test
+    public void strategyPathClickThroughOverlayRecoversWithJsFallback() {
+        SHAFT.GUI.WebDriver shaft = driver.get();
+        shaft.browser().navigateToURL(TestPageServer.url("clickTypeMicrobenchFixture.html"));
+
+        shaft.element().type(NAME, SAMPLE);
+
+        // Overlay still present: native click is intercepted; Wave B ladder + JS flag recovers.
+        long clickStart = System.nanoTime();
+        shaft.element().click(GO);
+        long clickMillis = (System.nanoTime() - clickStart) / 1_000_000L;
+
+        WebElement result = shaft.getDriver().findElement(RESULT);
+        Assert.assertEquals(result.getAttribute("data-status"), "clicked");
+        Assert.assertEquals(result.getText(), "clicked:" + SAMPLE);
+
+        ReportManager.log("Wave F strategy click-through-overlay timing (JS fallback): "
+                + clickMillis + " ms");
+        Assert.assertTrue(clickMillis < ACTION_BUDGET_MILLIS,
+                "Overlay click exceeded budget: " + clickMillis + " ms");
+    }
+
+    @Test
+    public void rawSeleniumFloorRemainsAvailableForBaselineComparison() {
+        SHAFT.GUI.WebDriver shaft = driver.get();
+        WebDriver webDriver = shaft.getDriver();
+        webDriver.navigate().to(TestPageServer.url("clickTypeMicrobenchFixture.html"));
+
+        WebElement name = webDriver.findElement(NAME);
+        WebElement go = webDriver.findElement(GO);
+
+        long typeStart = System.nanoTime();
+        name.clear();
+        name.sendKeys(SAMPLE);
+        long typeMillis = (System.nanoTime() - typeStart) / 1_000_000L;
+
+        ((JavascriptExecutor) webDriver).executeScript("window.__shaftDismissOverlay();");
+
+        long clickStart = System.nanoTime();
+        go.click();
+        long clickMillis = (System.nanoTime() - clickStart) / 1_000_000L;
+
+        WebElement result = webDriver.findElement(RESULT);
+        Assert.assertEquals(result.getAttribute("data-status"), "clicked");
+        Assert.assertEquals(result.getText(), "clicked:" + SAMPLE);
+
+        ReportManager.log("Wave F raw Selenium floor timing: type=" + typeMillis
+                + " ms, click=" + clickMillis + " ms (no SHAFT sync/screenshot/classify)");
+        Assert.assertTrue(typeMillis < ACTION_BUDGET_MILLIS);
+        Assert.assertTrue(clickMillis < ACTION_BUDGET_MILLIS);
+    }
+
+    private static void dismissOverlay(WebDriver webDriver) {
+        ((JavascriptExecutor) webDriver).executeScript("window.__shaftDismissOverlay();");
+    }
+}

--- a/shaft-engine/src/test/resources/testDataFiles/clickTypeMicrobenchFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/clickTypeMicrobenchFixture.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Wave F click/type microbench</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; }
+        #overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.35);
+            z-index: 20;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        #overlay.hidden { display: none; }
+        #go { position: relative; z-index: 1; padding: 0.5rem 1rem; }
+        #name { padding: 0.4rem; min-width: 16rem; }
+    </style>
+</head>
+<body>
+<main>
+    <h1 id="ready">Wave F microbench</h1>
+    <label for="name">Name</label>
+    <input id="name" type="text" name="name" autocomplete="off"/>
+    <button id="go" type="button">Go</button>
+    <p id="result" data-status="idle"></p>
+</main>
+<div id="overlay" aria-hidden="false"><span>toast overlay</span></div>
+<script>
+    (function () {
+        var overlay = document.getElementById("overlay");
+        var nameInput = document.getElementById("name");
+        var go = document.getElementById("go");
+        var result = document.getElementById("result");
+
+        // Sticky overlay covers the page so native clicks on #go are intercepted until
+        // dismissed. Wave F measures type on a clear input, then click with JS fallback
+        // (or after dismiss) through the overlay scenario from epic #5732.
+        window.__shaftDismissOverlay = function () {
+            overlay.classList.add("hidden");
+            overlay.setAttribute("aria-hidden", "true");
+        };
+
+        go.addEventListener("click", function () {
+            result.setAttribute("data-status", "clicked");
+            result.textContent = "clicked:" + (nameInput.value || "");
+        });
+    })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Implements **Wave F** of epic #5732: proof for live users that Wave B/C smarter click/type-by-kind is green under flake stress and that default happy-path text type / button click are not slower than pre-strategy in any meaningful way.

- Fixed demo fixture `clickTypeMicrobenchFixture.html` (text input + button + sticky toast overlay)
- Headless microbench `ClickTypeMicrobenchTest` (classifier ns/call, SHAFT happy-path timings, raw Selenium floor, overlay click recovered via Wave B JS fallback ladder)
- `scripts/ci/run_click_type_wave_f_proof.sh [N]` re-runs Wave B/C unit subset N times then the microbench
- Public API unchanged; no new Flags; no Headroom / FreeToken

**Release note blurb:** smarter click/type by control kind

### Baseline vs Wave B/C (tradeoff documented)

Pre-strategy Selenium already used `sendKeys` / native `click` for text-like inputs and buttons. Wave B/C add a cheap `ElementClassifier.classify` before routing; TEXT_LIKE / BUTTON still execute those same native primitives.

| Measurement (local headless Chrome) | Result |
| --- | --- |
| Classifier (`ElementSignals`) | ~150–213 ns/call (100k loop) |
| Raw Selenium floor | type ~40–53 ms, click ~21–28 ms |
| SHAFT strategy happy-path (overlay dismissed) | type ~477–478 ms, click ~474–477 ms |
| SHAFT click-through-overlay (JS fallback on) | ~2606–2607 ms (reliability path; expected slower) |

SHAFT wall-clock is dominated by existing sync/reporting, not classification. Overlay recovery pays the click-ladder cost by design.

### Waves D / E

**N/A for this PR** — no blocking web gap found that Wave F cannot prove without mobile/desktop. Desktop UIA matrix and Appium/Compose paths remain epic follow-ups.

## Test plan

- [x] `ClickTypeMicrobenchTest` (4 cases) green headless
- [x] Wave B/C unit subset green **N=3**:
  `ElementClassifierTest`, `InteractionStrategiesActionsTest`, `PlaywrightInteractionStrategiesUnitTest`
  (65 Surefire tests / run; 26 TestNG-reported methods; Failures: 0 each run)

```bash
bash scripts/ci/run_click_type_wave_f_proof.sh 3
# or:
mvn -pl shaft-engine -Dtest=ElementClassifierTest,InteractionStrategiesActionsTest,PlaywrightInteractionStrategiesUnitTest -Dallure.automaticallyOpen=false -DheadlessExecution=true test
mvn -pl shaft-engine -Dtest=ClickTypeMicrobenchTest -Dallure.automaticallyOpen=false -DheadlessExecution=true test
```

## N-run evidence

| Run | Suite | Result |
| --- | --- | --- |
| 1/3 | Wave B/C unit subset | BUILD SUCCESS — Tests run: 65, Failures: 0 |
| 2/3 | Wave B/C unit subset | BUILD SUCCESS — Tests run: 65, Failures: 0 |
| 3/3 | Wave B/C unit subset | BUILD SUCCESS — Tests run: 65, Failures: 0 |
| microbench | `ClickTypeMicrobenchTest` | BUILD SUCCESS — Tests run: 4, Failures: 0 |

## Related

Related to #5732 (Wave F). Does not close the epic (D/E remain optional follow-ups).

## Documentation Site

- Documentation not required because: proof/tests only; public fluent API unchanged; user-facing strategy docs were Wave A scope.

## Out of scope

Headroom, FreeToken/`ft launch`, Cloud Agents, re-implementing Wave B/C strategy matrices, mobile (D), desktop UIA (E).