### PR TITLE
fix(chaos-engine): prove epic initial scope before auto-merge

### DIFF
--- a/chaos-engine/references/consult-first.md
+++ b/chaos-engine/references/consult-first.md
@@ -93,7 +93,7 @@ rule overrides an imported skill's default path.
 Work runs in this order, and each phase ends before the next begins:
 
 analyze -> plan -> design -> RED -> GREEN -> refactor -> commit ->
-pull request -> babysit (fix review comments and failed tests) to green -> merge ->
+pull request -> babysit (fix review comments and failed tests) to green -> prove epic and tracker initial scope is complete -> merge ->
 terminal reflection when owed -> one root Learning Session -> final report.
 
 Behavior changes receive only the planning-approved terminal adversarial review

--- a/chaos-engine/references/work-github-planning.md
+++ b/chaos-engine/references/work-github-planning.md
@@ -106,6 +106,10 @@ delivery through **GitHub native sub-issues**, not checkbox prose alone.
 - File each subtask as a real issue and attach it as a sub-issue of the epic.
 - Delivery PRs close **children only**: one `Fixes #<child>` / `Closes #<child>`
   line per completed subtask. Never put a closing keyword on the epic number.
+- Before arming auto-merge on any child or tracker PR, re-read the epic's
+  initial scope and confirm every related sub-issue is merged or explicitly
+  dropped on the tracker. Auto-merge of one green PR must not close or imply
+  the epic is done while in-scope children remain open or unimplemented.
 - Workflow `.github/workflows/epic-autoclose.yml` runs on `issues: closed`. It
   no-ops unless the closed issue's parent is an eligible epic **and** every
   tracked sub-issue is closed; then it closes the epic with a receipt comment.

--- a/chaos-engine/references/work-github-playbook.md
+++ b/chaos-engine/references/work-github-playbook.md
@@ -153,7 +153,14 @@ and focused proofs observed; it must not represent remote checks as green.
    acceptance until the current exact head is fully green and no bot finding,
    review thread, inline comment, conversation comment, or annotation remains
    unresolved. Map the approved initial plan and every closing ticket to the
-   user-facing affected flows. This is the final assurance action before arming
+   user-facing affected flows. Re-read the original tracker or epic body (not a
+   later summary): every Functional Requirement, Success Criterion, and GitHub
+   sub-issue in that initial scope must map to live files and a merged or
+   currently-armed PR. Do not arm auto-merge while any in-scope sub-issue is
+   open, any FR/SC is unimplemented, or this PR would close an epic that still
+   has dropped scope. Owner-reduced scope counts only when the tracker body
+   itself records the drop. Remaining work becomes new sub-issues before merge;
+   it does not silently vanish. This is the final assurance action before arming
    auto-merge. If the head or remote feedback changes afterward, the receipt is
    stale: clear only that new observable state, then run one replacement
    acceptance against the new exact head. Unchanged state never triggers a retry.

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -270,7 +270,9 @@ For issue-to-merged-PR work, use the [GitHub playbook](../../references/work-git
 Do not confuse a diff with an outcome: run the real affected flow, review the
 actual diff, and keep external actions within granted authority.
 
-Opening a PR does not end the duty. Arm auto-merge once selected terminal assurance passes,
+Opening a PR does not end the duty. Arm auto-merge once selected terminal assurance passes
+and the tracker or epic's initial scope is complete (every in-scope sub-issue merged
+or explicitly dropped on the tracker; no dropped FR/SC),
 then watch with `gh pr checks <n> --watch --fail-fast` until the remote confirms
 merged. Red and conflicting are yours to fix, not to hand back; stale emits no
 event, so ask for it. The duty survives compaction, a dead delegate, and the

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -842,6 +842,7 @@ class EntrypointDutyTest(unittest.TestCase):
             "run final holistic acceptance last",
             "no bot finding",
             "remains unresolved",
+            "do not arm auto-merge while any in-scope sub-issue is open",
             "final assurance action before arming auto-merge",
             "immediately after that acceptance remains current",
         )

--- a/tests/scripts/test_chaos_engine_learn_contracts.py
+++ b/tests/scripts/test_chaos_engine_learn_contracts.py
@@ -48,6 +48,19 @@ class LearnContractTests(unittest.TestCase):
         self.assertIn("do not copy that rule into ChaosEngine", section)
         self.assertIn("do not edit the bundled skill in place", section)
 
+    def test_a2_pr_merger_requires_epic_scope_before_auto_merge(self):
+        playbook = PLAYBOOK.read_text(encoding="utf-8")
+        planning = (ROOT / "chaos-engine/references/work-github-planning.md").read_text(
+            encoding="utf-8"
+        )
+        skill = SKILL.read_text(encoding="utf-8")
+        compact = re.sub(r"\s+", " ", playbook).casefold()
+        self.assertIn("do not arm auto-merge while any in-scope sub-issue is open", compact)
+        self.assertIn("initial scope", compact)
+        self.assertIn("dropped scope", compact)
+        self.assertIn("related sub-issue is merged", planning.casefold())
+        self.assertIn("initial scope is complete", skill.casefold())
+
     def test_router_and_level1_discover_portable_contracts(self):
         rows = catalog_rows(SKILL.read_text(encoding="utf-8"))
         skill = SKILL.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Require re-reading the original tracker or epic body before arming auto-merge. Refuse while in-scope sub-issues are open or FR/SC items are unimplemented.

Closes #5744

## Checks
- `python3 -m unittest tests.scripts.test_chaos_engine_learn_contracts tests.scripts.test_agent_harness_reachability.EntrypointDutyTest.test_pr_merger_babysit_must_clear_feedback_and_accept_before_arming`

## Continuation
Do not squash. Use merge commits only if auto-merge is armed (`gh pr merge --auto --merge`). Do not arm auto-merge until the original tracker/epic initial scope is complete.