### PR TITLE
feat(chaos-engine): OmniRoute coding candidate filter + wave proof learnings (#5742)

### DIFF
--- a/chaos-engine/profiles/shaft/references/shaft-mastery/testng-lifecycle.md
+++ b/chaos-engine/profiles/shaft/references/shaft-mastery/testng-lifecycle.md
@@ -40,3 +40,14 @@ once forwarded the outer JVM's own `headlessExecution` instead of forcing
 - Parallel TestNG (`parallel="methods|classes"`) requires everything
   ThreadLocal (SHAFT drivers are); a static mutable field in test scope is a
   flake factory.
+
+## N-run proof under failure-ignore (#5739)
+The shaft-engine Surefire profile may set `testFailureIgnore=true` so JaCoCo
+can still report. Maven exit `0` then does **not** prove a green suite.
+Flake-proof / Wave N-run scripts must:
+
+1. Pass `-Dmaven.test.failure.ignore=false` on the proof invocation.
+2. After each run, parse Surefire `TEST-*.xml` (`failures` / `errors`) or
+   TestNG `testng-results.xml` (`failed`) and require zero.
+3. Call `python3 scripts/ci/assert_surefire_green.py <surefire-reports-dir>`
+   rather than trusting process exit alone.

--- a/chaos-engine/references/work-github-playbook.md
+++ b/chaos-engine/references/work-github-playbook.md
@@ -27,6 +27,26 @@ the PR with an explicit base. Persist its `baseRefName`, PR identity, and
 `closingIssuesReferences`. Keep nonempty `## Summary`, `## Checks`, and
 `## Continuation` sections current for the delivered head.
 
+### Wave PR open checklist (before first push)
+
+Strategy-matrix / Wave PRs fail governance without a release-note label and
+fail static analysis when Java switches lack a default branch. Before the
+first push of any Wave or strategy-matrix PR:
+
+1. Apply **exactly one** release-note classification label:
+   `breaking-change`, `enhancement`, `bug`, or `skip-release-notes`.
+2. Verify Java `switch` expressions/statements are **exhaustive** (include a
+   `default` branch where Codacy/`MissingDefaultCase` requires it). Confirm
+   locally before push so the first CI cycle is not a fix-push for labels or
+   switch exhaustiveness.
+
+N-run / flake-proof scripts that invoke Maven under the engine Surefire
+profile must not treat process exit alone as green: after each proof
+invocation, require a zero failed count from Surefire `TEST-*.xml` or
+TestNG `testng-results.xml` (and set `-Dmaven.test.failure.ignore=false`
+for defense in depth). Use
+[`scripts/ci/assert_surefire_green.py`](../../scripts/ci/assert_surefire_green.py).
+
 ## 5. Docs, catalog, and screenshots — only where real
 
 Update user documentation and the feature catalog only for shipped behavior.

--- a/chaos-engine/skills/omniroute/SKILL.md
+++ b/chaos-engine/skills/omniroute/SKILL.md
@@ -55,6 +55,7 @@ omniroute --output json models
 omniroute --output json usage quota
 omniroute --output json models <provider>
 python3 chaos-engine/skills/omniroute/scripts/runner.py candidates --capability mechanical|default|most-intelligent
+python3 chaos-engine/skills/omniroute/scripts/runner.py candidates --capability default --task coding|implementation|general
 ```
 
 Do not add `--json` after the `models` subcommand: that form prints a table, not JSON. Use `--output json` before `models`.
@@ -82,6 +83,41 @@ otherwise default. Architecture, review, and analytical work use only
 most-intelligent. Implementation uses `default` first, then most-intelligent,
 then mechanical. Do not pin a Codex profile model such as Gemini Flash-Lite.
 Empty result is `RUNTIME_EXHAUSTED`.
+
+### Coding candidate filter (implementation)
+
+For `--capability default` and for `--task coding|implementation`, rank from
+the live ids with an allow/deny token filter — never a stored model list:
+
+- **Deny** (drop before ranking): tokens `safety`, `guard`, `translate`,
+  `nano`, `tiny`.
+- **Boost** (sort first within the remaining pool): tokens/substrings `code`,
+  `coder`, `sonnet`, `claude`, `gpt-oss`, `qwen`, `kimi`, `devstral` (also
+  ids whose tokens start with `qwen`/`kimi` or contain `code`).
+
+Mechanical and most-intelligent capability selections without an explicit
+coding task keep the older capability-only ranking and do not apply this
+filter. Catalog ranking never writes route, model, or provider ids into
+repository files.
+
+When the gateway supports combo routing, prefer trying
+`omniroute run --model auto/coding` (or category coding) first; on failure or
+unsupported combo, fall back to the ranked native id from `candidates`.
+
+### Dispatch checklist (READY)
+
+1. Health on loopback only: `curl -sf --max-time 2 http://127.0.0.1:20128/api/health`.
+2. Live `candidates` (coding filter for implementation).
+3. Pick the first remaining identity; never reuse a just-failed identity on 429.
+4. On `READY`, launch `omniroute run --model --provider <target>` before any
+   native host model. Prefer the first installed target: `claude`, then
+   `opencode`, then `codex` (skip exit `127` missing binaries).
+5. On fail: skip that identity/provider, requery, next remaining id.
+6. Native host models only on `RUNTIME_EXHAUSTED`, empty remaining catalog,
+   sealed-launcher exit `78`, or missing OmniRoute binary (`ABSENT`).
+
+**Process failure:** ranking `candidates` then shipping via the native host
+model while OmniRoute is `READY` is not success. Catalog ≠ dispatch.
 
 Retry is chosen from the failure, not from a pinned profile. Official
 troubleshooting splits transient rate/400/401 from hard quota exhaustion:
@@ -153,9 +189,10 @@ Native host models only when OmniRoute itself cannot run.
 
 Canonical orchestration must probe the fixed loopback endpoint before native
 fallback, with no endpoint prompt. On `READY` after a live `candidates` pick,
-dispatch through `omniroute run` as above. A concrete `RUNTIME_EXHAUSTED`
-health result, empty remaining catalog, or sealed-launcher exit code `78`
-permits native implementer fallback.
+**must** dispatch through `omniroute run` as above before any native host
+model. A concrete `RUNTIME_EXHAUSTED` health result, empty remaining catalog,
+missing OmniRoute binary, or sealed-launcher exit code `78` permits native
+implementer fallback.
 
 ## Runner
 
@@ -164,6 +201,7 @@ Use only the standard-library [runner](scripts/runner.py):
 ```text
 python3 chaos-engine/skills/omniroute/scripts/runner.py probe
 python3 chaos-engine/skills/omniroute/scripts/runner.py candidates --capability mechanical|default|most-intelligent
+python3 chaos-engine/skills/omniroute/scripts/runner.py candidates --capability default --task coding
 python3 chaos-engine/skills/omniroute/scripts/runner.py dispatch --contract <private-state>/dispatch.json
 python3 chaos-engine/skills/omniroute/scripts/runner.py status ...
 python3 chaos-engine/skills/omniroute/scripts/runner.py cancel ...

--- a/chaos-engine/skills/omniroute/scripts/runner.py
+++ b/chaos-engine/skills/omniroute/scripts/runner.py
@@ -51,9 +51,16 @@ READINESS = frozenset({
 })
 RUN_STATUSES = frozenset({"planned", "running", "stalled", "blocked", "review", "completed", "cancelled", "quarantined"})
 _CAPABILITY_RANK = {"mechanical": 0, "default": 1, "most-intelligent": 2}
+_CODING_TASKS = frozenset({"coding", "implementation"})
 _ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 _MECHANICAL_MARKERS = frozenset({"low", "lite", "flash", "air", "mini", "nano", "turbo", "haiku", "small"})
 _HIGH_MARKERS = frozenset({"high", "max", "pro", "ultra", "opus", "thinking", "reasoner"})
+# Implementation ranking: prefer coding-tagged ids; drop unfit safety/tiny rows.
+_CODING_DENY_MARKERS = frozenset({"safety", "guard", "translate", "nano", "tiny"})
+_CODING_BOOST_MARKERS = frozenset({
+    "code", "coder", "sonnet", "claude", "qwen", "kimi", "devstral",
+})
+_CODING_BOOST_SUBSTRINGS = ("gpt-oss",)
 _CATALOG_COMMAND = ("omniroute", "--output", "json", "models")
 _QUOTA_COMMAND = ("omniroute", "--output", "json", "usage", "quota")
 _PROVIDER_ARG = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
@@ -864,6 +871,42 @@ def classify_capability(model_id: object) -> str:
     return "default"
 
 
+def _model_tokens(model_id: object) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", catalog_launch_id(model_id).lower()))
+
+
+def is_coding_denied(model_id: object) -> bool:
+    """True when the live id looks like safety/guard/translate/nano/tiny rather than coding."""
+    tokens = _model_tokens(model_id)
+    if tokens & _CODING_DENY_MARKERS:
+        return True
+    return False
+
+
+def is_coding_boosted(model_id: object) -> bool:
+    """True when the live id looks coding-capable (code/coder/sonnet/claude/gpt-oss/qwen/kimi/devstral)."""
+    text = catalog_launch_id(model_id).lower()
+    if any(needle in text for needle in _CODING_BOOST_SUBSTRINGS):
+        return True
+    tokens = _model_tokens(model_id)
+    if tokens & _CODING_BOOST_MARKERS:
+        return True
+    for token in tokens:
+        if token.startswith(("qwen", "kimi")) or "code" in token:
+            return True
+    return False
+
+
+def applies_coding_candidate_filter(
+    *, required_capability: str, task: str | None = None,
+) -> bool:
+    """Coding filter runs for implementation (`default`) and explicit coding/implementation tasks."""
+    normalized = (task or "").strip().lower()
+    if normalized in _CODING_TASKS:
+        return True
+    return required_capability == "default"
+
+
 _DEFAULT_TASK_ORDER = {"default": 0, "most-intelligent": 1, "mechanical": 2}
 _RATE_LIMIT_MARKERS = ("429", "too many requests", "resource_exhausted", "rate limit")
 _QUOTA_RESET_MARKERS = ("quota reset", "quota-reset", "rate limit reset")
@@ -1110,10 +1153,17 @@ def select_live_candidates(
     catalog: object, quota: object, *, required_capability: str,
     skip_identity_sha256s: object = (),
     exhaustion_cache: object = None,
+    task: str | None = None,
 ) -> list[dict[str, Any]]:
     """Join the current catalog to remaining quota and order the next usable model."""
     if required_capability not in _CAPABILITY_RANK:
         raise OmniRouteError("required capability is invalid")
+    normalized_task = (task or "").strip().lower() or None
+    if normalized_task is not None and normalized_task not in _CODING_TASKS | {"general"}:
+        raise OmniRouteError("required task is invalid")
+    coding_filter = applies_coding_candidate_filter(
+        required_capability=required_capability, task=normalized_task,
+    )
     skipped = {
         item for item in skip_identity_sha256s or ()
         if isinstance(item, str) and _HEX.fullmatch(item)
@@ -1167,14 +1217,38 @@ def select_live_candidates(
         identity_sha = _sha256({"model": model, "provider": provider})
         if identity_sha in skipped or identity_sha in blocked_identities:
             continue
+        if coding_filter and is_coding_denied(model):
+            continue
         selected.append({
             "model": model,
             "provider": provider,
             "remaining": left,
             "capability": classify_capability(model),
             "identitySha256": identity_sha,
+            "codingFit": (
+                "boost" if is_coding_boosted(model)
+                else "neutral"
+            ) if coding_filter else "n/a",
         })
-    if required_capability == "most-intelligent":
+    if coding_filter:
+        pool = selected
+        if required_capability == "most-intelligent":
+            pool = [row for row in pool if row["capability"] == "most-intelligent"]
+
+        def _capability_tiebreak(row: dict[str, Any]) -> int:
+            if required_capability == "mechanical":
+                return _CAPABILITY_RANK[row["capability"]]
+            if required_capability == "most-intelligent":
+                return 0
+            return _DEFAULT_TASK_ORDER.get(row["capability"], 9)
+
+        pool.sort(key=lambda row: (
+            0 if row.get("codingFit") == "boost" else 1,
+            _capability_tiebreak(row),
+            -row["remaining"],
+            row["model"],
+        ))
+    elif required_capability == "most-intelligent":
         pool = [row for row in selected if row["capability"] == "most-intelligent"]
         pool.sort(key=lambda row: (-row["remaining"], row["model"]))
     elif required_capability == "mechanical":
@@ -1311,6 +1385,7 @@ def candidates(
     diagnostic: object = None,
     failed_identity_sha256: str | None = None,
     failed_provider: str | None = None,
+    task: str | None = None,
 ) -> dict[str, Any]:
     """Query live catalog and quota every dispatch; overlay user-local exhaustion backoff only."""
     locator = which or shutil.which
@@ -1338,6 +1413,7 @@ def candidates(
         catalog, quota, required_capability=required_capability,
         skip_identity_sha256s=skip_identity_sha256s,
         exhaustion_cache=cache,
+        task=task,
     )
     return {"state": "READY" if picked else "RUNTIME_EXHAUSTED", "candidates": picked}
 
@@ -2558,12 +2634,20 @@ def main(argv: list[str] | None = None) -> int:
     candidates_parser.add_argument(
         "--capability", default="default", choices=sorted(_CAPABILITY_RANK),
     )
+    candidates_parser.add_argument(
+        "--task", default="general",
+        choices=sorted(_CODING_TASKS | {"general"}),
+        help="coding|implementation applies the coding allow/deny filter even outside default capability",
+    )
     args = parser.parse_args(raw_arguments)
     try:
         if args.command == "probe":
             return _print(probe(config_path=args.config))
         if args.command == "candidates":
-            return _print(candidates(required_capability=args.capability))
+            return _print(candidates(
+                required_capability=args.capability,
+                task=None if args.task == "general" else args.task,
+            ))
         if args.command == "attest":
             return _print(attest(config_path=args.config, contract_path=args.contract))
         if args.command == "dispatch":

--- a/scripts/ci/assert_surefire_green.py
+++ b/scripts/ci/assert_surefire_green.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Fail when Surefire/TestNG reports show failures under Maven failure-ignore.
+
+SHAFT's engine Surefire profile may set testFailureIgnore so JaCoCo still
+reports. A green Maven exit is then not proof. N-run / wave proof scripts must
+parse report XML after each invocation and require zero failed counts
+(issue #5739).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def summarize_surefire_reports(report_root: Path) -> tuple[int, int]:
+    """Return (failures, errors) across TEST-*.xml under report_root."""
+    failures = 0
+    errors = 0
+    for path in sorted(report_root.glob("TEST-*.xml")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        fm = re.search(r'\bfailures="(\d+)"', text)
+        em = re.search(r'\berrors="(\d+)"', text)
+        failures += int(fm.group(1)) if fm else 0
+        errors += int(em.group(1)) if em else 0
+    return failures, errors
+
+
+def summarize_testng_results(report_root: Path) -> int | None:
+    """Return failed count from testng-results.xml, or None when missing."""
+    path = report_root / "testng-results.xml"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = re.search(r'<testng-results[^>]*\bfailed="(\d+)"', text)
+    return int(match.group(1)) if match else 0
+
+
+def assert_surefire_green(report_root: Path, *, label: str = "run") -> None:
+    """Raise SystemExit(1) when reports are missing or show failures/errors."""
+    root = Path(report_root)
+    surefire = list(root.glob("TEST-*.xml"))
+    if surefire:
+        failures, errors = summarize_surefire_reports(root)
+        if failures or errors:
+            print(
+                f"FAIL: {label} reported failures={failures} errors={errors}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        print(f"OK: {label} green (failures=0 errors=0)")
+        return
+
+    failed = summarize_testng_results(root)
+    if failed is None:
+        print(
+            f"FAIL: {label} produced no Surefire/TestNG report under {root}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if failed:
+        print(f"FAIL: {label} reported failures={failed} errors=0", file=sys.stderr)
+        raise SystemExit(1)
+    print(f"OK: {label} green (failures=0 errors=0)")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "report_root",
+        type=Path,
+        help="Directory containing TEST-*.xml and/or testng-results.xml",
+    )
+    parser.add_argument("--label", default="run", help="Label for OK/FAIL lines")
+    args = parser.parse_args(argv)
+    try:
+        assert_surefire_green(args.report_root, label=args.label)
+    except SystemExit as exit_code:
+        return int(exit_code.code or 0)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_click_type_wave_f_proof.sh
+++ b/scripts/ci/run_click_type_wave_f_proof.sh
@@ -33,38 +33,9 @@ REPORT_ROOT="${ROOT}/shaft-engine/target/surefire-reports"
 
 assert_surefire_green() {
   local label="$1"
-  python3 - "$REPORT_ROOT" "$label" <<'PY'
-import pathlib
-import re
-import sys
-
-report_root = pathlib.Path(sys.argv[1])
-label = sys.argv[2]
-failures = 0
-errors = 0
-
-surefire = list(report_root.glob("TEST-*.xml"))
-if surefire:
-    for path in surefire:
-        text = path.read_text(encoding="utf-8", errors="replace")
-        fm = re.search(r'\bfailures="(\d+)"', text)
-        em = re.search(r'\berrors="(\d+)"', text)
-        failures += int(fm.group(1)) if fm else 0
-        errors += int(em.group(1)) if em else 0
-else:
-    testng = report_root / "testng-results.xml"
-    if not testng.is_file():
-        print(f"FAIL: {label} produced no Surefire/TestNG report under {report_root}", file=sys.stderr)
-        sys.exit(1)
-    text = testng.read_text(encoding="utf-8", errors="replace")
-    fm = re.search(r'<testng-results[^>]*\bfailed="(\d+)"', text)
-    failures = int(fm.group(1)) if fm else 0
-
-if failures or errors:
-    print(f"FAIL: {label} reported failures={failures} errors={errors}", file=sys.stderr)
-    sys.exit(1)
-print(f"OK: {label} green (failures=0 errors=0)")
-PY
+  # Do not trust Maven exit under testFailureIgnore / -Dmaven.test.failure.ignore
+  # (issue #5739). Shared parser: scripts/ci/assert_surefire_green.py
+  python3 "${ROOT}/scripts/ci/assert_surefire_green.py" "${REPORT_ROOT}" --label "${label}"
 }
 
 echo "=== Wave F flake proof: unit subset x${N} (${UNIT_TESTS}) ==="

--- a/tests/scripts/test_assert_surefire_green.py
+++ b/tests/scripts/test_assert_surefire_green.py
@@ -1,0 +1,96 @@
+"""Unit tests for Surefire/TestNG green assertion used by N-run proof scripts."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.assert_surefire_green import (
+    assert_surefire_green,
+    main,
+    summarize_surefire_reports,
+    summarize_testng_results,
+)
+
+
+SUREFIRE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="{name}" tests="{tests}" failures="{failures}" errors="{errors}" skipped="0">
+</testsuite>
+"""
+
+TESTNG_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<testng-results ignored="0" total="{total}" passed="{passed}" failed="{failed}" skipped="0">
+</testng-results>
+"""
+
+
+class AssertSurefireGreenTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+
+    def write_surefire(self, filename: str, *, failures: int = 0, errors: int = 0) -> Path:
+        path = self.root / filename
+        path.write_text(
+            SUREFIRE_XML.format(
+                name=filename, tests=1, failures=failures, errors=errors,
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def write_testng(self, *, failed: int = 0) -> Path:
+        path = self.root / "testng-results.xml"
+        path.write_text(
+            TESTNG_XML.format(total=1, passed=0 if failed else 1, failed=failed),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_summarize_surefire_aggregates_failures_and_errors(self):
+        self.write_surefire("TEST-One.xml", failures=1, errors=0)
+        self.write_surefire("TEST-Two.xml", failures=0, errors=2)
+        self.assertEqual((1, 2), summarize_surefire_reports(self.root))
+
+    def test_green_surefire_passes(self):
+        self.write_surefire("TEST-Ok.xml", failures=0, errors=0)
+        assert_surefire_green(self.root, label="unit run 1/3")
+        self.assertEqual(0, main([str(self.root), "--label", "unit run 1/3"]))
+
+    def test_failed_surefire_exits_nonzero(self):
+        self.write_surefire("TEST-Bad.xml", failures=1, errors=0)
+        with self.assertRaises(SystemExit) as raised:
+            assert_surefire_green(self.root, label="unit run 2/3")
+        self.assertEqual(1, raised.exception.code)
+        self.assertEqual(1, main([str(self.root), "--label", "unit run 2/3"]))
+
+    def test_testng_fallback_when_no_surefire_xml(self):
+        self.write_testng(failed=0)
+        assert_surefire_green(self.root, label="testng green")
+        self.write_testng(failed=3)
+        with self.assertRaises(SystemExit) as raised:
+            assert_surefire_green(self.root, label="testng red")
+        self.assertEqual(1, raised.exception.code)
+
+    def test_missing_reports_fail_closed(self):
+        with self.assertRaises(SystemExit) as raised:
+            assert_surefire_green(self.root, label="empty")
+        self.assertEqual(1, raised.exception.code)
+        self.assertIsNone(summarize_testng_results(self.root))
+
+    def test_wave_proof_script_uses_shared_helper(self):
+        root = Path(__file__).resolve().parents[2]
+        script = (root / "scripts/ci/run_click_type_wave_f_proof.sh").read_text(encoding="utf-8")
+        self.assertIn("scripts/ci/assert_surefire_green.py", script)
+        self.assertIn("maven.test.failure.ignore=false", script)
+        playbook = (root / "chaos-engine/references/work-github-playbook.md").read_text(
+            encoding="utf-8",
+        )
+        self.assertIn("Wave PR open checklist", playbook)
+        self.assertIn("assert_surefire_green.py", playbook)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_omniroute_coding_filter.py
+++ b/tests/scripts/test_omniroute_coding_filter.py
@@ -1,0 +1,111 @@
+"""Unit tests for OmniRoute coding candidate allow/deny ranking helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = ROOT / "chaos-engine/skills/omniroute/scripts/runner.py"
+SKILL = ROOT / "chaos-engine/skills/omniroute/SKILL.md"
+SPEC = importlib.util.spec_from_file_location("omniroute_coding_filter_runner", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("OmniRoute runner could not be loaded")
+RUNNER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RUNNER)
+
+
+class OmniRouteCodingFilterTest(unittest.TestCase):
+    def test_deny_markers_drop_safety_guard_translate_nano_tiny(self):
+        for model in (
+            "vendor/safety-guard-1",
+            "vendor/content-guard",
+            "vendor/translate-en",
+            "vendor/flash-nano",
+            "vendor/tiny-chat",
+        ):
+            with self.subTest(model=model):
+                self.assertTrue(RUNNER.is_coding_denied(model), model)
+
+    def test_boost_markers_prefer_coding_tagged_ids(self):
+        for model in (
+            "vendor/qwen3-coder",
+            "vendor/devstral-small",
+            "vendor/kimi-k2-instruct",
+            "vendor/gpt-oss-120b",
+            "vendor/claude-sonnet-4",
+            "vendor/code-assist",
+        ):
+            with self.subTest(model=model):
+                self.assertTrue(RUNNER.is_coding_boosted(model), model)
+                self.assertFalse(RUNNER.is_coding_denied(model), model)
+
+    def test_default_capability_drops_deny_and_ranks_boost_first(self):
+        catalog = [
+            {"id": "Safety Guard", "provider": "alpha"},
+            {"id": "Chat Default", "provider": "alpha"},
+            {"id": "Qwen3 Coder", "provider": "beta"},
+            {"id": "Flash Nano", "provider": "beta"},
+            {"id": "Translate En", "provider": "gamma"},
+        ]
+        quota = [
+            {"provider": "alpha", "remaining": 80, "state": "available"},
+            {"provider": "beta", "remaining": 40, "state": "available"},
+            {"provider": "gamma", "remaining": 90, "state": "available"},
+        ]
+        picked = RUNNER.select_live_candidates(
+            catalog, quota, required_capability="default",
+        )
+        models = [item["model"] for item in picked]
+        self.assertEqual(["beta/qwen3-coder", "alpha/chat-default"], models)
+        self.assertEqual("boost", picked[0]["codingFit"])
+        self.assertEqual("neutral", picked[1]["codingFit"])
+        for denied in ("safety", "nano", "translate"):
+            self.assertTrue(
+                all(denied not in model for model in models),
+                models,
+            )
+
+    def test_explicit_coding_task_filters_even_for_mechanical_capability(self):
+        catalog = [
+            {"id": "Flash Nano", "provider": "alpha"},
+            {"id": "Tool Low", "provider": "alpha"},
+            {"id": "Qwen3 Coder", "provider": "alpha"},
+        ]
+        quota = [{"provider": "alpha", "remaining": 50, "state": "available"}]
+        unfiltered = RUNNER.select_live_candidates(
+            catalog, quota, required_capability="mechanical",
+        )
+        self.assertIn("alpha/flash-nano", [item["model"] for item in unfiltered])
+        filtered = RUNNER.select_live_candidates(
+            catalog, quota, required_capability="mechanical", task="coding",
+        )
+        models = [item["model"] for item in filtered]
+        self.assertNotIn("alpha/flash-nano", models)
+        self.assertEqual("alpha/qwen3-coder", models[0])
+
+    def test_invalid_task_raises(self):
+        with self.assertRaises(RUNNER.OmniRouteError):
+            RUNNER.select_live_candidates(
+                [], [], required_capability="default", task="vision",
+            )
+
+    def test_skill_documents_coding_filter_and_ready_before_native(self):
+        skill = SKILL.read_text(encoding="utf-8")
+        collapsed = " ".join(skill.split())
+        self.assertIn("Coding candidate filter", skill)
+        self.assertIn("safety", skill)
+        self.assertIn("gpt-oss", skill)
+        self.assertIn("devstral", skill)
+        self.assertIn("Dispatch checklist (READY)", skill)
+        self.assertIn("before any native host model", collapsed)
+        self.assertIn("Catalog ≠ dispatch", skill)
+        self.assertIn("auto/coding", skill)
+        self.assertIn("--task coding", skill)
+        self.assertNotIn("catalog-policy.json", skill)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- OmniRoute coding candidate filter: boost `code`/`coder`/`sonnet`/`claude`/`gpt-oss`/`qwen`/`kimi`/`devstral`; deny `safety`/`guard`/`translate`/`nano`/`tiny`. SKILL.md requires `omniroute run` on READY before native fallback; unit tests cover the filter.
- Wave PR open checklist (#5736): release-note label + exhaustive Java switches before first push (work-github-playbook).
- N-run proof (#5739): shared `scripts/ci/assert_surefire_green.py` parses Surefire/TestNG failed counts; wave proof script no longer trusts Maven exit under failure-ignore.

Closes #5742
Closes #5736
Closes #5739

## Checks
- `python3 -m unittest tests.scripts.test_omniroute_coding_filter tests.scripts.test_assert_surefire_green tests.scripts.test_omniroute_catalog`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`

## Continuation
No Cloud Agents. No Headroom. Receipts never persist model/provider ids in-repo.