### PR TITLE
feat(element): Wave D mobile click/type strategies (#5732)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -764,7 +764,13 @@ public class Actions extends ElementActions {
                         String expectedText = shouldValidateTypedText
                                 ? readElementValueForTyping(targetElement) + stringifyTypedValue(text)
                                 : "";
-                        targetElement.sendKeys(text);
+                        if (isMobileNativeExecution) {
+                            ClickStrategies.focusTap(d, targetElement);
+                            TypeStrategies.typeMobileText(d, targetElement, text, false);
+                            TypeStrategies.hideKeyboardIfConfigured(d, SHAFT.Properties.flags.hideKeyboardAfterTyping());
+                        } else {
+                            targetElement.sendKeys(text);
+                        }
                         validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
                     }
                     case JAVASCRIPT_SET_VALUE ->
@@ -1182,8 +1188,11 @@ public class Actions extends ElementActions {
             executeClearBasedOnClearMode(targetElement, clearMode);
         }
 
-        if (mobileRoute == TypeStrategies.MobileTypeRoute.MOBILE_TEXT) {
-            TypeStrategies.typeMobileText(d, targetElement, text);
+        // replaceElementValue wipes the field — only when clear mode is not "off" (mobile default is off).
+        boolean replaceAllowed = !"off".equals(clearMode);
+        if (mobileRoute == TypeStrategies.MobileTypeRoute.MOBILE_TEXT
+                || mobileRoute == TypeStrategies.MobileTypeRoute.LEGACY_SEND_KEYS) {
+            TypeStrategies.typeMobileText(d, targetElement, text, replaceAllowed);
         } else {
             targetElement.sendKeys(text);
         }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -670,11 +670,13 @@ public class Actions extends ElementActions {
                                 : foundElements.get().getFirst();
                         screenshot.set(0, takeActionScreenshot(targetElement));
                         // Wave B (#5732): native → scroll/stabilize retry → flagged JS; preserve exception when JS off.
+                        // Wave D: mobile native uses W3C touch tap when WebDriver click flakes (web defaults unchanged).
                         ClickStrategies.click(
                                 d,
                                 targetElement,
                                 ElementClassifier.classify(targetElement),
-                                SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails());
+                                SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails(),
+                                isMobileNativeExecution);
                     }
                     case JAVASCRIPT_CLICK -> {
                         screenshot.set(0, takeActionScreenshot(foundElements.get().getFirst()));
@@ -721,34 +723,38 @@ public class Actions extends ElementActions {
                         WebElement targetElement = foundElements.get().getFirst();
                         CharSequence[] text = (CharSequence[]) data;
                         ElementKind kind = ElementClassifier.classify(targetElement);
-                        TypeStrategies.TypeRoute typeRoute = TypeStrategies.routeFor(kind);
-                        if (typeRoute == TypeStrategies.TypeRoute.REJECT) {
-                            TypeStrategies.rejectUnsupported(kind);
-                        } else if (typeRoute == TypeStrategies.TypeRoute.TOGGLE_CLICK) {
-                            TypeStrategies.toggleInsteadOfTyping(targetElement, kind);
-                        } else if (typeRoute == TypeStrategies.TypeRoute.SELECT_OPTION) {
-                            selectValue(targetElement, locator, stringifyTypedValue(text));
-                        } else if (typeRoute == TypeStrategies.TypeRoute.SET_FILES) {
-                            typeFileLocationForUpload(targetElement, locator, stringifyTypedValue(text));
-                        } else if (typeRoute == TypeStrategies.TypeRoute.SET_VALUE_WITH_EVENTS) {
-                            TypeStrategies.setValueWithEvents(d, targetElement, stringifyTypedValue(text));
-                        } else if (typeRoute == TypeStrategies.TypeRoute.CONTENTEDITABLE) {
-                            boolean clearBefore = !"off".equals(SHAFT.Properties.flags.clearBeforeTypingMode());
-                            TypeStrategies.typeContentEditable(d, targetElement, text, clearBefore);
+                        if (isMobileNativeExecution) {
+                            performMobileNativeType(d, targetElement, kind, text, action);
                         } else {
-                            // TEXT_LIKE / COMBOBOX / UNKNOWN — legacy clear+sendKeys honors existing flags.
-                            String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
-                            String typedText = stringifyTypedValue(text);
-                            boolean shouldValidateTypedText = shouldValidateTypedText(text);
-                            String expectedText = shouldValidateTypedText && "off".equals(clearMode)
-                                    ? readElementValueForTyping(targetElement) + typedText
-                                    : typedText;
-                            if (SHAFT.Properties.flags.attemptToClickBeforeTyping() && !"native".equals(clearMode)) {
-                                targetElement.click();
+                            TypeStrategies.TypeRoute typeRoute = TypeStrategies.routeFor(kind);
+                            if (typeRoute == TypeStrategies.TypeRoute.REJECT) {
+                                TypeStrategies.rejectUnsupported(kind);
+                            } else if (typeRoute == TypeStrategies.TypeRoute.TOGGLE_CLICK) {
+                                TypeStrategies.toggleInsteadOfTyping(targetElement, kind);
+                            } else if (typeRoute == TypeStrategies.TypeRoute.SELECT_OPTION) {
+                                selectValue(targetElement, locator, stringifyTypedValue(text));
+                            } else if (typeRoute == TypeStrategies.TypeRoute.SET_FILES) {
+                                typeFileLocationForUpload(targetElement, locator, stringifyTypedValue(text));
+                            } else if (typeRoute == TypeStrategies.TypeRoute.SET_VALUE_WITH_EVENTS) {
+                                TypeStrategies.setValueWithEvents(d, targetElement, stringifyTypedValue(text));
+                            } else if (typeRoute == TypeStrategies.TypeRoute.CONTENTEDITABLE) {
+                                boolean clearBefore = !"off".equals(SHAFT.Properties.flags.clearBeforeTypingMode());
+                                TypeStrategies.typeContentEditable(d, targetElement, text, clearBefore);
+                            } else {
+                                // TEXT_LIKE / COMBOBOX / UNKNOWN — legacy clear+sendKeys honors existing flags.
+                                String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
+                                String typedText = stringifyTypedValue(text);
+                                boolean shouldValidateTypedText = shouldValidateTypedText(text);
+                                String expectedText = shouldValidateTypedText && "off".equals(clearMode)
+                                        ? readElementValueForTyping(targetElement) + typedText
+                                        : typedText;
+                                if (SHAFT.Properties.flags.attemptToClickBeforeTyping() && !"native".equals(clearMode)) {
+                                    targetElement.click();
+                                }
+                                executeClearBasedOnClearMode(targetElement, clearMode);
+                                targetElement.sendKeys(text);
+                                validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
                             }
-                            executeClearBasedOnClearMode(targetElement, clearMode);
-                            targetElement.sendKeys(text);
-                            validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
                         }
                     }
                     case TYPE_APPEND -> {
@@ -1138,6 +1144,51 @@ public class Actions extends ElementActions {
                 }
             }
         }
+    }
+
+    /**
+     * Wave D (#5732): mobile-native type — focus (tap) → clear flags → setValue/sendKeys/{@code mobile: type}
+     * → optional {@code hideKeyboardAfterTyping}. Checkbox/Switch toggle; never blind sendKeys on toggles.
+     */
+    private void performMobileNativeType(WebDriver d, WebElement targetElement, ElementKind kind,
+                                         CharSequence[] text, ActionType action) {
+        TypeStrategies.MobileTypeRoute mobileRoute = TypeStrategies.mobileRouteFor(kind);
+        if (mobileRoute == TypeStrategies.MobileTypeRoute.REJECT) {
+            TypeStrategies.rejectUnsupported(kind);
+            return;
+        }
+        if (mobileRoute == TypeStrategies.MobileTypeRoute.TOGGLE_CLICK) {
+            TypeStrategies.toggleMobileInsteadOfTyping(d, targetElement, kind);
+            return;
+        }
+
+        String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
+        String typedText = stringifyTypedValue(text);
+        boolean shouldValidateTypedText = shouldValidateTypedText(text);
+        String expectedText = shouldValidateTypedText && "off".equals(clearMode)
+                ? readElementValueForTyping(targetElement) + typedText
+                : typedText;
+
+        // Always focus before typing on mobile native (Compose/Flutter require it; honors research ladder).
+        ClickStrategies.focusTap(d, targetElement);
+        if ("native".equals(clearMode)) {
+            // focusTap already clicked; clear without a second click.
+            try {
+                targetElement.clear();
+            } catch (RuntimeException ignored) {
+                executeClearBasedOnClearMode(targetElement, "backspace");
+            }
+        } else {
+            executeClearBasedOnClearMode(targetElement, clearMode);
+        }
+
+        if (mobileRoute == TypeStrategies.MobileTypeRoute.MOBILE_TEXT) {
+            TypeStrategies.typeMobileText(d, targetElement, text);
+        } else {
+            targetElement.sendKeys(text);
+        }
+        TypeStrategies.hideKeyboardIfConfigured(d, SHAFT.Properties.flags.hideKeyboardAfterTyping());
+        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
     }
 
     private void executeClearBasedOnClearMode(WebElement elem, String clearMode) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
@@ -45,21 +45,10 @@ public final class ClickStrategies {
         }
         try {
             element.click();
-        } catch (RuntimeException firstFailure) {
+        } catch (InvalidElementStateException firstFailure) {
             if (mobileNativeTouchFallback) {
-                // Broader than web: Appium often wraps click flakes outside InvalidElementStateException.
-                stabilizeMobile(driver, element);
-                try {
-                    element.click();
-                } catch (RuntimeException retryFailure) {
-                    tapWithTouch(driver, element);
-                    ReportManager.logDiscrete(
-                            "Performed Click using W3C touch tap after WebDriver click failed on mobile native.");
-                }
+                retryMobileNativeClick(driver, element);
                 return;
-            }
-            if (!(firstFailure instanceof InvalidElementStateException)) {
-                throw firstFailure;
             }
             stabilize(driver, element);
             try {
@@ -73,6 +62,24 @@ public final class ClickStrategies {
                     throw retryFailure;
                 }
             }
+        } catch (RuntimeException firstFailure) {
+            // Broader than web: Appium often wraps click flakes outside InvalidElementStateException.
+            if (mobileNativeTouchFallback) {
+                retryMobileNativeClick(driver, element);
+                return;
+            }
+            throw firstFailure;
+        }
+    }
+
+    private static void retryMobileNativeClick(WebDriver driver, WebElement element) {
+        stabilizeMobile(driver, element);
+        try {
+            element.click();
+        } catch (RuntimeException retryFailure) {
+            tapWithTouch(driver, element);
+            ReportManager.logDiscrete(
+                    "Performed Click using W3C touch tap after WebDriver click failed on mobile native.");
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
@@ -1,25 +1,44 @@
 package com.shaft.gui.element.internal.interaction;
 
 import com.shaft.tools.io.ReportManager;
+import io.appium.java_client.AppiumDriver;
 import org.openqa.selenium.InvalidElementStateException;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Pause;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
+
+import java.time.Duration;
+import java.util.List;
 
 /**
  * Selenium click ladder: native click → optional scroll/stabilize retry → flagged JS fallback.
- * When JS fallback is off, the native {@link InvalidElementStateException} is preserved.
+ * Mobile native (#5732 Wave D): native click → W3C touch tap when WebDriver click flakes
+ * (does not change desktop/web defaults; JS fallback stays web-oriented).
  */
 public final class ClickStrategies {
 
     private static final String JS_CLICK = "arguments[0].click();";
     private static final String JS_SCROLL_CENTER = """
             arguments[0].scrollIntoView({behavior: "auto", block: "center", inline: "center"});""";
+    private static final Duration TOUCH_PAUSE = Duration.ofMillis(100);
 
     private ClickStrategies() {
     }
 
     public static void click(WebDriver driver, WebElement element, ElementKind kind, boolean javascriptFallbackEnabled) {
+        click(driver, element, kind, javascriptFallbackEnabled, false);
+    }
+
+    /**
+     * @param mobileNativeTouchFallback when true (mobile native only), retry failed clicks with a W3C
+     *                                  touch tap instead of JavaScript click
+     */
+    public static void click(WebDriver driver, WebElement element, ElementKind kind,
+                             boolean javascriptFallbackEnabled, boolean mobileNativeTouchFallback) {
         if (kind == ElementKind.DISABLED) {
             throw new InvalidElementStateException(
                     "Refusing to click a disabled/readonly/aria-disabled element.");
@@ -27,6 +46,17 @@ public final class ClickStrategies {
         try {
             element.click();
         } catch (InvalidElementStateException firstFailure) {
+            if (mobileNativeTouchFallback) {
+                stabilizeMobile(driver, element);
+                try {
+                    element.click();
+                } catch (RuntimeException retryFailure) {
+                    tapWithTouch(driver, element);
+                    ReportManager.logDiscrete(
+                            "Performed Click using W3C touch tap after WebDriver click failed on mobile native.");
+                }
+                return;
+            }
             stabilize(driver, element);
             try {
                 element.click();
@@ -42,12 +72,52 @@ public final class ClickStrategies {
         }
     }
 
+    /**
+     * Best-effort focus tap for mobile typing: WebDriver click, then W3C touch if needed.
+     */
+    public static void focusTap(WebDriver driver, WebElement element) {
+        try {
+            element.click();
+        } catch (RuntimeException ignored) {
+            tapWithTouch(driver, element);
+        }
+    }
+
+    static void tapWithTouch(WebDriver driver, WebElement element) {
+        if (!(driver instanceof AppiumDriver appiumDriver)) {
+            throw new InvalidElementStateException(
+                    "Mobile touch tap fallback requires an AppiumDriver session.");
+        }
+        Rectangle rect = element.getRect();
+        int x = rect.getX() + Math.max(rect.getWidth() / 2, 1);
+        int y = rect.getY() + Math.max(rect.getHeight() / 2, 1);
+        PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "shaft-mobile-finger");
+        Sequence tap = new Sequence(finger, 0);
+        PointerInput.Origin view = PointerInput.Origin.viewport();
+        tap.addAction(finger.createPointerMove(Duration.ZERO, view, x, y));
+        tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+        tap.addAction(new Pause(finger, TOUCH_PAUSE));
+        tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+        appiumDriver.perform(List.of(tap));
+    }
+
     private static void stabilize(WebDriver driver, WebElement element) {
         if (driver instanceof JavascriptExecutor executor) {
             try {
                 executor.executeScript(JS_SCROLL_CENTER, element);
             } catch (RuntimeException ignored) {
                 // Best-effort scroll before retry; native exception still drives fallback/fail.
+            }
+        }
+    }
+
+    private static void stabilizeMobile(WebDriver driver, WebElement element) {
+        // Native contexts rarely support DOM scrollIntoView; keep a no-op hook for symmetry.
+        if (driver instanceof JavascriptExecutor executor) {
+            try {
+                executor.executeScript(JS_SCROLL_CENTER, element);
+            } catch (RuntimeException ignored) {
+                // Ignore — touch fallback follows.
             }
         }
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
@@ -45,8 +45,9 @@ public final class ClickStrategies {
         }
         try {
             element.click();
-        } catch (InvalidElementStateException firstFailure) {
+        } catch (RuntimeException firstFailure) {
             if (mobileNativeTouchFallback) {
+                // Broader than web: Appium often wraps click flakes outside InvalidElementStateException.
                 stabilizeMobile(driver, element);
                 try {
                     element.click();
@@ -56,6 +57,9 @@ public final class ClickStrategies {
                             "Performed Click using W3C touch tap after WebDriver click failed on mobile native.");
                 }
                 return;
+            }
+            if (!(firstFailure instanceof InvalidElementStateException)) {
+                throw firstFailure;
             }
             stabilize(driver, element);
             try {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -53,9 +53,15 @@ public final class ElementClassifier {
         String tag = safeLower(signals.tagName());
         String type = safeLower(signals.type());
         String role = safeLower(signals.role());
+        String className = safeLower(signals.className());
 
         if (isContentEditable(signals)) {
             return ElementKind.CONTENTEDITABLE;
+        }
+
+        ElementKind byMobile = classifyMobileNative(tag, className, role);
+        if (byMobile != null) {
+            return byMobile;
         }
 
         ElementKind byTag = classifyByTag(tag, role);
@@ -68,6 +74,86 @@ public final class ElementClassifier {
         }
 
         return classifyByRole(role);
+    }
+
+    /**
+     * Appium native class / XCUI / Flutter-ish tags. Returns null when not a known mobile control.
+     * Conservative: only exact / well-known suffixes so custom views stay {@link ElementKind#UNKNOWN}.
+     */
+    static ElementKind classifyMobileNative(String tag, String className, String role) {
+        String token = firstNonBlank(tag, className);
+        if (token == null) {
+            return null;
+        }
+        String simple = simpleClassName(token);
+
+        if (isMobileToggle(simple, role)) {
+            return ElementKind.CHECKBOX;
+        }
+        if (isMobileRadio(simple, role)) {
+            return ElementKind.RADIO;
+        }
+        if (isMobileTextField(simple, role)) {
+            return ElementKind.TEXT_LIKE;
+        }
+        if (isMobileButton(simple, role)) {
+            return ElementKind.BUTTON;
+        }
+        if (isMobileLink(simple, role)) {
+            return ElementKind.LINK;
+        }
+        if ("seekbar".equals(simple) || "slider".equals(simple) || "xcuielementtypeslider".equals(simple)) {
+            return ElementKind.RANGE;
+        }
+        return null;
+    }
+
+    private static boolean isMobileToggle(String simple, String role) {
+        return "checkbox".equals(role)
+                || "switch".equals(role)
+                || "checkbox".equals(simple)
+                || "switch".equals(simple)
+                || "togglebutton".equals(simple)
+                || "xcuielementtypeswitch".equals(simple)
+                || "xcuielementtypecheckbox".equals(simple);
+    }
+
+    private static boolean isMobileRadio(String simple, String role) {
+        return "radio".equals(role)
+                || "radiobutton".equals(simple)
+                || "xcuielementtyperadiobutton".equals(simple);
+    }
+
+    private static boolean isMobileTextField(String simple, String role) {
+        if (role != null && TEXT_ROLES.contains(role)) {
+            return true;
+        }
+        return "edittext".equals(simple)
+                || "textfield".equals(simple)
+                || "autocompletetextview".equals(simple)
+                || "multiautocompletetextview".equals(simple)
+                || "xcuielementtypetextfield".equals(simple)
+                || "xcuielementtypesecuretextfield".equals(simple)
+                || "xcuielementtypetextview".equals(simple)
+                // Flutter integration driver type names (ValueKey / Semantics still required by apps).
+                || "editabletext".equals(simple);
+    }
+
+    private static boolean isMobileButton(String simple, String role) {
+        return "button".equals(role)
+                || "button".equals(simple)
+                || "imagebutton".equals(simple)
+                || "xcuielementtypebutton".equals(simple);
+    }
+
+    private static boolean isMobileLink(String simple, String role) {
+        return "link".equals(role) || "xcuielementtypelink".equals(simple);
+    }
+
+    private static String simpleClassName(String raw) {
+        String lower = raw.toLowerCase(Locale.ROOT);
+        int slash = Math.max(lower.lastIndexOf('.'), lower.lastIndexOf('/'));
+        return slash >= 0 && slash + 1 < lower.length() ? lower.substring(slash + 1) : lower;
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -2,9 +2,11 @@ package com.shaft.gui.element.internal.interaction;
 
 import org.openqa.selenium.WebElement;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 /**
  * Cheap classifier: tagName, type, role/ARIA, contenteditable, disabled flags.
@@ -21,6 +23,54 @@ public final class ElementClassifier {
             "button", "submit", "reset", "image");
     private static final Set<String> TEXT_ROLES = Set.of(
             "textbox", "searchbox", "spinbutton");
+
+    /** Android / generic toggle class suffixes (lowered simple names). */
+    private static final Set<String> MOBILE_TOGGLE_CLASSES = Set.of(
+            "checkbox", "switch", "togglebutton");
+    /** iOS XCUI toggle class suffixes. */
+    private static final Set<String> IOS_TOGGLE_CLASSES = Set.of(
+            "xcuielementtypeswitch", "xcuielementtypecheckbox");
+    private static final Set<String> MOBILE_TOGGLE_ROLES = Set.of("checkbox", "switch");
+
+    private static final Set<String> MOBILE_RADIO_CLASSES = Set.of(
+            "radiobutton", "xcuielementtyperadiobutton");
+    private static final Set<String> MOBILE_RADIO_ROLES = Set.of("radio");
+
+    /** Android / Flutter text-entry class suffixes. */
+    private static final Set<String> MOBILE_TEXT_CLASSES = Set.of(
+            "edittext", "textfield", "autocompletetextview", "multiautocompletetextview",
+            // Flutter integration driver type names (ValueKey / Semantics still required by apps).
+            "editabletext");
+    /** iOS XCUI text-entry class suffixes. */
+    private static final Set<String> IOS_TEXT_CLASSES = Set.of(
+            "xcuielementtypetextfield", "xcuielementtypesecuretextfield", "xcuielementtypetextview");
+
+    private static final Set<String> MOBILE_BUTTON_CLASSES = Set.of(
+            "button", "imagebutton", "xcuielementtypebutton");
+    private static final Set<String> MOBILE_BUTTON_ROLES = Set.of("button");
+
+    private static final Set<String> MOBILE_LINK_CLASSES = Set.of("xcuielementtypelink");
+    private static final Set<String> MOBILE_LINK_ROLES = Set.of("link");
+
+    private static final Set<String> MOBILE_RANGE_CLASSES = Set.of(
+            "seekbar", "slider", "xcuielementtypeslider");
+
+    /**
+     * First-match-wins mobile kind rules. A loop over this table (rather than a sequential
+     * if-return chain) keeps {@link #classifyMobileNative} NPath under Codacy/PMD's gate —
+     * NPath multiplies across sequential branches even when each guard is a trivial call.
+     */
+    private static final List<MobileKindRule> MOBILE_KIND_RULES = List.of(
+            new MobileKindRule(ElementClassifier::isMobileToggle, ElementKind.CHECKBOX),
+            new MobileKindRule(ElementClassifier::isMobileRadio, ElementKind.RADIO),
+            new MobileKindRule(ElementClassifier::isMobileTextField, ElementKind.TEXT_LIKE),
+            new MobileKindRule(ElementClassifier::isMobileButton, ElementKind.BUTTON),
+            new MobileKindRule(ElementClassifier::isMobileLink, ElementKind.LINK),
+            // Range is class-suffix only; role "slider" stays on classifyByRole for non-mobile tags.
+            new MobileKindRule((simple, role) -> isMobileRange(simple), ElementKind.RANGE));
+
+    private record MobileKindRule(BiPredicate<String, String> matches, ElementKind kind) {
+    }
 
     private ElementClassifier() {
     }
@@ -86,68 +136,44 @@ public final class ElementClassifier {
             return null;
         }
         String simple = simpleClassName(token);
-
-        if (isMobileToggle(simple, role)) {
-            return ElementKind.CHECKBOX;
-        }
-        if (isMobileRadio(simple, role)) {
-            return ElementKind.RADIO;
-        }
-        if (isMobileTextField(simple, role)) {
-            return ElementKind.TEXT_LIKE;
-        }
-        if (isMobileButton(simple, role)) {
-            return ElementKind.BUTTON;
-        }
-        if (isMobileLink(simple, role)) {
-            return ElementKind.LINK;
-        }
-        if ("seekbar".equals(simple) || "slider".equals(simple) || "xcuielementtypeslider".equals(simple)) {
-            return ElementKind.RANGE;
+        for (MobileKindRule rule : MOBILE_KIND_RULES) {
+            if (rule.matches().test(simple, role)) {
+                return rule.kind();
+            }
         }
         return null;
     }
 
     private static boolean isMobileToggle(String simple, String role) {
-        return "checkbox".equals(role)
-                || "switch".equals(role)
-                || "checkbox".equals(simple)
-                || "switch".equals(simple)
-                || "togglebutton".equals(simple)
-                || "xcuielementtypeswitch".equals(simple)
-                || "xcuielementtypecheckbox".equals(simple);
+        return roleMatches(role, MOBILE_TOGGLE_ROLES)
+                || MOBILE_TOGGLE_CLASSES.contains(simple)
+                || IOS_TOGGLE_CLASSES.contains(simple);
     }
 
     private static boolean isMobileRadio(String simple, String role) {
-        return "radio".equals(role)
-                || "radiobutton".equals(simple)
-                || "xcuielementtyperadiobutton".equals(simple);
+        return roleMatches(role, MOBILE_RADIO_ROLES) || MOBILE_RADIO_CLASSES.contains(simple);
     }
 
     private static boolean isMobileTextField(String simple, String role) {
-        if (role != null && TEXT_ROLES.contains(role)) {
-            return true;
-        }
-        return "edittext".equals(simple)
-                || "textfield".equals(simple)
-                || "autocompletetextview".equals(simple)
-                || "multiautocompletetextview".equals(simple)
-                || "xcuielementtypetextfield".equals(simple)
-                || "xcuielementtypesecuretextfield".equals(simple)
-                || "xcuielementtypetextview".equals(simple)
-                // Flutter integration driver type names (ValueKey / Semantics still required by apps).
-                || "editabletext".equals(simple);
+        return roleMatches(role, TEXT_ROLES)
+                || MOBILE_TEXT_CLASSES.contains(simple)
+                || IOS_TEXT_CLASSES.contains(simple);
     }
 
     private static boolean isMobileButton(String simple, String role) {
-        return "button".equals(role)
-                || "button".equals(simple)
-                || "imagebutton".equals(simple)
-                || "xcuielementtypebutton".equals(simple);
+        return roleMatches(role, MOBILE_BUTTON_ROLES) || MOBILE_BUTTON_CLASSES.contains(simple);
     }
 
     private static boolean isMobileLink(String simple, String role) {
-        return "link".equals(role) || "xcuielementtypelink".equals(simple);
+        return roleMatches(role, MOBILE_LINK_ROLES) || MOBILE_LINK_CLASSES.contains(simple);
+    }
+
+    private static boolean isMobileRange(String simple) {
+        return MOBILE_RANGE_CLASSES.contains(simple);
+    }
+
+    private static boolean roleMatches(String role, Set<String> roles) {
+        return role != null && roles.contains(role);
     }
 
     private static String simpleClassName(String raw) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -188,14 +188,20 @@ public final class TypeStrategies {
      * Mobile native text entry after the caller has focused (and optionally cleared) the field.
      * Ladder: {@code sendKeys} → Android {@code mobile: replaceElementValue} (replace/clear modes only)
      * → {@code mobile: type}. Compose/Flutter rejections without focus surface an actionable error.
-     *
-     * @param replaceAllowed when false ({@code clearBeforeTypingMode=off} / append), skip
-     *                       {@code replaceElementValue} so existing text is not wiped
+     * Defaults to replace-allowed ({@code replaceAllowed=true}).
      */
     public static void typeMobileText(WebDriver driver, WebElement element, CharSequence[] text) {
         typeMobileText(driver, element, text, true);
     }
 
+    /**
+     * Mobile native text entry after the caller has focused (and optionally cleared) the field.
+     * Ladder: {@code sendKeys} → Android {@code mobile: replaceElementValue} (replace/clear modes only)
+     * → {@code mobile: type}. Compose/Flutter rejections without focus surface an actionable error.
+     *
+     * @param replaceAllowed when false ({@code clearBeforeTypingMode=off} / append), skip
+     *                       {@code replaceElementValue} so existing text is not wiped
+     */
     public static void typeMobileText(WebDriver driver, WebElement element, CharSequence[] text,
                                       boolean replaceAllowed) {
         String typed = stringify(text);

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -100,9 +100,9 @@ public final class TypeStrategies {
     public static MobileTypeRoute mobileRouteFor(ElementKind kind) {
         return switch (kind) {
             case CHECKBOX, RADIO -> MobileTypeRoute.TOGGLE_CLICK;
-            case DISABLED, READONLY, IFRAME, FILE, SELECT -> MobileTypeRoute.REJECT;
-            case TEXT_LIKE, COMBOBOX, DATE_LIKE, RANGE, COLOR, CONTENTEDITABLE, UNKNOWN ->
-                    MobileTypeRoute.MOBILE_TEXT;
+            // SeekBar/slider/date/color need platform value APIs — do not pretend sendKeys works.
+            case DISABLED, READONLY, IFRAME, FILE, SELECT, RANGE, DATE_LIKE, COLOR -> MobileTypeRoute.REJECT;
+            case TEXT_LIKE, COMBOBOX, CONTENTEDITABLE, UNKNOWN -> MobileTypeRoute.MOBILE_TEXT;
             case BUTTON, LINK -> MobileTypeRoute.LEGACY_SEND_KEYS;
         };
     }
@@ -186,10 +186,18 @@ public final class TypeStrategies {
 
     /**
      * Mobile native text entry after the caller has focused (and optionally cleared) the field.
-     * Ladder: {@code sendKeys} → Android {@code mobile: replaceElementValue} → {@code mobile: type}.
-     * Compose/Flutter rejections without focus surface an actionable error.
+     * Ladder: {@code sendKeys} → Android {@code mobile: replaceElementValue} (replace/clear modes only)
+     * → {@code mobile: type}. Compose/Flutter rejections without focus surface an actionable error.
+     *
+     * @param replaceAllowed when false ({@code clearBeforeTypingMode=off} / append), skip
+     *                       {@code replaceElementValue} so existing text is not wiped
      */
     public static void typeMobileText(WebDriver driver, WebElement element, CharSequence[] text) {
+        typeMobileText(driver, element, text, true);
+    }
+
+    public static void typeMobileText(WebDriver driver, WebElement element, CharSequence[] text,
+                                      boolean replaceAllowed) {
         String typed = stringify(text);
         RuntimeException lastFailure = null;
 
@@ -201,7 +209,9 @@ public final class TypeStrategies {
             ReportManager.logDiscrete("mobile sendKeys failed; trying platform setValue / mobile: type.");
         }
 
-        if (driver instanceof CanReplaceElementValue replacer && element instanceof RemoteWebElement remote) {
+        if (replaceAllowed
+                && driver instanceof CanReplaceElementValue replacer
+                && element instanceof RemoteWebElement remote) {
             try {
                 replacer.replaceElementValue(remote, typed);
                 return;
@@ -222,14 +232,6 @@ public final class TypeStrategies {
         }
 
         throw actionableMobileTypeFailure(element, lastFailure);
-    }
-
-    /**
-     * Focus (tap) then type for mobile native text-like controls.
-     */
-    public static void focusAndTypeMobile(WebDriver driver, WebElement element, CharSequence[] text) {
-        ClickStrategies.focusTap(driver, element);
-        typeMobileText(driver, element, text);
     }
 
     public static void hideKeyboardIfConfigured(WebDriver driver, boolean hideKeyboardAfterTyping) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -1,15 +1,28 @@
 package com.shaft.gui.element.internal.interaction;
 
 import com.shaft.tools.io.ReportManager;
+import io.appium.java_client.HidesKeyboard;
+import io.appium.java_client.android.CanReplaceElementValue;
 import org.openqa.selenium.InvalidElementStateException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Routes {@code type} by {@link ElementKind} so checkbox/radio/select/file/date/contenteditable
  * never take the blind clear+sendKeys path. Unknown kinds stay on the legacy caller path.
+ * Mobile native (#5732 Wave D): focus → setValue / sendKeys / {@code mobile: type} → optional hideKeyboard.
+ *
+ * <p><b>Compose / Flutter notes:</b> Jetpack Compose TextFields often reject setValue/sendKeys until
+ * focused (enable {@code testTagsAsResourceId} and tap first). Flutter TextFields need ValueKey /
+ * Semantics identifiers; after focus prefer driver sendKeys or {@code flutter:*} enter-text helpers.
+ * When setValue is rejected without focus, SHAFT throws an actionable {@link InvalidElementStateException}.
  */
 public final class TypeStrategies {
 
@@ -59,6 +72,15 @@ public final class TypeStrategies {
         REJECT
     }
 
+    /** Mobile-native type routes (Wave D). */
+    public enum MobileTypeRoute {
+        TOGGLE_CLICK,
+        MOBILE_TEXT,
+        REJECT,
+        /** Unknown / button / link — keep sendKeys after focus for conservative compatibility. */
+        LEGACY_SEND_KEYS
+    }
+
     private TypeStrategies() {
     }
 
@@ -72,6 +94,16 @@ public final class TypeStrategies {
             // Readonly/disabled/iframe: refuse type. Button/link stay legacy (conservative).
             case DISABLED, READONLY, IFRAME -> TypeRoute.REJECT;
             case TEXT_LIKE, COMBOBOX, BUTTON, LINK, UNKNOWN -> TypeRoute.LEGACY_SEND_KEYS;
+        };
+    }
+
+    public static MobileTypeRoute mobileRouteFor(ElementKind kind) {
+        return switch (kind) {
+            case CHECKBOX, RADIO -> MobileTypeRoute.TOGGLE_CLICK;
+            case DISABLED, READONLY, IFRAME, FILE, SELECT -> MobileTypeRoute.REJECT;
+            case TEXT_LIKE, COMBOBOX, DATE_LIKE, RANGE, COLOR, CONTENTEDITABLE, UNKNOWN ->
+                    MobileTypeRoute.MOBILE_TEXT;
+            case BUTTON, LINK -> MobileTypeRoute.LEGACY_SEND_KEYS;
         };
     }
 
@@ -102,6 +134,14 @@ public final class TypeStrategies {
     public static void toggleInsteadOfTyping(WebElement element, ElementKind kind) {
         ReportManager.logDiscrete("type() on " + kind + " redirected to click (toggle); sendKeys skipped.");
         element.click();
+    }
+
+    /**
+     * Mobile checkbox/switch/radio: toggle via click/tap, never sendKeys.
+     */
+    public static void toggleMobileInsteadOfTyping(WebDriver driver, WebElement element, ElementKind kind) {
+        ReportManager.logDiscrete("type() on mobile " + kind + " redirected to tap (toggle); sendKeys skipped.");
+        ClickStrategies.focusTap(driver, element);
     }
 
     public static void setValueWithEvents(WebDriver driver, WebElement element, String text) {
@@ -144,7 +184,104 @@ public final class TypeStrategies {
         element.sendKeys(absoluteFilePath);
     }
 
-    private static String stringify(CharSequence[] text) {
+    /**
+     * Mobile native text entry after the caller has focused (and optionally cleared) the field.
+     * Ladder: {@code sendKeys} → Android {@code mobile: replaceElementValue} → {@code mobile: type}.
+     * Compose/Flutter rejections without focus surface an actionable error.
+     */
+    public static void typeMobileText(WebDriver driver, WebElement element, CharSequence[] text) {
+        String typed = stringify(text);
+        RuntimeException lastFailure = null;
+
+        try {
+            element.sendKeys(text);
+            return;
+        } catch (RuntimeException sendKeysFailure) {
+            lastFailure = sendKeysFailure;
+            ReportManager.logDiscrete("mobile sendKeys failed; trying platform setValue / mobile: type.");
+        }
+
+        if (driver instanceof CanReplaceElementValue replacer && element instanceof RemoteWebElement remote) {
+            try {
+                replacer.replaceElementValue(remote, typed);
+                return;
+            } catch (RuntimeException replaceFailure) {
+                lastFailure = replaceFailure;
+            }
+        }
+
+        if (driver instanceof JavascriptExecutor executor) {
+            try {
+                Map<String, Object> params = new LinkedHashMap<>();
+                params.put("text", typed);
+                executor.executeScript("mobile: type", params);
+                return;
+            } catch (RuntimeException mobileTypeFailure) {
+                lastFailure = mobileTypeFailure;
+            }
+        }
+
+        throw actionableMobileTypeFailure(element, lastFailure);
+    }
+
+    /**
+     * Focus (tap) then type for mobile native text-like controls.
+     */
+    public static void focusAndTypeMobile(WebDriver driver, WebElement element, CharSequence[] text) {
+        ClickStrategies.focusTap(driver, element);
+        typeMobileText(driver, element, text);
+    }
+
+    public static void hideKeyboardIfConfigured(WebDriver driver, boolean hideKeyboardAfterTyping) {
+        if (!hideKeyboardAfterTyping) {
+            return;
+        }
+        if (driver instanceof HidesKeyboard hidesKeyboard) {
+            try {
+                hidesKeyboard.hideKeyboard();
+                ReportManager.logDiscrete("hideKeyboard after mobile type (hideKeyboardAfterTyping=true).");
+            } catch (RuntimeException ignored) {
+                ReportManager.logDiscrete("hideKeyboard after typing was requested but failed; continuing.");
+            }
+        }
+    }
+
+    static InvalidElementStateException actionableMobileTypeFailure(WebElement element, RuntimeException cause) {
+        String hint = composeFlutterHint(element);
+        String message = "Mobile type/setValue was rejected"
+                + (hint.isEmpty() ? "" : " (" + hint + ")")
+                + ". Focus the field first (tap/click), then type. "
+                + "Jetpack Compose: enable testTagsAsResourceId and tap the TextField before type — "
+                + "setValue/sendKeys often throws InvalidElementState until focused. "
+                + "Flutter: use ValueKey/Semantics locators; after focus use sendKeys or flutter enter-text helpers.";
+        if (cause == null) {
+            return new InvalidElementStateException(message);
+        }
+        return new InvalidElementStateException(message, cause);
+    }
+
+    private static String composeFlutterHint(WebElement element) {
+        try {
+            String tag = element.getTagName();
+            String className = element.getDomAttribute("class");
+            if (className == null) {
+                className = element.getAttribute("class");
+            }
+            String blob = ((tag == null ? "" : tag) + " " + (className == null ? "" : className))
+                    .toLowerCase(Locale.ROOT);
+            if (blob.contains("compose")) {
+                return "Compose-like control";
+            }
+            if (blob.contains("flutter") || blob.contains("editabletext") || "textfield".equals(blob.trim())) {
+                return "Flutter-like control";
+            }
+        } catch (RuntimeException ignored) {
+            // Hint is best-effort only.
+        }
+        return "";
+    }
+
+    public static String stringify(CharSequence[] text) {
         if (text == null) {
             return "";
         }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/package-info.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Shared click/type strategy layer for Selenium, Playwright, and Appium (#5732).
+ *
+ * <p>Waves B/C cover web kind routing. Wave D extends the same package for mobile native:
+ * focus → {@code sendKeys} / {@code mobile: replaceElementValue} / {@code mobile: type},
+ * W3C touch click fallback, and checkbox/switch toggle semantics.
+ *
+ * <p>Compose: enable {@code testTagsAsResourceId} and tap before type.
+ * Flutter: prefer ValueKey/Semantics; type after focus.
+ */
+package com.shaft.gui.element.internal.interaction;

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Flags.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Flags.java
@@ -97,6 +97,14 @@ public interface Flags extends EngineProperties<Flags> {
     @DefaultValue("false")
     boolean attemptToClickBeforeTyping();
 
+    /**
+     * When true, hide the native soft keyboard after a successful mobile-native {@code type()}.
+     * Default false preserves historical behavior; iOS hideKeyboard can be unreliable.
+     */
+    @Key("hideKeyboardAfterTyping")
+    @DefaultValue("false")
+    boolean hideKeyboardAfterTyping();
+
     @Key("disableCache")
     @DefaultValue("false")
     boolean disableCache();
@@ -201,6 +209,11 @@ public interface Flags extends EngineProperties<Flags> {
 
         public SetProperty attemptToClickBeforeTyping(boolean value) {
             setProperty("attemptToClickBeforeTyping", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty hideKeyboardAfterTyping(boolean value) {
+            setProperty("hideKeyboardAfterTyping", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/MobileInteractionStrategiesTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/MobileInteractionStrategiesTest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/MobileInteractionStrategiesTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/MobileInteractionStrategiesTest.java
@@ -148,7 +148,40 @@ public class MobileInteractionStrategiesTest {
         try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
             new Actions(helperFor(driver)).type(LOCATOR, "compose-text");
             verify(driver).executeScript(eq("mobile: type"), any(Map.class));
+            // clearBeforeTypingMode defaults to off on mobile — must not wipe via replaceElementValue
+            verify((CanReplaceElementValue) driver, never()).replaceElementValue(any(), anyString());
         }
+    }
+
+    @Test
+    public void typeWithNativeClearMayUseReplaceElementValue() {
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("native");
+        AppiumDriver driver = mockAppiumDriver();
+        RemoteWebElement element = mock(RemoteWebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("android.widget.EditText");
+        when(element.getAttribute(anyString())).thenReturn(null);
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getText()).thenReturn("");
+        when(element.getRect()).thenReturn(new Rectangle(10, 20, 40, 60));
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        doThrow(new InvalidElementStateException("sendKeys blocked")).when(element).sendKeys(any(CharSequence[].class));
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "replaced");
+            verify((CanReplaceElementValue) driver).replaceElementValue(eq(element), eq("replaced"));
+        }
+    }
+
+    @Test
+    public void mobileRouteRejectsRangeAndDate() {
+        Assert.assertEquals(TypeStrategies.mobileRouteFor(ElementKind.RANGE),
+                TypeStrategies.MobileTypeRoute.REJECT);
+        Assert.assertEquals(TypeStrategies.mobileRouteFor(ElementKind.DATE_LIKE),
+                TypeStrategies.MobileTypeRoute.REJECT);
     }
 
     @Test
@@ -231,7 +264,7 @@ public class MobileInteractionStrategiesTest {
         RemoteWebElement element = mock(RemoteWebElement.class);
         doThrow(new InvalidElementStateException("sendKeys blocked")).when(element).sendKeys(any(CharSequence[].class));
 
-        TypeStrategies.typeMobileText(driver, element, new CharSequence[]{"via-replace"});
+        TypeStrategies.typeMobileText(driver, element, new CharSequence[]{"via-replace"}, true);
         verify((CanReplaceElementValue) driver).replaceElementValue(eq(element), eq("via-replace"));
     }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/MobileInteractionStrategiesTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/MobileInteractionStrategiesTest.java
@@ -1,0 +1,277 @@
+package com.shaft.gui.element.internal.interaction;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.gui.browser.internal.JavaScriptWaitManager;
+import com.shaft.gui.element.internal.Actions;
+import com.shaft.gui.internal.locator.LocatorBuilder;
+import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
+import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.internal.FlakeProfiler;
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.HidesKeyboard;
+import io.appium.java_client.android.CanReplaceElementValue;
+import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Interactive;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Wave D (#5732): mocked mobile-native click/type routing without a device farm.
+ */
+@Test(singleThreaded = true)
+public class MobileInteractionStrategiesTest {
+    private static final By LOCATOR = By.id("mobile-target");
+    private static final byte[] PNG = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+
+    @BeforeMethod
+    public void configureMobileNativeMockSession() {
+        SHAFT.Properties.reporting.set().captureElementName(false);
+        SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(false);
+        SHAFT.Properties.flags.set().scrollingMode("legacy");
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
+        SHAFT.Properties.flags.set().forceCheckTextWasTypedCorrectly(false);
+        SHAFT.Properties.flags.set().attemptToClickBeforeTyping(false);
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(false);
+        SHAFT.Properties.flags.set().hideKeyboardAfterTyping(false);
+        SHAFT.Properties.visuals.set().createAnimatedGif(false);
+        SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("ValidationPointsOnly");
+        SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
+        SHAFT.Properties.platform.set().targetPlatform(Platform.ANDROID.name());
+        SHAFT.Properties.mobile.set().browserName("");
+        LocatorBuilder.cleanup();
+        ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanupThreadLocalState() {
+        LocatorBuilder.cleanup();
+        ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
+        Properties.clearForCurrentThread();
+    }
+
+    @DataProvider(name = "mobileKinds")
+    public Object[][] mobileKinds() {
+        return new Object[][]{
+                {nativeElement("android.widget.EditText"), ElementKind.TEXT_LIKE},
+                {nativeElement("android.widget.CheckBox"), ElementKind.CHECKBOX},
+                {nativeElement("android.widget.Switch"), ElementKind.CHECKBOX},
+                {nativeElement("android.widget.RadioButton"), ElementKind.RADIO},
+                {nativeElement("android.widget.Button"), ElementKind.BUTTON},
+                {nativeElement("XCUIElementTypeTextField"), ElementKind.TEXT_LIKE},
+                {nativeElement("XCUIElementTypeSecureTextField"), ElementKind.TEXT_LIKE},
+                {nativeElement("XCUIElementTypeSwitch"), ElementKind.CHECKBOX},
+                {nativeElement("XCUIElementTypeButton"), ElementKind.BUTTON},
+                {nativeElement("TextField"), ElementKind.TEXT_LIKE},
+                {nativeElement("EditableText"), ElementKind.TEXT_LIKE},
+        };
+    }
+
+    @Test(dataProvider = "mobileKinds")
+    public void classifierRecognizesMobileNativeControls(WebElement element, ElementKind expected) {
+        Assert.assertEquals(ElementClassifier.classify(element), expected);
+    }
+
+    @Test
+    public void mobileRouteMapsToggleAndText() {
+        Assert.assertEquals(TypeStrategies.mobileRouteFor(ElementKind.CHECKBOX),
+                TypeStrategies.MobileTypeRoute.TOGGLE_CLICK);
+        Assert.assertEquals(TypeStrategies.mobileRouteFor(ElementKind.RADIO),
+                TypeStrategies.MobileTypeRoute.TOGGLE_CLICK);
+        Assert.assertEquals(TypeStrategies.mobileRouteFor(ElementKind.TEXT_LIKE),
+                TypeStrategies.MobileTypeRoute.MOBILE_TEXT);
+        Assert.assertEquals(TypeStrategies.mobileRouteFor(ElementKind.DISABLED),
+                TypeStrategies.MobileTypeRoute.REJECT);
+    }
+
+    @Test
+    public void typeEditTextFocusesThenSendKeys() {
+        AppiumDriver driver = mockAppiumDriver();
+        WebElement element = nativeElement("android.widget.EditText");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "hello-mobile");
+            verify(element).click();
+            verify(element).sendKeys(eq("hello-mobile"));
+        }
+    }
+
+    @Test
+    public void typeSwitchTogglesAndNeverSendKeys() {
+        AppiumDriver driver = mockAppiumDriver();
+        WebElement element = nativeElement("android.widget.Switch");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "ignored");
+            verify(element).click();
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+            verify(element, never()).sendKeys(anyString());
+        }
+    }
+
+    @Test
+    public void typeFallsBackToMobileTypeWhenSendKeysRejected() {
+        AppiumDriver driver = mockAppiumDriver();
+        WebElement element = nativeElement("android.widget.EditText");
+        doThrow(new InvalidElementStateException("not focused")).when(element).sendKeys(any(CharSequence[].class));
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "compose-text");
+            verify(driver).executeScript(eq("mobile: type"), any(Map.class));
+        }
+    }
+
+    @Test
+    public void typeComposeRejectionSurfacesActionableError() {
+        AppiumDriver driver = mockAppiumDriver();
+        WebElement element = nativeElement("android.view.View");
+        when(element.getDomAttribute("class")).thenReturn("androidx.compose.ui.platform.ComposeView");
+        doThrow(new InvalidElementStateException("setValue rejected"))
+                .when(element).sendKeys(any(CharSequence[].class));
+        when(driver.executeScript(eq("mobile: type"), any(Map.class)))
+                .thenThrow(new InvalidElementStateException("still rejected"));
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            RuntimeException exception = Assert.expectThrows(RuntimeException.class,
+                    () -> new Actions(helperFor(driver)).type(LOCATOR, "x"));
+            Assert.assertTrue(hasCauseMessage(exception, "Focus the field first")
+                    || hasCauseMessage(exception, "testTagsAsResourceId")
+                    || hasCauseMessage(exception, "Compose"),
+                    "Expected Compose/focus guidance in: " + exception);
+        }
+    }
+
+    @Test
+    public void hideKeyboardRunsWhenFlagEnabled() {
+        SHAFT.Properties.flags.set().hideKeyboardAfterTyping(true);
+        AppiumDriver driver = mockAppiumDriver();
+        WebElement element = nativeElement("android.widget.EditText");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "typed");
+            verify((HidesKeyboard) driver).hideKeyboard();
+        }
+    }
+
+    @Test
+    public void clickUsesTouchFallbackWhenWebDriverClickFlakes() {
+        AppiumDriver driver = mockAppiumDriver();
+        WebElement element = nativeElement("android.widget.Button");
+        doThrow(new InvalidElementStateException("not clickable")).when(element).click();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).click(LOCATOR);
+            verify(driver, atLeastOnce()).perform(any(Collection.class));
+        }
+    }
+
+    @Test
+    public void webDefaultsUnchangedWhenNotMobileNative() {
+        SHAFT.Properties.platform.set().targetPlatform(Platform.LINUX.name());
+        SHAFT.Properties.mobile.set().browserName("chrome");
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
+
+        AppiumDriver driver = mockAppiumDriver();
+        // Use a plain WebDriver-style mock path: still AppiumDriver but isMobileNativeExecution is false.
+        WebElement element = mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("button");
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getAttribute(anyString())).thenReturn(null);
+        when(element.getRect()).thenReturn(new Rectangle(10, 20, 30, 40));
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        doThrow(new InvalidElementStateException("blocked")).when(element).click();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).click(LOCATOR);
+            verify(driver).executeScript(eq("arguments[0].click();"), eq(element));
+            verify(driver, never()).perform(any(Collection.class));
+        }
+    }
+
+    @Test
+    public void typeMobileTextDirectReplaceElementValue() {
+        AppiumDriver driver = mockAppiumDriver();
+        RemoteWebElement element = mock(RemoteWebElement.class);
+        doThrow(new InvalidElementStateException("sendKeys blocked")).when(element).sendKeys(any(CharSequence[].class));
+
+        TypeStrategies.typeMobileText(driver, element, new CharSequence[]{"via-replace"});
+        verify((CanReplaceElementValue) driver).replaceElementValue(eq(element), eq("via-replace"));
+    }
+
+    private static AppiumDriver mockAppiumDriver() {
+        return mock(AppiumDriver.class, org.mockito.Mockito.withSettings()
+                .extraInterfaces(TakesScreenshot.class, Interactive.class, HidesKeyboard.class, CanReplaceElementValue.class));
+    }
+
+    private DriverFactoryHelper helperFor(AppiumDriver driver) {
+        DriverFactoryHelper helper = mock(DriverFactoryHelper.class);
+        when(helper.getDriver()).thenReturn(driver);
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        return helper;
+    }
+
+    private WebElement nativeElement(String className) {
+        WebElement element = mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.isSelected()).thenReturn(false);
+        when(element.getAccessibleName()).thenReturn("mobile target");
+        when(element.getText()).thenReturn("");
+        when(element.getTagName()).thenReturn(className);
+        when(element.getAttribute(anyString())).thenReturn(null);
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getCssValue(anyString())).thenReturn("");
+        when(element.getRect()).thenReturn(new Rectangle(10, 20, 40, 60));
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        return element;
+    }
+
+    private boolean hasCauseMessage(Throwable throwable, String fragment) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current.getMessage() != null && current.getMessage().contains(fragment)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java
@@ -24,6 +24,7 @@ public class FlagsSetPropertyCoverageUnitTest {
     private boolean originalRespectBuiltInWaitsInNativeMode;
     private boolean originalClickUsingJavascriptWhenWebDriverClickFails;
     private boolean originalAttemptToClickBeforeTyping;
+    private boolean originalHideKeyboardAfterTyping;
     private boolean originalAutoCloseDriverInstance;
     private boolean originalAutomaticallyAssertResponseStatusCode;
     private int originalMaximumPerformanceMode;
@@ -51,6 +52,7 @@ public class FlagsSetPropertyCoverageUnitTest {
         originalRespectBuiltInWaitsInNativeMode = SHAFT.Properties.flags.respectBuiltInWaitsInNativeMode();
         originalClickUsingJavascriptWhenWebDriverClickFails = SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails();
         originalAttemptToClickBeforeTyping = SHAFT.Properties.flags.attemptToClickBeforeTyping();
+        originalHideKeyboardAfterTyping = SHAFT.Properties.flags.hideKeyboardAfterTyping();
         originalAutoCloseDriverInstance = SHAFT.Properties.flags.autoCloseDriverInstance();
         originalAutomaticallyAssertResponseStatusCode = SHAFT.Properties.flags.automaticallyAssertResponseStatusCode();
         originalMaximumPerformanceMode = SHAFT.Properties.flags.maximumPerformanceMode();
@@ -80,6 +82,7 @@ public class FlagsSetPropertyCoverageUnitTest {
                 .respectBuiltInWaitsInNativeMode(originalRespectBuiltInWaitsInNativeMode)
                 .clickUsingJavascriptWhenWebDriverClickFails(originalClickUsingJavascriptWhenWebDriverClickFails)
                 .attemptToClickBeforeTyping(originalAttemptToClickBeforeTyping)
+                .hideKeyboardAfterTyping(originalHideKeyboardAfterTyping)
                 .autoCloseDriverInstance(originalAutoCloseDriverInstance)
                 .automaticallyAssertResponseStatusCode(originalAutomaticallyAssertResponseStatusCode)
                 .maximumPerformanceMode(originalMaximumPerformanceMode)
@@ -112,6 +115,7 @@ public class FlagsSetPropertyCoverageUnitTest {
         Assert.assertSame(setProperty.respectBuiltInWaitsInNativeMode(!originalRespectBuiltInWaitsInNativeMode), setProperty);
         Assert.assertSame(setProperty.clickUsingJavascriptWhenWebDriverClickFails(!originalClickUsingJavascriptWhenWebDriverClickFails), setProperty);
         Assert.assertSame(setProperty.attemptToClickBeforeTyping(!originalAttemptToClickBeforeTyping), setProperty);
+        Assert.assertSame(setProperty.hideKeyboardAfterTyping(!originalHideKeyboardAfterTyping), setProperty);
         Assert.assertSame(setProperty.autoCloseDriverInstance(!originalAutoCloseDriverInstance), setProperty);
         Assert.assertSame(setProperty.automaticallyAssertResponseStatusCode(!originalAutomaticallyAssertResponseStatusCode), setProperty);
         Assert.assertSame(setProperty.maximumPerformanceMode(originalMaximumPerformanceMode == 0 ? 1 : 0), setProperty);
@@ -137,6 +141,7 @@ public class FlagsSetPropertyCoverageUnitTest {
         Assert.assertEquals(SHAFT.Properties.flags.respectBuiltInWaitsInNativeMode(), !originalRespectBuiltInWaitsInNativeMode);
         Assert.assertEquals(SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails(), !originalClickUsingJavascriptWhenWebDriverClickFails);
         Assert.assertEquals(SHAFT.Properties.flags.attemptToClickBeforeTyping(), !originalAttemptToClickBeforeTyping);
+        Assert.assertEquals(SHAFT.Properties.flags.hideKeyboardAfterTyping(), !originalHideKeyboardAfterTyping);
         Assert.assertEquals(SHAFT.Properties.flags.autoCloseDriverInstance(), !originalAutoCloseDriverInstance);
         Assert.assertEquals(SHAFT.Properties.flags.automaticallyAssertResponseStatusCode(), !originalAutomaticallyAssertResponseStatusCode);
         Assert.assertEquals(SHAFT.Properties.flags.maximumPerformanceMode(), originalMaximumPerformanceMode == 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Wave D of epic #5732 — mobile-native click/type strategies on top of Waves B+C+F (already on `main`).

- **Type (mobile native):** focus (tap) → `sendKeys` → Android `mobile: replaceElementValue` (only when clear mode is not `off`) → `mobile: type` → optional `hideKeyboardAfterTyping`
- **Compose / Flutter:** package + `TypeStrategies` notes; actionable `InvalidElementStateException` when setValue/type is rejected until focused
- **Click (mobile native only):** W3C touch tap when WebDriver click flakes (web/desktop JS defaults unchanged)
- **Checkbox / Switch:** toggle via tap, never `sendKeys`
- **Flag:** `hideKeyboardAfterTyping` (default `false`) — additive; existing flags honored
- **No public API break**

Part of #5732 (does **not** close the epic — Wave E desktop remains).

## Files
- `shaft-engine/.../interaction/ClickStrategies.java` — mobile touch fallback
- `shaft-engine/.../interaction/TypeStrategies.java` — mobile type ladder + Compose/Flutter errors
- `shaft-engine/.../interaction/ElementClassifier.java` — Android/XCUI/Flutter-ish class names
- `shaft-engine/.../interaction/package-info.java` — Wave D / Compose / Flutter pointer
- `shaft-engine/.../Actions.java` — wire mobile TYPE / TYPE_APPEND / CLICK
- `shaft-engine/.../Flags.java` — `hideKeyboardAfterTyping`
- `MobileInteractionStrategiesTest.java` — mocked mobile routing
- `FlagsSetPropertyCoverageUnitTest.java` — new flag coverage

## Tests
```bash
mvn -pl shaft-engine \
  -Dtest=MobileInteractionStrategiesTest,ElementClassifierTest,InteractionStrategiesActionsTest,FlagsSetPropertyCoverageUnitTest \
  -Dallure.automaticallyOpen=false -DheadlessExecution=true test
```
Result: **77 tests, 0 failures** (local).

## Residual risks
- Real-device / emulator CI not run here (mocked Appium path only)
- iOS `hideKeyboard` remains unreliable when the new flag is enabled — callers may still need Done/outside tap
- SeekBar / date / color on mobile intentionally **reject** `type()` until a dedicated value/gesture strategy exists
- Classifier stays conservative; unknown custom views keep the mobile text ladder after focus

## Out of scope
Wave E (desktop/UIA). Broader user-guide Wave A docs left for docs follow-up (package-info pointer included).