### PR TITLE
feat(chaos-engine): classifier NPath helpers + Codacy Complexity gate (#5747)

### DIFF
--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -346,7 +346,7 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | argparse | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/draft_skill_pr.py, chaos-engine/heuristics.py, chaos-engine/hooks/reflection.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/learning_session.py, chaos-engine/meta_optimize.py, chaos-engine/phase_ledger.py, chaos-engine/retrieve.py, chaos-engine/significance.py, chaos-engine/silent_verify.py, chaos-engine/skill_compress_audit.py, chaos-engine/skills/freetoken/scripts/probe.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/wake_pack.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | base64 | Portable runtime standard-library dependency. | chaos-engine/hosts.py, chaos-engine/install.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
-| collections | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/hooks/lifecycle.py, chaos-engine/mcp_policy.py, chaos-engine/silent_verify.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
+| collections | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/lifecycle.py, chaos-engine/mcp_policy.py, chaos-engine/silent_verify.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | concurrent | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | contextlib | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/learning_session.py, chaos-engine/silent_verify.py, chaos-engine/skills/omniroute/scripts/runner.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | ctypes | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
@@ -692,7 +692,7 @@ reports, caches, runtime indexes, or `graphify-out/`.
 ## Read next
 
 - [Delivery phase gates](references/delivery-phase-gates.md) — hooks vs skills map + research-before-mutation.
-
+- [Codacy Complexity gate](references/codacy-complexity-gate.md) — classifier helpers; Complexity ACTION_REQUIRED == unit red.
 
 - [Zero-LLM catalog](references/zero-llm-catalog.md) — deterministic doctor/install/repair paths.
 - [Context firewall](references/context-firewall.md) — research/explore subagent isolation; distillate only.

--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -13,6 +13,7 @@ import posixpath
 import re
 import shlex
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 def _load_sibling(module_name: str):
@@ -647,6 +648,69 @@ def _record_denial_with_significance(event: dict, event_name: str, tool_name: st
     )
 
 
+# Soft Codacy Complexity reminder for classifier / interaction mutations (#5747).
+_CLASSIFIER_PATH_MARKERS = (
+    "elementclassifier",
+    "/interaction/",
+    "\\interaction\\",
+)
+_CLASSIFIER_NAME_MARKERS = (
+    "elementclassifier",
+    "classifymobilenative",
+    "classifywindowsdesktop",
+    "classifybytag",
+    "classifybyrole",
+    "classifyinput",
+)
+CODACY_COMPLEXITY_GATE_HINT = (
+    "Codacy Complexity gate (#5747): kind-family helpers / rule tables before "
+    "fat classify* arms; Complexity ACTION_REQUIRED == unit red. "
+    "Checklist: references/codacy-complexity-gate.md"
+)
+
+
+def _mutation_path_blobs(tool_name: str, tool_input: object, commands: tuple[str, ...]) -> str:
+    """Flatten Write/Edit/patch/shell targets for classifier-path matching."""
+    chunks: list[str] = []
+    if isinstance(tool_input, Mapping):
+        for key in ("file_path", "filePath", "path", "notebook_path", "notebookPath"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                chunks.append(value)
+        for key in ("old_string", "new_string", "content", "patch", "input", "command", "cmd"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                chunks.append(value)
+    elif isinstance(tool_input, str) and tool_input.strip():
+        chunks.append(tool_input)
+    chunks.extend(commands)
+    compact = tool_name.casefold() if tool_name else ""
+    if compact:
+        chunks.append(compact)
+    return "\n".join(chunks).casefold()
+
+
+def classifier_complexity_gate_hint(
+    event_name: str,
+    *,
+    mutation: bool,
+    tool_name: str,
+    tool_input: object,
+    commands: tuple[str, ...] = (),
+) -> str | None:
+    """Return soft checklist hint when mutating classifier / interaction surfaces."""
+    if event_name != "PreToolUse" or not mutation:
+        return None
+    blob = _mutation_path_blobs(tool_name, tool_input, commands)
+    if not blob:
+        return None
+    path_hit = any(marker in blob for marker in _CLASSIFIER_PATH_MARKERS)
+    name_hit = any(marker in blob for marker in _CLASSIFIER_NAME_MARKERS)
+    if path_hit or name_hit:
+        return CODACY_COMPLEXITY_GATE_HINT
+    return None
+
+
 def _run_event(event: dict, _host: str) -> int:
     tool_input = event.get("tool_input", {}) if isinstance(event, dict) else {}
     tool_name = str(event.get("tool_name", "")) if isinstance(event, dict) else ""
@@ -717,6 +781,16 @@ def _run_event(event: dict, _host: str) -> int:
             return 2
     if event_name == "SessionStart":
         print(json.dumps({"additionalContext": _event_context(event_name, token)}))
+        return 0
+    complexity_hint = classifier_complexity_gate_hint(
+        event_name,
+        mutation=mutation,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        commands=commands,
+    )
+    if complexity_hint:
+        print(json.dumps({"additionalContext": complexity_hint}))
     return 0
 
 

--- a/chaos-engine/references/codacy-complexity-gate.md
+++ b/chaos-engine/references/codacy-complexity-gate.md
@@ -1,0 +1,41 @@
+# Codacy Complexity gate
+
+Learning from issue #5747 (Waves D/E of epic #5732): Codacy **Complexity /
+NPath** repeatedly blocked merge after functional CI was already green.
+Pattern: element-classifier growth lands as one fat `classify*` method, then a
+second pass splits it.
+
+## Iron rule
+
+Treat Codacy **Complexity** `ACTION_REQUIRED` as a first-class red gate **equal
+to a failing unit test**. Do not wait for GitHub unit jobs to finish when Codacy
+Complexity already failed — extract helpers and re-push.
+
+`scripts/agents/watch_pr_checks.py` already classifies `ACTION_REQUIRED` as
+RED (Codacy and similar apps). Agent behavior must match that: triage Complexity
+red immediately, same urgency as unit red.
+
+## Checklist (before opening or pushing interaction / classifier PRs)
+
+- [ ] New mobile / desktop / web kind branches land as **kind-family helpers**
+      or first-match rule tables — not more sequential `if`/`return` arms on a
+      single `classify*` method
+- [ ] Prefer `Set` / `Map` buckets plus a loop over rules (NPath multiplies
+      across sequential branches even when each guard is trivial)
+- [ ] Codacy Complexity `ACTION_REQUIRED` == unit red: fix before waiting on
+      other checks
+- [ ] Local proof includes the touched classifier unit tests (and any
+      interaction strategy tests that share those kinds)
+
+## Hook
+
+Portable PreToolUse soft reminder (non-blocking `additionalContext`) when a
+mutation targets an `ElementClassifier` path or interaction `classify*` surface.
+See [`hooks/guard.py`](../hooks/guard.py). Hosts that ignore soft context still
+owe this checklist via the Level-1 catalog and router row.
+
+## Boundaries
+
+- Soft reminder never denies a tool call; Complexity red is still a delivery gate.
+- Do not weaken Codacy findings or delete tests to clear the gate.
+- Portable overlay owns the policy; host adapters stay thin pointers.

--- a/chaos-engine/references/level-1-catalog.md
+++ b/chaos-engine/references/level-1-catalog.md
@@ -25,6 +25,7 @@ sorted. Each row is a name, ≤2-line Use-when, and a path — no workflow dumps
 | Retrieve-first | A store can shorten discovery; one bounded attempt | [`retrieve-first.md`](retrieve-first.md) |
 | Research receipt | Before implementation mutation; triage scales depth | [`research-receipt.md`](research-receipt.md) |
 | Delivery phase gates | Phase ledger / research-before-mutation enforcement | [`delivery-phase-gates.md`](delivery-phase-gates.md) |
+| Codacy Complexity gate | Classifier / interaction PRs; Complexity ACTION_REQUIRED == unit red | [`codacy-complexity-gate.md`](codacy-complexity-gate.md) |
 | Eval-parity fixtures | Cross-host CE policy fixture suite | [`eval-parity-fixtures.md`](eval-parity-fixtures.md) |
 | Self-improve | Learning Session dual-track harness + product observations | [`../skills/self-improve/SKILL.md`](../skills/self-improve/SKILL.md) |
 | Self-improve master plan | Next-wave self-improve roadmap + Top 10 (post-Learning Session Stop gate); profile may extend under `profiles/<product>/references/` | [`self-improve-master-plan.md`](self-improve-master-plan.md) |

--- a/chaos-engine/references/work-github-playbook.md
+++ b/chaos-engine/references/work-github-playbook.md
@@ -176,7 +176,10 @@ and focused proofs observed; it must not represent remote checks as green.
    branch, or merge the fetched configured upstream default branch for a
    conflict or stale head, then return to watch. Never force-push away
    owner-visible history. Any new push restarts the comment gate before
-   auto-merge may remain armed.
+   auto-merge may remain armed. Codacy **Complexity** `ACTION_REQUIRED` is
+   unit-red urgency ([codacy-complexity-gate](codacy-complexity-gate.md)):
+   extract kind-family helpers immediately; do not wait for unit jobs when
+   Complexity already failed.
 8. **Confirm** remotely that `mergedAt` is non-null; armed is not merged.
 
 ## 8. Report

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -216,6 +216,7 @@ return here for the next.
 | Eliminate waste | Token optimization: drop hops that do not change the next decision | [eliminate-waste](../../references/eliminate-waste.md) |
 | No proxy | Never install a traffic proxy | [no-proxy](../../references/no-proxy.md) |
 | GAP-EXIT2 UX | Grok/Copilot may not honor exit-2 hard blocks | [host-parity-matrix](../../references/host-parity-matrix.md) checklist |
+| Codacy Complexity | Classifier / interaction PRs; Complexity ACTION_REQUIRED == unit red | [codacy-complexity-gate](../../references/codacy-complexity-gate.md) checklist |
 
 Routing also orders applicable knowledge retrieval before broad manual
 discovery. One bounded attempt is enough; never retry, repair, refresh, mine,

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/interaction/ElementClassifier.java
@@ -332,24 +332,29 @@ public final class ElementClassifier {
                 safeDom(element, "autocomplete"));
     }
 
+    /** Tag → kind for web tags decided before input handling (NPath-safe map). */
+    private static final Map<String, ElementKind> TAG_KINDS = Map.of(
+            "select", ElementKind.SELECT,
+            "textarea", ElementKind.TEXT_LIKE,
+            "iframe", ElementKind.IFRAME,
+            "frame", ElementKind.IFRAME,
+            "a", ElementKind.LINK,
+            "button", ElementKind.BUTTON);
+
     /**
      * Tag-driven kinds (and tag/role pairs that are decided before input handling).
      * Returns null when the tag does not decide the kind.
      */
     private static ElementKind classifyByTag(String tag, String role) {
-        if ("select".equals(tag)) {
-            return ElementKind.SELECT;
+        ElementKind fromTag = tag == null ? null : TAG_KINDS.get(tag);
+        if (fromTag != null) {
+            return fromTag;
         }
-        if ("textarea".equals(tag)) {
-            return ElementKind.TEXT_LIKE;
-        }
-        if ("iframe".equals(tag) || "frame".equals(tag)) {
-            return ElementKind.IFRAME;
-        }
-        if ("a".equals(tag) || "link".equals(role)) {
+        // Role-only link/button when the tag did not already decide.
+        if ("link".equals(role)) {
             return ElementKind.LINK;
         }
-        if ("button".equals(tag) || "button".equals(role)) {
+        if ("button".equals(role)) {
             return ElementKind.BUTTON;
         }
         return null;
@@ -407,23 +412,25 @@ public final class ElementClassifier {
         return ElementKind.UNKNOWN;
     }
 
+    /** ARIA role → kind for the role-only fallthrough path (NPath-safe map). */
+    private static final Map<String, ElementKind> ROLE_KINDS = Map.of(
+            "checkbox", ElementKind.CHECKBOX,
+            "switch", ElementKind.CHECKBOX,
+            "radio", ElementKind.RADIO,
+            "slider", ElementKind.RANGE,
+            "combobox", ElementKind.COMBOBOX,
+            "listbox", ElementKind.COMBOBOX);
+
     private static ElementKind classifyByRole(String role) {
-        if ("checkbox".equals(role) || "switch".equals(role)) {
-            return ElementKind.CHECKBOX;
+        if (role == null) {
+            return ElementKind.UNKNOWN;
         }
-        if ("radio".equals(role)) {
-            return ElementKind.RADIO;
+        ElementKind kind = ROLE_KINDS.get(role);
+        if (kind != null) {
+            return kind;
         }
-        if ("slider".equals(role)) {
-            return ElementKind.RANGE;
-        }
-        if ("combobox".equals(role) || "listbox".equals(role)) {
-            return ElementKind.COMBOBOX;
-        }
-        if (role != null && TEXT_ROLES.contains(role)) {
-            return ElementKind.TEXT_LIKE;
-        }
-        return ElementKind.UNKNOWN;
+        // TEXT_ROLES stays the single source for textbox/searchbox/spinbutton.
+        return TEXT_ROLES.contains(role) ? ElementKind.TEXT_LIKE : ElementKind.UNKNOWN;
     }
 
     private static boolean isContentEditable(ElementSignals signals) {

--- a/tests/scripts/test_chaos_engine_codacy_complexity_gate_5747.py
+++ b/tests/scripts/test_chaos_engine_codacy_complexity_gate_5747.py
@@ -1,0 +1,126 @@
+"""#5747: Codacy Complexity gate checklist + soft classifier-edit hook."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GATE = ROOT / "chaos-engine/references/codacy-complexity-gate.md"
+LEVEL1 = ROOT / "chaos-engine/references/level-1-catalog.md"
+SKILL = ROOT / "chaos-engine/skills/chaos-engine/SKILL.md"
+PLAYBOOK = ROOT / "chaos-engine/references/work-github-playbook.md"
+GUARD = ROOT / "chaos-engine/hooks/guard.py"
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CodacyComplexityGate5747Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guard = load(GUARD, "ce_guard_codacy_5747")
+
+    def test_checklist_documents_unit_red_parity_and_helpers(self):
+        text = GATE.read_text(encoding="utf-8")
+        self.assertIn("ACTION_REQUIRED", text)
+        self.assertIn("unit", text.casefold())
+        self.assertIn("kind-family", text.casefold())
+        self.assertIn("classify*", text)
+        self.assertIn("#5747", text)
+
+    def test_catalog_and_router_point_at_checklist(self):
+        level1 = LEVEL1.read_text(encoding="utf-8")
+        skill = SKILL.read_text(encoding="utf-8")
+        playbook = PLAYBOOK.read_text(encoding="utf-8")
+        self.assertIn("codacy-complexity-gate.md", level1)
+        self.assertIn("Codacy Complexity", level1)
+        self.assertIn("codacy-complexity-gate.md", skill)
+        self.assertIn("| Codacy Complexity |", skill)
+        self.assertIn("codacy-complexity-gate.md", playbook)
+        self.assertIn("ACTION_REQUIRED", playbook)
+
+    def test_hint_fires_for_element_classifier_edit(self):
+        hint = self.guard.classifier_complexity_gate_hint(
+            "PreToolUse",
+            mutation=True,
+            tool_name="Edit",
+            tool_input={
+                "file_path": (
+                    "shaft-engine/src/main/java/com/shaft/gui/element/"
+                    "internal/interaction/ElementClassifier.java"
+                ),
+                "old_string": "a",
+                "new_string": "b",
+            },
+        )
+        self.assertIsNotNone(hint)
+        self.assertIn("ACTION_REQUIRED", hint)
+        self.assertIn("codacy-complexity-gate.md", hint)
+
+    def test_hint_skips_unrelated_mutation(self):
+        hint = self.guard.classifier_complexity_gate_hint(
+            "PreToolUse",
+            mutation=True,
+            tool_name="Write",
+            tool_input={"file_path": "README.md", "content": "hello"},
+        )
+        self.assertIsNone(hint)
+
+    def test_hint_skips_non_mutation_and_non_pretool(self):
+        self.assertIsNone(
+            self.guard.classifier_complexity_gate_hint(
+                "PreToolUse",
+                mutation=False,
+                tool_name="Edit",
+                tool_input={"file_path": "ElementClassifier.java"},
+            )
+        )
+        self.assertIsNone(
+            self.guard.classifier_complexity_gate_hint(
+                "PostToolUse",
+                mutation=True,
+                tool_name="Edit",
+                tool_input={"file_path": "ElementClassifier.java"},
+            )
+        )
+
+    def test_pretool_use_emits_soft_context_without_blocking(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            event = {
+                "hook_event_name": "PreToolUse",
+                "session_id": "codacy-5747-soft",
+                "cwd": temporary,
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": (
+                        "shaft-engine/src/main/java/com/shaft/gui/element/"
+                        "internal/interaction/ElementClassifier.java"
+                    ),
+                    "old_string": "x",
+                    "new_string": "y",
+                },
+            }
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                code = self.guard._run_event(event, "claude")
+            self.assertEqual(0, code)
+            payload = json.loads(buffer.getvalue().strip().splitlines()[-1])
+            self.assertIn("additionalContext", payload)
+            self.assertIn("ACTION_REQUIRED", payload["additionalContext"])
+            self.assertNotEqual("block", payload.get("decision"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #5747. Encodes the ChaosEngine learning from Waves D/E: treat Codacy **Complexity** `ACTION_REQUIRED` as unit-red urgency, and land new classifier kinds as kind-family helpers / rule tables before opening interaction PRs.

- **Portable checklist** `chaos-engine/references/codacy-complexity-gate.md` + Level-1 catalog / router / GitHub playbook wiring
- **Soft PreToolUse hook** reminder on `ElementClassifier` / interaction mutations (non-blocking `additionalContext`)
- **Classifier helpers:** `TAG_KINDS` / `ROLE_KINDS` maps for `classifyByTag` / `classifyByRole` (NPath-safe; `TEXT_ROLES` remains the text-role source)

## Checks

```bash
python3 -m unittest tests.scripts.test_chaos_engine_codacy_complexity_gate_5747 tests.scripts.test_chaos_engine_wave_b_router_catalog -q
python3 scripts/ci/validate_agent_setup.py --skip-external
mvn -pl shaft-engine -Dtest=ElementClassifierTest -Dallure.automaticallyOpen=false -DheadlessExecution=true test
```

Local: harness 12 tests OK; `ElementClassifierTest` 45/0; validate_agent_setup exit 0.

## Continuation

Watch CI / Codacy Complexity; Complexity `ACTION_REQUIRED` is unit-red — fix helpers first if it fires.