### PR TITLE
feat(element): Wave E Windows/UIA click/type strategies (#5732)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -550,6 +550,7 @@ public class Actions extends ElementActions {
 
                 // identify run type
                 boolean isMobileNativeExecution = DriverFactoryHelper.isMobileNativeExecution();
+                boolean isWindowsDesktopExecution = DriverFactoryHelper.isWindowsAppiumExecution();
 
                 // get accessible name if needed
                 if (SHAFT.Properties.reporting.captureElementName()) {
@@ -671,12 +672,14 @@ public class Actions extends ElementActions {
                         screenshot.set(0, takeActionScreenshot(targetElement));
                         // Wave B (#5732): native → scroll/stabilize retry → flagged JS; preserve exception when JS off.
                         // Wave D: mobile native uses W3C touch tap when WebDriver click flakes (web defaults unchanged).
+                        // Wave E: Windows desktop uses windows: click when WebDriver click flakes (no JS on desktop).
                         ClickStrategies.click(
                                 d,
                                 targetElement,
                                 ElementClassifier.classify(targetElement),
                                 SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails(),
-                                isMobileNativeExecution);
+                                isMobileNativeExecution,
+                                isWindowsDesktopExecution);
                     }
                     case JAVASCRIPT_CLICK -> {
                         screenshot.set(0, takeActionScreenshot(foundElements.get().getFirst()));
@@ -725,6 +728,8 @@ public class Actions extends ElementActions {
                         ElementKind kind = ElementClassifier.classify(targetElement);
                         if (isMobileNativeExecution) {
                             performMobileNativeType(d, targetElement, kind, text, action);
+                        } else if (isWindowsDesktopExecution) {
+                            performWindowsDesktopType(d, targetElement, kind, text, action);
                         } else {
                             TypeStrategies.TypeRoute typeRoute = TypeStrategies.routeFor(kind);
                             if (typeRoute == TypeStrategies.TypeRoute.REJECT) {
@@ -768,6 +773,9 @@ public class Actions extends ElementActions {
                             ClickStrategies.focusTap(d, targetElement);
                             TypeStrategies.typeMobileText(d, targetElement, text, false);
                             TypeStrategies.hideKeyboardIfConfigured(d, SHAFT.Properties.flags.hideKeyboardAfterTyping());
+                        } else if (isWindowsDesktopExecution) {
+                            ClickStrategies.focusWindows(d, targetElement);
+                            TypeStrategies.typeDesktopText(d, targetElement, text);
                         } else {
                             targetElement.sendKeys(text);
                         }
@@ -1197,6 +1205,54 @@ public class Actions extends ElementActions {
             targetElement.sendKeys(text);
         }
         TypeStrategies.hideKeyboardIfConfigured(d, SHAFT.Properties.flags.hideKeyboardAfterTyping());
+        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
+    }
+
+    /**
+     * Wave E (#5732): Windows desktop / UIA type — ensure foreground (click / {@code windows: click}) →
+     * clear flags → sendKeys / {@code windows: keys}. CheckBox/Radio toggle; ComboBox expand + filter + Enter.
+     */
+    private void performWindowsDesktopType(WebDriver d, WebElement targetElement, ElementKind kind,
+                                           CharSequence[] text, ActionType action) {
+        TypeStrategies.DesktopTypeRoute desktopRoute = TypeStrategies.desktopRouteFor(kind);
+        if (desktopRoute == TypeStrategies.DesktopTypeRoute.REJECT) {
+            TypeStrategies.rejectUnsupported(kind);
+            return;
+        }
+        if (desktopRoute == TypeStrategies.DesktopTypeRoute.TOGGLE_CLICK) {
+            TypeStrategies.toggleDesktopInsteadOfTyping(d, targetElement, kind);
+            return;
+        }
+        if (desktopRoute == TypeStrategies.DesktopTypeRoute.COMBOBOX) {
+            TypeStrategies.typeDesktopCombobox(d, targetElement, text);
+            return;
+        }
+
+        String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
+        String typedText = stringifyTypedValue(text);
+        boolean shouldValidateTypedText = shouldValidateTypedText(text);
+        String expectedText = shouldValidateTypedText && "off".equals(clearMode)
+                ? readElementValueForTyping(targetElement) + typedText
+                : typedText;
+
+        // Foreground / focus before type (Window/Pane sessions; Edit/Document Value path).
+        ClickStrategies.focusWindows(d, targetElement);
+        if ("native".equals(clearMode)) {
+            try {
+                targetElement.clear();
+            } catch (RuntimeException ignored) {
+                executeClearBasedOnClearMode(targetElement, "backspace");
+            }
+        } else {
+            executeClearBasedOnClearMode(targetElement, clearMode);
+        }
+
+        if (desktopRoute == TypeStrategies.DesktopTypeRoute.DESKTOP_TEXT
+                || desktopRoute == TypeStrategies.DesktopTypeRoute.LEGACY_SEND_KEYS) {
+            TypeStrategies.typeDesktopText(d, targetElement, text);
+        } else {
+            targetElement.sendKeys(text);
+        }
         validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -769,16 +769,19 @@ public class Actions extends ElementActions {
                         String expectedText = shouldValidateTypedText
                                 ? readElementValueForTyping(targetElement) + stringifyTypedValue(text)
                                 : "";
+                        boolean textWasTyped = true;
                         if (isMobileNativeExecution) {
                             ClickStrategies.focusTap(d, targetElement);
                             TypeStrategies.typeMobileText(d, targetElement, text, false);
                             TypeStrategies.hideKeyboardIfConfigured(d, SHAFT.Properties.flags.hideKeyboardAfterTyping());
                         } else if (isWindowsDesktopExecution) {
-                            performWindowsDesktopTypeAppend(d, targetElement, text);
+                            textWasTyped = performWindowsDesktopTypeAppend(d, targetElement, text);
                         } else {
                             targetElement.sendKeys(text);
                         }
-                        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
+                        if (textWasTyped) {
+                            validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
+                        }
                     }
                     case JAVASCRIPT_SET_VALUE ->
                             ((JavascriptExecutor) d).executeScript("""
@@ -1262,30 +1265,33 @@ public class Actions extends ElementActions {
 
     /**
      * Wave E append path: same kind routing as {@link #performWindowsDesktopType} without clear.
+     *
+     * @return true when text was typed (caller may validate); false for toggle / focus-surface / reject paths
      */
-    private void performWindowsDesktopTypeAppend(WebDriver d, WebElement targetElement, CharSequence[] text) {
+    private boolean performWindowsDesktopTypeAppend(WebDriver d, WebElement targetElement, CharSequence[] text) {
         if (ElementClassifier.isWindowsFocusSurface(targetElement)) {
             ClickStrategies.focusWindows(d, targetElement);
             ReportManager.logDiscrete(
                     "typeAppend() on UIA Window/Pane ensured foreground focus; sendKeys skipped on focus surface.");
-            return;
+            return false;
         }
         ElementKind kind = ElementClassifier.classify(targetElement);
         TypeStrategies.DesktopTypeRoute desktopRoute = TypeStrategies.desktopRouteFor(kind);
         if (desktopRoute == TypeStrategies.DesktopTypeRoute.REJECT) {
             TypeStrategies.rejectUnsupported(kind);
-            return;
+            return false;
         }
         if (desktopRoute == TypeStrategies.DesktopTypeRoute.TOGGLE_CLICK) {
             TypeStrategies.toggleDesktopInsteadOfTyping(d, targetElement, kind);
-            return;
+            return false;
         }
         if (desktopRoute == TypeStrategies.DesktopTypeRoute.COMBOBOX) {
             TypeStrategies.typeDesktopCombobox(d, targetElement, text);
-            return;
+            return true;
         }
         ClickStrategies.focusWindows(d, targetElement);
         TypeStrategies.typeDesktopText(d, targetElement, text);
+        return true;
     }
 
     private void executeClearBasedOnClearMode(WebElement elem, String clearMode) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -774,8 +774,7 @@ public class Actions extends ElementActions {
                             TypeStrategies.typeMobileText(d, targetElement, text, false);
                             TypeStrategies.hideKeyboardIfConfigured(d, SHAFT.Properties.flags.hideKeyboardAfterTyping());
                         } else if (isWindowsDesktopExecution) {
-                            ClickStrategies.focusWindows(d, targetElement);
-                            TypeStrategies.typeDesktopText(d, targetElement, text);
+                            performWindowsDesktopTypeAppend(d, targetElement, text);
                         } else {
                             targetElement.sendKeys(text);
                         }
@@ -1211,9 +1210,67 @@ public class Actions extends ElementActions {
     /**
      * Wave E (#5732): Windows desktop / UIA type — ensure foreground (click / {@code windows: click}) →
      * clear flags → sendKeys / {@code windows: keys}. CheckBox/Radio toggle; ComboBox expand + filter + Enter.
+     * Window/Pane locators only bring the surface to the foreground (no sendKeys into the chrome).
      */
     private void performWindowsDesktopType(WebDriver d, WebElement targetElement, ElementKind kind,
                                            CharSequence[] text, ActionType action) {
+        if (ElementClassifier.isWindowsFocusSurface(targetElement)) {
+            ClickStrategies.focusWindows(d, targetElement);
+            ReportManager.logDiscrete(
+                    "type() on UIA Window/Pane ensured foreground focus; sendKeys skipped on focus surface.");
+            return;
+        }
+
+        TypeStrategies.DesktopTypeRoute desktopRoute = TypeStrategies.desktopRouteFor(kind);
+        if (desktopRoute == TypeStrategies.DesktopTypeRoute.REJECT) {
+            TypeStrategies.rejectUnsupported(kind);
+            return;
+        }
+        if (desktopRoute == TypeStrategies.DesktopTypeRoute.TOGGLE_CLICK) {
+            TypeStrategies.toggleDesktopInsteadOfTyping(d, targetElement, kind);
+            return;
+        }
+        if (desktopRoute == TypeStrategies.DesktopTypeRoute.COMBOBOX) {
+            TypeStrategies.typeDesktopCombobox(d, targetElement, text);
+            validateTypedTextIfConfigured(targetElement, action, stringifyTypedValue(text),
+                    shouldValidateTypedText(text));
+            return;
+        }
+
+        String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
+        String typedText = stringifyTypedValue(text);
+        boolean shouldValidateTypedText = shouldValidateTypedText(text);
+        String expectedText = shouldValidateTypedText && "off".equals(clearMode)
+                ? readElementValueForTyping(targetElement) + typedText
+                : typedText;
+
+        // Foreground / focus before type (brings hosting Window/Pane forward when practical).
+        ClickStrategies.focusWindows(d, targetElement);
+        if ("native".equals(clearMode)) {
+            try {
+                targetElement.clear();
+            } catch (RuntimeException ignored) {
+                executeClearBasedOnClearMode(targetElement, "backspace");
+            }
+        } else {
+            executeClearBasedOnClearMode(targetElement, clearMode);
+        }
+
+        TypeStrategies.typeDesktopText(d, targetElement, text);
+        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
+    }
+
+    /**
+     * Wave E append path: same kind routing as {@link #performWindowsDesktopType} without clear.
+     */
+    private void performWindowsDesktopTypeAppend(WebDriver d, WebElement targetElement, CharSequence[] text) {
+        if (ElementClassifier.isWindowsFocusSurface(targetElement)) {
+            ClickStrategies.focusWindows(d, targetElement);
+            ReportManager.logDiscrete(
+                    "typeAppend() on UIA Window/Pane ensured foreground focus; sendKeys skipped on focus surface.");
+            return;
+        }
+        ElementKind kind = ElementClassifier.classify(targetElement);
         TypeStrategies.DesktopTypeRoute desktopRoute = TypeStrategies.desktopRouteFor(kind);
         if (desktopRoute == TypeStrategies.DesktopTypeRoute.REJECT) {
             TypeStrategies.rejectUnsupported(kind);
@@ -1227,33 +1284,8 @@ public class Actions extends ElementActions {
             TypeStrategies.typeDesktopCombobox(d, targetElement, text);
             return;
         }
-
-        String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
-        String typedText = stringifyTypedValue(text);
-        boolean shouldValidateTypedText = shouldValidateTypedText(text);
-        String expectedText = shouldValidateTypedText && "off".equals(clearMode)
-                ? readElementValueForTyping(targetElement) + typedText
-                : typedText;
-
-        // Foreground / focus before type (Window/Pane sessions; Edit/Document Value path).
         ClickStrategies.focusWindows(d, targetElement);
-        if ("native".equals(clearMode)) {
-            try {
-                targetElement.clear();
-            } catch (RuntimeException ignored) {
-                executeClearBasedOnClearMode(targetElement, "backspace");
-            }
-        } else {
-            executeClearBasedOnClearMode(targetElement, clearMode);
-        }
-
-        if (desktopRoute == TypeStrategies.DesktopTypeRoute.DESKTOP_TEXT
-                || desktopRoute == TypeStrategies.DesktopTypeRoute.LEGACY_SEND_KEYS) {
-            TypeStrategies.typeDesktopText(d, targetElement, text);
-        } else {
-            targetElement.sendKeys(text);
-        }
-        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
+        TypeStrategies.typeDesktopText(d, targetElement, text);
     }
 
     private void executeClearBasedOnClearMode(WebElement elem, String clearMode) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ClickStrategies.java
@@ -10,14 +10,19 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Pause;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Selenium click ladder: native click → optional scroll/stabilize retry → flagged JS fallback.
  * Mobile native (#5732 Wave D): native click → W3C touch tap when WebDriver click flakes
  * (does not change desktop/web defaults; JS fallback stays web-oriented).
+ * Windows desktop (#5732 Wave E): native click → {@code windows: click} when WebDriver click flakes
+ * (Invoke-equivalent for Button/Hyperlink; JS fallback stays off the desktop path).
  */
 public final class ClickStrategies {
 
@@ -30,7 +35,7 @@ public final class ClickStrategies {
     }
 
     public static void click(WebDriver driver, WebElement element, ElementKind kind, boolean javascriptFallbackEnabled) {
-        click(driver, element, kind, javascriptFallbackEnabled, false);
+        click(driver, element, kind, javascriptFallbackEnabled, false, false);
     }
 
     /**
@@ -39,6 +44,18 @@ public final class ClickStrategies {
      */
     public static void click(WebDriver driver, WebElement element, ElementKind kind,
                              boolean javascriptFallbackEnabled, boolean mobileNativeTouchFallback) {
+        click(driver, element, kind, javascriptFallbackEnabled, mobileNativeTouchFallback, false);
+    }
+
+    /**
+     * @param mobileNativeTouchFallback when true (mobile native only), retry failed clicks with a W3C
+     *                                  touch tap instead of JavaScript click
+     * @param windowsDesktop            when true (WinAppDriver / Appium Windows only), retry failed
+     *                                  clicks with {@code windows: click} instead of JavaScript click
+     */
+    public static void click(WebDriver driver, WebElement element, ElementKind kind,
+                             boolean javascriptFallbackEnabled, boolean mobileNativeTouchFallback,
+                             boolean windowsDesktop) {
         if (kind == ElementKind.DISABLED) {
             throw new InvalidElementStateException(
                     "Refusing to click a disabled/readonly/aria-disabled element.");
@@ -48,6 +65,10 @@ public final class ClickStrategies {
         } catch (InvalidElementStateException firstFailure) {
             if (mobileNativeTouchFallback) {
                 retryMobileNativeClick(driver, element);
+                return;
+            }
+            if (windowsDesktop) {
+                retryWindowsDesktopClick(driver, element);
                 return;
             }
             stabilize(driver, element);
@@ -66,6 +87,10 @@ public final class ClickStrategies {
             // Broader than web: Appium often wraps click flakes outside InvalidElementStateException.
             if (mobileNativeTouchFallback) {
                 retryMobileNativeClick(driver, element);
+                return;
+            }
+            if (windowsDesktop) {
+                retryWindowsDesktopClick(driver, element);
                 return;
             }
             throw firstFailure;
@@ -92,6 +117,42 @@ public final class ClickStrategies {
         } catch (RuntimeException ignored) {
             tapWithTouch(driver, element);
         }
+    }
+
+    /**
+     * Best-effort focus / foreground for Windows desktop typing: WebDriver click, then
+     * {@code windows: click}. Helps Window/Pane sessions receive keys before Edit SendKeys.
+     */
+    public static void focusWindows(WebDriver driver, WebElement element) {
+        try {
+            element.click();
+        } catch (RuntimeException ignored) {
+            windowsClick(driver, element);
+        }
+    }
+
+    private static void retryWindowsDesktopClick(WebDriver driver, WebElement element) {
+        try {
+            element.click();
+        } catch (RuntimeException retryFailure) {
+            windowsClick(driver, element);
+            ReportManager.logDiscrete(
+                    "Performed Click using windows: click after WebDriver click failed on Windows desktop.");
+        }
+    }
+
+    static void windowsClick(WebDriver driver, WebElement element) {
+        if (!(driver instanceof JavascriptExecutor executor)) {
+            throw new InvalidElementStateException(
+                    "Windows click fallback requires a driver that executes scripts.");
+        }
+        if (!(element instanceof RemoteWebElement remote)) {
+            throw new InvalidElementStateException(
+                    "Windows click fallback requires a RemoteWebElement with an element id.");
+        }
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("elementId", remote.getId());
+        executor.executeScript("windows: click", params);
     }
 
     static void tapWithTouch(WebDriver driver, WebElement element) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -9,9 +9,10 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 
 /**
- * Cheap classifier: tagName, type, role/ARIA, contenteditable, disabled flags.
+ * Cheap classifier: tagName, type, role/ARIA, contenteditable, disabled flags,
+ * Appium mobile class names, and Windows/UIA ControlType tokens.
  * Conservative by design — ambiguous custom widgets return {@link ElementKind#UNKNOWN}.
- * Shared by Selenium Wave B and Playwright Wave C (#5732).
+ * Shared by Selenium Wave B, Playwright Wave C, mobile Wave D, and desktop Wave E (#5732).
  */
 public final class ElementClassifier {
 
@@ -72,6 +73,32 @@ public final class ElementClassifier {
     private record MobileKindRule(BiPredicate<String, String> matches, ElementKind kind) {
     }
 
+    /**
+     * WinAppDriver / Appium Windows UIA control-type tokens (tag or class often
+     * {@code ControlType.Edit}, {@code Edit}, {@code CheckBox}, …).
+     */
+    private static final Set<String> WINDOWS_TEXT_CLASSES = Set.of("edit", "document");
+    private static final Set<String> WINDOWS_BUTTON_CLASSES = Set.of("button");
+    private static final Set<String> WINDOWS_LINK_CLASSES = Set.of("hyperlink");
+    private static final Set<String> WINDOWS_TOGGLE_CLASSES = Set.of("checkbox");
+    private static final Set<String> WINDOWS_RADIO_CLASSES = Set.of("radiobutton");
+    private static final Set<String> WINDOWS_COMBO_CLASSES = Set.of("combobox");
+    /** Window / Pane — focus surfaces only; not typed into as text fields. */
+    private static final Set<String> WINDOWS_FOCUS_SURFACE_CLASSES = Set.of("window", "pane");
+
+    /**
+     * First-match-wins Windows/UIA kind rules (NPath-safe table, same pattern as mobile).
+     * Button/CheckBox/Radio often already match mobile suffix sets; Edit/Document/Hyperlink/ComboBox
+     * need this table so they do not fall through to {@link ElementKind#UNKNOWN}.
+     */
+    private static final List<MobileKindRule> WINDOWS_KIND_RULES = List.of(
+            new MobileKindRule(ElementClassifier::isWindowsToggle, ElementKind.CHECKBOX),
+            new MobileKindRule(ElementClassifier::isWindowsRadio, ElementKind.RADIO),
+            new MobileKindRule(ElementClassifier::isWindowsTextField, ElementKind.TEXT_LIKE),
+            new MobileKindRule(ElementClassifier::isWindowsButton, ElementKind.BUTTON),
+            new MobileKindRule(ElementClassifier::isWindowsLink, ElementKind.LINK),
+            new MobileKindRule(ElementClassifier::isWindowsCombo, ElementKind.COMBOBOX));
+
     private ElementClassifier() {
     }
 
@@ -114,6 +141,11 @@ public final class ElementClassifier {
             return byMobile;
         }
 
+        ElementKind byWindows = classifyWindowsDesktop(tag, className, role);
+        if (byWindows != null) {
+            return byWindows;
+        }
+
         ElementKind byTag = classifyByTag(tag, role);
         if (byTag != null) {
             return byTag;
@@ -131,12 +163,39 @@ public final class ElementClassifier {
      * Conservative: only exact / well-known suffixes so custom views stay {@link ElementKind#UNKNOWN}.
      */
     static ElementKind classifyMobileNative(String tag, String className, String role) {
+        return classifyByKindRules(tag, className, role, MOBILE_KIND_RULES);
+    }
+
+    /**
+     * WinAppDriver / Appium Windows UIA ControlType tags. Returns null when not a known desktop control.
+     */
+    static ElementKind classifyWindowsDesktop(String tag, String className, String role) {
+        return classifyByKindRules(tag, className, role, WINDOWS_KIND_RULES);
+    }
+
+    /**
+     * True when tag/class looks like a UIA Window or Pane (foreground / focus surface).
+     */
+    public static boolean isWindowsFocusSurface(WebElement element) {
+        if (element == null) {
+            return false;
+        }
+        String token = firstNonBlank(safeTagName(element),
+                firstNonBlank(safeDom(element, "class"), safeProperty(element, "className")));
+        if (token == null) {
+            return false;
+        }
+        return WINDOWS_FOCUS_SURFACE_CLASSES.contains(simpleClassName(token));
+    }
+
+    private static ElementKind classifyByKindRules(String tag, String className, String role,
+                                                   List<MobileKindRule> rules) {
         String token = firstNonBlank(tag, className);
         if (token == null) {
             return null;
         }
         String simple = simpleClassName(token);
-        for (MobileKindRule rule : MOBILE_KIND_RULES) {
+        for (MobileKindRule rule : rules) {
             if (rule.matches().test(simple, role)) {
                 return rule.kind();
             }
@@ -170,6 +229,30 @@ public final class ElementClassifier {
 
     private static boolean isMobileRange(String simple) {
         return MOBILE_RANGE_CLASSES.contains(simple);
+    }
+
+    private static boolean isWindowsToggle(String simple, String role) {
+        return roleMatches(role, MOBILE_TOGGLE_ROLES) || WINDOWS_TOGGLE_CLASSES.contains(simple);
+    }
+
+    private static boolean isWindowsRadio(String simple, String role) {
+        return roleMatches(role, MOBILE_RADIO_ROLES) || WINDOWS_RADIO_CLASSES.contains(simple);
+    }
+
+    private static boolean isWindowsTextField(String simple, String role) {
+        return roleMatches(role, TEXT_ROLES) || WINDOWS_TEXT_CLASSES.contains(simple);
+    }
+
+    private static boolean isWindowsButton(String simple, String role) {
+        return roleMatches(role, MOBILE_BUTTON_ROLES) || WINDOWS_BUTTON_CLASSES.contains(simple);
+    }
+
+    private static boolean isWindowsLink(String simple, String role) {
+        return roleMatches(role, MOBILE_LINK_ROLES) || WINDOWS_LINK_CLASSES.contains(simple);
+    }
+
+    private static boolean isWindowsCombo(String simple, String role) {
+        return "combobox".equals(role) || "listbox".equals(role) || WINDOWS_COMBO_CLASSES.contains(simple);
     }
 
     private static boolean roleMatches(String role, Set<String> roles) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -173,17 +173,60 @@ public final class TypeStrategies {
 
     /**
      * Windows CheckBox / RadioButton: toggle via click (Invoke/Toggle), never sendKeys.
-     * Logs {@link WebElement#isSelected()} and {@code Toggle.ToggleState} when available.
+     * Asserts toggle state when {@link WebElement#isSelected()} or {@code Toggle.ToggleState} is observable.
      */
     public static void toggleDesktopInsteadOfTyping(WebDriver driver, WebElement element, ElementKind kind) {
         ReportManager.logDiscrete("type() on desktop " + kind + " redirected to click (toggle); sendKeys skipped.");
-        boolean before = safeIsSelected(element);
+        Boolean beforeSelected = tryIsSelected(element);
+        String beforeToggle = safeAttribute(element, "Toggle.ToggleState");
         ClickStrategies.focusWindows(driver, element);
-        boolean after = safeIsSelected(element);
-        String toggleState = safeAttribute(element, "Toggle.ToggleState");
-        ReportManager.logDiscrete("desktop toggle state selected=" + after
-                + (before == after ? " (unchanged from " + before + ")" : " (was " + before + ")")
-                + (toggleState == null ? "" : " Toggle.ToggleState=" + toggleState));
+        Boolean afterSelected = tryIsSelected(element);
+        String afterToggle = safeAttribute(element, "Toggle.ToggleState");
+        ReportManager.logDiscrete("desktop toggle state selected=" + afterSelected
+                + (afterToggle == null ? "" : " Toggle.ToggleState=" + afterToggle));
+        assertDesktopToggleChanged(kind, beforeSelected, afterSelected, beforeToggle, afterToggle);
+    }
+
+    /**
+     * Fail when a readable toggle signal exists and did not change after click.
+     * Skip the assert when neither {@code isSelected} nor {@code Toggle.ToggleState} is available.
+     */
+    static void assertDesktopToggleChanged(ElementKind kind, Boolean beforeSelected, Boolean afterSelected,
+                                           String beforeToggle, String afterToggle) {
+        boolean selectedObservable = beforeSelected != null && afterSelected != null;
+        boolean toggleAttrObservable = nonBlank(beforeToggle) || nonBlank(afterToggle);
+        if (!selectedObservable && !toggleAttrObservable) {
+            return;
+        }
+        // Already-selected radio is often idempotent under UIA click — do not fail.
+        if (kind == ElementKind.RADIO
+                && Boolean.TRUE.equals(beforeSelected)
+                && Boolean.TRUE.equals(afterSelected)
+                && !toggleAttrObservable) {
+            return;
+        }
+        boolean selectedChanged = selectedObservable && !beforeSelected.equals(afterSelected);
+        boolean toggleAttrChanged = toggleAttrObservable
+                && !String.valueOf(beforeToggle).equals(String.valueOf(afterToggle));
+        if (selectedChanged || toggleAttrChanged) {
+            return;
+        }
+        throw new InvalidElementStateException(
+                "Desktop toggle of " + kind + " did not change observable state"
+                        + " (selected " + beforeSelected + "→" + afterSelected
+                        + ", Toggle.ToggleState " + beforeToggle + "→" + afterToggle + ").");
+    }
+
+    private static boolean nonBlank(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static Boolean tryIsSelected(WebElement element) {
+        try {
+            return element.isSelected();
+        } catch (RuntimeException ignored) {
+            return null;
+        }
     }
 
     public static void setValueWithEvents(WebDriver driver, WebElement element, String text) {
@@ -353,14 +396,6 @@ public final class TypeStrategies {
         String value = safeAttribute(element, "Value.Value");
         if (value != null) {
             ReportManager.logDiscrete("UIA Value.Value after type: " + value);
-        }
-    }
-
-    private static boolean safeIsSelected(WebElement element) {
-        try {
-            return element.isSelected();
-        } catch (RuntimeException ignored) {
-            return false;
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -190,38 +190,63 @@ public final class TypeStrategies {
     /**
      * Fail when a readable toggle signal exists and did not change after click.
      * Skip the assert when neither {@code isSelected} nor {@code Toggle.ToggleState} is available.
+     * Early-exit helpers keep NPath under Codacy/PMD's gate.
      */
     static void assertDesktopToggleChanged(ElementKind kind, Boolean beforeSelected, Boolean afterSelected,
                                            String beforeToggle, String afterToggle) {
-        boolean selectedObservable = beforeSelected != null && afterSelected != null;
-        boolean toggleAttrObservable = nonBlank(beforeToggle) || nonBlank(afterToggle);
-        if (!selectedObservable && !toggleAttrObservable) {
+        if (!desktopToggleObservable(beforeSelected, afterSelected, beforeToggle, afterToggle)) {
             return;
         }
         // Already-selected radio is often idempotent under UIA click — do not fail
         // even when Toggle.ToggleState stays On/1.
-        if (kind == ElementKind.RADIO
-                && Boolean.TRUE.equals(beforeSelected)
-                && Boolean.TRUE.equals(afterSelected)) {
+        if (radioDesktopToggleAlreadySettled(kind, beforeSelected, afterSelected, beforeToggle, afterToggle)) {
             return;
         }
-        if (kind == ElementKind.RADIO
-                && toggleAttrObservable
-                && isToggleOnToken(beforeToggle)
-                && isToggleOnToken(afterToggle)
-                && !selectedObservable) {
-            return;
-        }
-        boolean selectedChanged = selectedObservable && !beforeSelected.equals(afterSelected);
-        boolean toggleAttrChanged = toggleAttrObservable
-                && !String.valueOf(beforeToggle).equals(String.valueOf(afterToggle));
-        if (selectedChanged || toggleAttrChanged) {
+        if (desktopToggleSignalChanged(beforeSelected, afterSelected, beforeToggle, afterToggle)) {
             return;
         }
         throw new InvalidElementStateException(
                 "Desktop toggle of " + kind + " did not change observable state"
                         + " (selected " + beforeSelected + "→" + afterSelected
                         + ", Toggle.ToggleState " + beforeToggle + "→" + afterToggle + ").");
+    }
+
+    private static boolean desktopToggleObservable(Boolean beforeSelected, Boolean afterSelected,
+                                                   String beforeToggle, String afterToggle) {
+        return selectedObservable(beforeSelected, afterSelected)
+                || toggleAttrObservable(beforeToggle, afterToggle);
+    }
+
+    private static boolean radioDesktopToggleAlreadySettled(ElementKind kind, Boolean beforeSelected,
+                                                            Boolean afterSelected, String beforeToggle,
+                                                            String afterToggle) {
+        if (kind != ElementKind.RADIO) {
+            return false;
+        }
+        if (Boolean.TRUE.equals(beforeSelected) && Boolean.TRUE.equals(afterSelected)) {
+            return true;
+        }
+        return toggleAttrObservable(beforeToggle, afterToggle)
+                && isToggleOnToken(beforeToggle)
+                && isToggleOnToken(afterToggle)
+                && !selectedObservable(beforeSelected, afterSelected);
+    }
+
+    private static boolean desktopToggleSignalChanged(Boolean beforeSelected, Boolean afterSelected,
+                                                      String beforeToggle, String afterToggle) {
+        boolean selectedChanged = selectedObservable(beforeSelected, afterSelected)
+                && !beforeSelected.equals(afterSelected);
+        boolean toggleAttrChanged = toggleAttrObservable(beforeToggle, afterToggle)
+                && !String.valueOf(beforeToggle).equals(String.valueOf(afterToggle));
+        return selectedChanged || toggleAttrChanged;
+    }
+
+    private static boolean selectedObservable(Boolean beforeSelected, Boolean afterSelected) {
+        return beforeSelected != null && afterSelected != null;
+    }
+
+    private static boolean toggleAttrObservable(String beforeToggle, String afterToggle) {
+        return nonBlank(beforeToggle) || nonBlank(afterToggle);
     }
 
     private static boolean nonBlank(String value) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -18,11 +19,17 @@ import java.util.Map;
  * Routes {@code type} by {@link ElementKind} so checkbox/radio/select/file/date/contenteditable
  * never take the blind clear+sendKeys path. Unknown kinds stay on the legacy caller path.
  * Mobile native (#5732 Wave D): focus → setValue / sendKeys / {@code mobile: type} → optional hideKeyboard.
+ * Windows desktop (#5732 Wave E): focus → clear → sendKeys / {@code windows: keys}; CheckBox/Radio toggle
+ * (not sendKeys); ComboBox expand then type-to-filter + Enter.
  *
  * <p><b>Compose / Flutter notes:</b> Jetpack Compose TextFields often reject setValue/sendKeys until
  * focused (enable {@code testTagsAsResourceId} and tap first). Flutter TextFields need ValueKey /
  * Semantics identifiers; after focus prefer driver sendKeys or {@code flutter:*} enter-text helpers.
  * When setValue is rejected without focus, SHAFT throws an actionable {@link InvalidElementStateException}.
+ *
+ * <p><b>WinAppDriver / UIA notes:</b> Prefer WebElement click/clear/sendKeys. On flake use
+ * {@code windows: click} / {@code windows: keys}. Value pattern is read via {@code Value.Value} when
+ * present; writing still goes through clear+keys (classic WinAppDriver has no setValue script).
  */
 public final class TypeStrategies {
 
@@ -81,6 +88,16 @@ public final class TypeStrategies {
         LEGACY_SEND_KEYS
     }
 
+    /** Windows desktop / UIA type routes (Wave E). */
+    public enum DesktopTypeRoute {
+        TOGGLE_CLICK,
+        DESKTOP_TEXT,
+        COMBOBOX,
+        REJECT,
+        /** Unknown / button / link — keep sendKeys after focus for conservative compatibility. */
+        LEGACY_SEND_KEYS
+    }
+
     private TypeStrategies() {
     }
 
@@ -104,6 +121,16 @@ public final class TypeStrategies {
             case DISABLED, READONLY, IFRAME, FILE, SELECT, RANGE, DATE_LIKE, COLOR -> MobileTypeRoute.REJECT;
             case TEXT_LIKE, COMBOBOX, CONTENTEDITABLE, UNKNOWN -> MobileTypeRoute.MOBILE_TEXT;
             case BUTTON, LINK -> MobileTypeRoute.LEGACY_SEND_KEYS;
+        };
+    }
+
+    public static DesktopTypeRoute desktopRouteFor(ElementKind kind) {
+        return switch (kind) {
+            case CHECKBOX, RADIO -> DesktopTypeRoute.TOGGLE_CLICK;
+            case TEXT_LIKE, CONTENTEDITABLE -> DesktopTypeRoute.DESKTOP_TEXT;
+            case COMBOBOX -> DesktopTypeRoute.COMBOBOX;
+            case DISABLED, READONLY, IFRAME, FILE, SELECT, RANGE, DATE_LIKE, COLOR -> DesktopTypeRoute.REJECT;
+            case BUTTON, LINK, UNKNOWN -> DesktopTypeRoute.LEGACY_SEND_KEYS;
         };
     }
 
@@ -142,6 +169,21 @@ public final class TypeStrategies {
     public static void toggleMobileInsteadOfTyping(WebDriver driver, WebElement element, ElementKind kind) {
         ReportManager.logDiscrete("type() on mobile " + kind + " redirected to tap (toggle); sendKeys skipped.");
         ClickStrategies.focusTap(driver, element);
+    }
+
+    /**
+     * Windows CheckBox / RadioButton: toggle via click (Invoke/Toggle), never sendKeys.
+     * Logs {@link WebElement#isSelected()} and {@code Toggle.ToggleState} when available.
+     */
+    public static void toggleDesktopInsteadOfTyping(WebDriver driver, WebElement element, ElementKind kind) {
+        ReportManager.logDiscrete("type() on desktop " + kind + " redirected to click (toggle); sendKeys skipped.");
+        boolean before = safeIsSelected(element);
+        ClickStrategies.focusWindows(driver, element);
+        boolean after = safeIsSelected(element);
+        String toggleState = safeAttribute(element, "Toggle.ToggleState");
+        ReportManager.logDiscrete("desktop toggle state selected=" + after
+                + (before == after ? " (unchanged from " + before + ")" : " (was " + before + ")")
+                + (toggleState == null ? "" : " Toggle.ToggleState=" + toggleState));
     }
 
     public static void setValueWithEvents(WebDriver driver, WebElement element, String text) {
@@ -251,6 +293,90 @@ public final class TypeStrategies {
             } catch (RuntimeException ignored) {
                 ReportManager.logDiscrete("hideKeyboard after typing was requested but failed; continuing.");
             }
+        }
+    }
+
+    /**
+     * Windows Edit / Document text entry after focus: {@code sendKeys} → {@code windows: keys}.
+     * Value pattern ({@code Value.Value}) is observed when present; writing uses keys.
+     */
+    public static void typeDesktopText(WebDriver driver, WebElement element, CharSequence[] text) {
+        String typed = stringify(text);
+        try {
+            element.sendKeys(text);
+            logValuePatternIfPresent(element);
+            return;
+        } catch (RuntimeException sendKeysFailure) {
+            ReportManager.logDiscrete("desktop sendKeys failed; trying windows: keys.");
+            windowsKeys(driver, typed);
+            logValuePatternIfPresent(element);
+        }
+    }
+
+    /**
+     * Windows ComboBox: click to expand (best-effort), type-to-filter, then Enter to commit.
+     */
+    public static void typeDesktopCombobox(WebDriver driver, WebElement element, CharSequence[] text) {
+        ClickStrategies.focusWindows(driver, element);
+        String typed = stringify(text);
+        try {
+            if (!typed.isEmpty()) {
+                element.sendKeys(text);
+            }
+            element.sendKeys(Keys.ENTER);
+        } catch (RuntimeException sendKeysFailure) {
+            ReportManager.logDiscrete("desktop ComboBox sendKeys failed; trying windows: keys + Enter.");
+            if (!typed.isEmpty()) {
+                windowsKeys(driver, typed);
+            }
+            Map<String, Object> enter = new LinkedHashMap<>();
+            enter.put("virtualKeyCode", 0x0D);
+            windowsKeys(driver, List.of(enter));
+        }
+    }
+
+    static void windowsKeys(WebDriver driver, String text) {
+        windowsKeys(driver, List.of(Map.of("text", text == null ? "" : text)));
+    }
+
+    static void windowsKeys(WebDriver driver, List<Map<String, Object>> actions) {
+        if (!(driver instanceof JavascriptExecutor executor)) {
+            throw new InvalidElementStateException(
+                    "windows: keys requires a driver that executes scripts.");
+        }
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("actions", actions);
+        executor.executeScript("windows: keys", params);
+    }
+
+    private static void logValuePatternIfPresent(WebElement element) {
+        String value = safeAttribute(element, "Value.Value");
+        if (value != null) {
+            ReportManager.logDiscrete("UIA Value.Value after type: " + value);
+        }
+    }
+
+    private static boolean safeIsSelected(WebElement element) {
+        try {
+            return element.isSelected();
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    private static String safeAttribute(WebElement element, String name) {
+        try {
+            String dom = element.getDomAttribute(name);
+            if (dom != null && !dom.isBlank()) {
+                return dom;
+            }
+        } catch (RuntimeException ignored) {
+            // Fall through to getAttribute.
+        }
+        try {
+            return element.getAttribute(name);
+        } catch (RuntimeException ignored) {
+            return null;
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/TypeStrategies.java
@@ -198,11 +198,18 @@ public final class TypeStrategies {
         if (!selectedObservable && !toggleAttrObservable) {
             return;
         }
-        // Already-selected radio is often idempotent under UIA click — do not fail.
+        // Already-selected radio is often idempotent under UIA click — do not fail
+        // even when Toggle.ToggleState stays On/1.
         if (kind == ElementKind.RADIO
                 && Boolean.TRUE.equals(beforeSelected)
-                && Boolean.TRUE.equals(afterSelected)
-                && !toggleAttrObservable) {
+                && Boolean.TRUE.equals(afterSelected)) {
+            return;
+        }
+        if (kind == ElementKind.RADIO
+                && toggleAttrObservable
+                && isToggleOnToken(beforeToggle)
+                && isToggleOnToken(afterToggle)
+                && !selectedObservable) {
             return;
         }
         boolean selectedChanged = selectedObservable && !beforeSelected.equals(afterSelected);
@@ -219,6 +226,14 @@ public final class TypeStrategies {
 
     private static boolean nonBlank(String value) {
         return value != null && !value.isBlank();
+    }
+
+    private static boolean isToggleOnToken(String raw) {
+        if (raw == null) {
+            return false;
+        }
+        String lower = raw.trim().toLowerCase(Locale.ROOT);
+        return "on".equals(lower) || "1".equals(lower) || "true".equals(lower);
     }
 
     private static Boolean tryIsSelected(WebElement element) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/package-info.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/package-info.java
@@ -5,6 +5,11 @@
  * focus → {@code sendKeys} / {@code mobile: replaceElementValue} / {@code mobile: type},
  * W3C touch click fallback, and checkbox/switch toggle semantics.
  *
+ * <p>Wave E covers Windows desktop (WinAppDriver / UIA): Edit/Document click→clear→sendKeys
+ * ({@code windows: keys} fallback; {@code Value.Value} observed when present), Button/Hyperlink
+ * Invoke via click/{@code windows: click}, CheckBox/RadioButton toggle (not sendKeys), ComboBox
+ * expand → type-to-filter → Enter, and Window/Pane foreground focus before type.
+ *
  * <p>Compose: enable {@code testTagsAsResourceId} and tap before type.
  * Flutter: prefer ValueKey/Semantics; type after focus.
  */

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/DesktopInteractionStrategiesTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/DesktopInteractionStrategiesTest.java
@@ -1,0 +1,265 @@
+package com.shaft.gui.element.internal.interaction;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.gui.browser.internal.JavaScriptWaitManager;
+import com.shaft.gui.element.internal.Actions;
+import com.shaft.gui.internal.locator.LocatorBuilder;
+import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
+import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.internal.FlakeProfiler;
+import io.appium.java_client.windows.WindowsDriver;
+import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Wave E (#5732): mocked WinAppDriver / UIA click/type routing without a live desktop session.
+ */
+@Test(singleThreaded = true)
+public class DesktopInteractionStrategiesTest {
+    private static final By LOCATOR = By.id("desktop-target");
+    private static final byte[] PNG = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+
+    @BeforeMethod
+    public void configureWindowsDesktopMockSession() {
+        SHAFT.Properties.reporting.set().captureElementName(false);
+        SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(false);
+        SHAFT.Properties.flags.set().scrollingMode("legacy");
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
+        SHAFT.Properties.flags.set().forceCheckTextWasTypedCorrectly(false);
+        SHAFT.Properties.flags.set().attemptToClickBeforeTyping(false);
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(false);
+        SHAFT.Properties.visuals.set().createAnimatedGif(false);
+        SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("ValidationPointsOnly");
+        SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
+        SHAFT.Properties.platform.set().targetPlatform(Platform.WINDOWS.name());
+        SHAFT.Properties.web.set().targetBrowserName("WindowsApp");
+        SHAFT.Properties.mobile.set().browserName("");
+        LocatorBuilder.cleanup();
+        ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanupThreadLocalState() {
+        LocatorBuilder.cleanup();
+        ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
+        Properties.clearForCurrentThread();
+    }
+
+    @DataProvider(name = "windowsKinds")
+    public Object[][] windowsKinds() {
+        return new Object[][]{
+                {uiaElement("ControlType.Edit"), ElementKind.TEXT_LIKE},
+                {uiaElement("Edit"), ElementKind.TEXT_LIKE},
+                {uiaElement("ControlType.Document"), ElementKind.TEXT_LIKE},
+                {uiaElement("Document"), ElementKind.TEXT_LIKE},
+                {uiaElement("ControlType.Button"), ElementKind.BUTTON},
+                {uiaElement("Button"), ElementKind.BUTTON},
+                {uiaElement("ControlType.Hyperlink"), ElementKind.LINK},
+                {uiaElement("Hyperlink"), ElementKind.LINK},
+                {uiaElement("ControlType.CheckBox"), ElementKind.CHECKBOX},
+                {uiaElement("CheckBox"), ElementKind.CHECKBOX},
+                {uiaElement("ControlType.RadioButton"), ElementKind.RADIO},
+                {uiaElement("RadioButton"), ElementKind.RADIO},
+                {uiaElement("ControlType.ComboBox"), ElementKind.COMBOBOX},
+                {uiaElement("ComboBox"), ElementKind.COMBOBOX},
+        };
+    }
+
+    @Test(dataProvider = "windowsKinds")
+    public void classifierRecognizesWindowsUiaControls(WebElement element, ElementKind expected) {
+        Assert.assertEquals(ElementClassifier.classify(element), expected);
+    }
+
+    @Test
+    public void focusSurfacesAreWindowAndPane() {
+        Assert.assertTrue(ElementClassifier.isWindowsFocusSurface(uiaElement("ControlType.Window")));
+        Assert.assertTrue(ElementClassifier.isWindowsFocusSurface(uiaElement("Pane")));
+        Assert.assertFalse(ElementClassifier.isWindowsFocusSurface(uiaElement("ControlType.Edit")));
+        Assert.assertFalse(ElementClassifier.isWindowsFocusSurface(null));
+    }
+
+    @Test
+    public void desktopRouteMapsToggleTextAndCombo() {
+        Assert.assertEquals(TypeStrategies.desktopRouteFor(ElementKind.CHECKBOX),
+                TypeStrategies.DesktopTypeRoute.TOGGLE_CLICK);
+        Assert.assertEquals(TypeStrategies.desktopRouteFor(ElementKind.RADIO),
+                TypeStrategies.DesktopTypeRoute.TOGGLE_CLICK);
+        Assert.assertEquals(TypeStrategies.desktopRouteFor(ElementKind.TEXT_LIKE),
+                TypeStrategies.DesktopTypeRoute.DESKTOP_TEXT);
+        Assert.assertEquals(TypeStrategies.desktopRouteFor(ElementKind.COMBOBOX),
+                TypeStrategies.DesktopTypeRoute.COMBOBOX);
+        Assert.assertEquals(TypeStrategies.desktopRouteFor(ElementKind.DISABLED),
+                TypeStrategies.DesktopTypeRoute.REJECT);
+    }
+
+    @Test
+    public void typeEditFocusesThenSendKeys() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.Edit");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "hello-desktop");
+            verify(element).click();
+            verify(element).sendKeys(eq("hello-desktop"));
+        }
+    }
+
+    @Test
+    public void typeCheckBoxTogglesAndNeverSendKeys() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.CheckBox");
+        when(element.isSelected()).thenReturn(false, true);
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "ignored");
+            verify(element).click();
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+            verify(element, never()).sendKeys(anyString());
+        }
+    }
+
+    @Test
+    public void typeComboBoxExpandsFiltersAndEnters() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.ComboBox");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "Option A");
+            verify(element).click();
+            verify(element).sendKeys(eq("Option A"));
+            verify(element, atLeastOnce()).sendKeys(any(CharSequence[].class));
+        }
+    }
+
+    @Test
+    public void typeFallsBackToWindowsKeysWhenSendKeysRejected() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.Edit");
+        doThrow(new InvalidElementStateException("not focused")).when(element).sendKeys(any(CharSequence[].class));
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "via-keys");
+            verify(driver).executeScript(eq("windows: keys"), any(Map.class));
+        }
+    }
+
+    @Test
+    public void clickUsesWindowsClickFallbackWhenWebDriverClickFlakes() {
+        WindowsDriver driver = mockWindowsDriver();
+        RemoteWebElement element = mock(RemoteWebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("ControlType.Button");
+        when(element.getAttribute(anyString())).thenReturn(null);
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getText()).thenReturn("");
+        when(element.getRect()).thenReturn(new Rectangle(10, 20, 40, 60));
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        when(element.getId()).thenReturn("uia-button-1");
+        doThrow(new InvalidElementStateException("not clickable")).when(element).click();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).click(LOCATOR);
+            verify(driver, atLeastOnce()).executeScript(eq("windows: click"), any(Map.class));
+        }
+    }
+
+    @Test
+    public void webDefaultsUnchangedWhenNotWindowsDesktop() {
+        SHAFT.Properties.platform.set().targetPlatform(Platform.LINUX.name());
+        SHAFT.Properties.web.set().targetBrowserName("chrome");
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
+
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("button");
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getAttribute(anyString())).thenReturn(null);
+        when(element.getRect()).thenReturn(new Rectangle(10, 20, 30, 40));
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        doThrow(new InvalidElementStateException("blocked")).when(element).click();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).click(LOCATOR);
+            verify(driver).executeScript(eq("arguments[0].click();"), eq(element));
+            verify(driver, never()).executeScript(eq("windows: click"), any(Map.class));
+        }
+    }
+
+    @Test
+    public void typeDesktopTextDirectWindowsKeys() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("Edit");
+        doThrow(new InvalidElementStateException("sendKeys blocked")).when(element).sendKeys(any(CharSequence[].class));
+
+        TypeStrategies.typeDesktopText(driver, element, new CharSequence[]{"via-keys"});
+        verify(driver).executeScript(eq("windows: keys"), any(Map.class));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static WindowsDriver mockWindowsDriver() {
+        return mock(WindowsDriver.class, org.mockito.Mockito.withSettings()
+                .extraInterfaces(TakesScreenshot.class));
+    }
+
+    private DriverFactoryHelper helperFor(WindowsDriver driver) {
+        DriverFactoryHelper helper = mock(DriverFactoryHelper.class);
+        when(helper.getDriver()).thenReturn(driver);
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        return helper;
+    }
+
+    private WebElement uiaElement(String controlType) {
+        WebElement element = mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.isSelected()).thenReturn(false);
+        when(element.getAccessibleName()).thenReturn("desktop target");
+        when(element.getText()).thenReturn("");
+        when(element.getTagName()).thenReturn(controlType);
+        when(element.getAttribute(anyString())).thenReturn(null);
+        when(element.getDomAttribute(anyString())).thenReturn(null);
+        when(element.getDomProperty(anyString())).thenReturn(null);
+        when(element.getCssValue(anyString())).thenReturn("");
+        when(element.getRect()).thenReturn(new Rectangle(10, 20, 40, 60));
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        return element;
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/DesktopInteractionStrategiesTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/DesktopInteractionStrategiesTest.java
@@ -194,6 +194,36 @@ public class DesktopInteractionStrategiesTest {
     }
 
     @Test
+    public void typeAlreadySelectedRadioWithToggleStateDoesNotFail() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.RadioButton");
+        when(element.isSelected()).thenReturn(true, true);
+        when(element.getAttribute("Toggle.ToggleState")).thenReturn("On");
+        when(element.getDomAttribute("Toggle.ToggleState")).thenReturn("On");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "ignored");
+            verify(element).click();
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+        }
+    }
+
+    @Test
+    public void typeAppendComboBoxExpandsFiltersAndEnters() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.ComboBox");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).typeAppend(LOCATOR, "Option B");
+            verify(element).click();
+            verify(element).sendKeys(eq("Option B"));
+            verify(element).sendKeys(Keys.ENTER);
+        }
+    }
+
+    @Test
     public void typeWindowOnlyEnsuresForeground() {
         WindowsDriver driver = mockWindowsDriver();
         WebElement element = uiaElement("ControlType.Window");

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/DesktopInteractionStrategiesTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/interaction/DesktopInteractionStrategiesTest.java
@@ -11,6 +11,7 @@ import com.shaft.tools.io.internal.FlakeProfiler;
 import io.appium.java_client.windows.WindowsDriver;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.Rectangle;
@@ -133,6 +134,21 @@ public class DesktopInteractionStrategiesTest {
     }
 
     @Test
+    public void typeEditWithNativeClearDoesClickClearSendKeys() {
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("native");
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.Edit");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "replaced");
+            verify(element).click();
+            verify(element).clear();
+            verify(element).sendKeys(eq("replaced"));
+        }
+    }
+
+    @Test
     public void typeCheckBoxTogglesAndNeverSendKeys() {
         WindowsDriver driver = mockWindowsDriver();
         WebElement element = uiaElement("ControlType.CheckBox");
@@ -141,6 +157,50 @@ public class DesktopInteractionStrategiesTest {
 
         try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
             new Actions(helperFor(driver)).type(LOCATOR, "ignored");
+            verify(element).click();
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+            verify(element, never()).sendKeys(anyString());
+        }
+    }
+
+    @Test
+    public void typeAppendCheckBoxTogglesAndNeverSendKeys() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.CheckBox");
+        when(element.isSelected()).thenReturn(false, true);
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).typeAppend(LOCATOR, "ignored");
+            verify(element).click();
+            verify(element, never()).sendKeys(any(CharSequence[].class));
+            verify(element, never()).sendKeys(anyString());
+        }
+    }
+
+    @Test
+    public void typeCheckBoxFailsWhenToggleStateUnchanged() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.CheckBox");
+        when(element.isSelected()).thenReturn(false, false);
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            RuntimeException exception = Assert.expectThrows(RuntimeException.class,
+                    () -> new Actions(helperFor(driver)).type(LOCATOR, "ignored"));
+            Assert.assertTrue(hasCauseMessage(exception, "did not change observable state"),
+                    "Expected toggle assert in: " + exception);
+        }
+    }
+
+    @Test
+    public void typeWindowOnlyEnsuresForeground() {
+        WindowsDriver driver = mockWindowsDriver();
+        WebElement element = uiaElement("ControlType.Window");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "should-not-type");
             verify(element).click();
             verify(element, never()).sendKeys(any(CharSequence[].class));
             verify(element, never()).sendKeys(anyString());
@@ -157,7 +217,7 @@ public class DesktopInteractionStrategiesTest {
             new Actions(helperFor(driver)).type(LOCATOR, "Option A");
             verify(element).click();
             verify(element).sendKeys(eq("Option A"));
-            verify(element, atLeastOnce()).sendKeys(any(CharSequence[].class));
+            verify(element).sendKeys(Keys.ENTER);
         }
     }
 
@@ -261,5 +321,16 @@ public class DesktopInteractionStrategiesTest {
         when(element.getRect()).thenReturn(new Rectangle(10, 20, 40, 60));
         when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
         return element;
+    }
+
+    private boolean hasCauseMessage(Throwable throwable, String fragment) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current.getMessage() != null && current.getMessage().contains(fragment)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
Wave E of epic #5732 — Windows desktop (WinAppDriver / UIA) click/type strategies on top of Waves B–D (already on `main`).

- **Edit / Document:** focus → clear (honors `clearBeforeTypingMode`) → `sendKeys`, with `windows: keys` fallback; observes `Value.Value` when present
- **Button / Hyperlink:** native click, then `windows: click` on flake (Invoke-equivalent; no JS on desktop path)
- **CheckBox / RadioButton:** toggle via click, never `sendKeys`; asserts observable `isSelected` / `Toggle.ToggleState` (radio already-selected stays idempotent)
- **ComboBox:** expand (click) → type-to-filter → Enter
- **Window / Pane:** `type`/`typeAppend` only ensures foreground focus (no sendKeys into chrome)
- **Classifier:** UIA ControlType tokens (`ControlType.Edit`, `Edit`, `CheckBox`, `ComboBox`, …) via NPath-safe rule tables
- **No public API break**; web defaults unchanged unless `DriverFactoryHelper.isWindowsAppiumExecution()`

Part of #5732 (does **not** close the epic — Wave A docs pointer / Wave F proof may still remain).

## Files
- `shaft-engine/.../interaction/ElementClassifier.java` — Windows/UIA control-type sets + focus-surface helper
- `shaft-engine/.../interaction/ClickStrategies.java` — `windows: click` fallback + `focusWindows`
- `shaft-engine/.../interaction/TypeStrategies.java` — desktop routes, toggle assert, ComboBox, `windows: keys`
- `shaft-engine/.../interaction/package-info.java` — Wave E pointer
- `shaft-engine/.../Actions.java` — wire Windows TYPE / TYPE_APPEND / CLICK
- `DesktopInteractionStrategiesTest.java` — mocked WinAppDriver routing (no live session)

## Tests
```bash
mvn -pl shaft-engine \
  -Dtest=DesktopInteractionStrategiesTest,ElementClassifierTest,MobileInteractionStrategiesTest,InteractionStrategiesActionsTest \
  -Dallure.automaticallyOpen=false -DheadlessExecution=true test
```
Result: **102 tests, 0 failures** (local).

## Residual risks
- Live WinAppDriver / Windows CI not run here (mocked Appium Windows path only; `WindowsDesktopAppiumE2ETest` remains opt-in via `-DrunWindowsDesktopE2E=true`)
- Classic WinAppDriver has no `windows: setValue`; value writing stays clear+keys; `Value.Value` is read-only observation
- Toggle assert is skipped when neither `isSelected` nor `Toggle.ToggleState` is readable
- Classifier Windows tokens are matched on any platform when tags look like UIA names (conservative overlap with mobile/web kinds)

## Out of scope
Wave F live-user proof. Broader user-guide Wave A docs left for docs follow-up (package-info pointer included).