### PR TITLE
fix(ci): Flutter BrowserStack nightly, local emulator, OCR swipe/focus

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -49,6 +49,7 @@ jobs:
       - Windows_Appium_Desktop_Local
       - MacOSX_Chrome_Local
       - Windows_Edge_Cucumber_Local
+      - Ubuntu_Flutter_Emulator_Local
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -631,9 +632,154 @@ jobs:
           job-name: Ubuntu_Managed_Android
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  Ubuntu_Flutter_Emulator_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Flutter_Emulator_Local,')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7.0.1
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          java-version: '17'
+          node-version: '20'
+      - name: Setup Flutter 3.22.1
+        uses: subosito/flutter-action@v2.23.0
+        with:
+          flutter-version: 3.22.1
+          channel: stable
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4.0.1
+      - name: Flutter emulator preflight
+        run: bash scripts/ci/flutter_emulator_preflight.sh
+      - name: Checkout pinned appium-flutter-server demo-app
+        uses: actions/checkout@v7.0.1
+        with:
+          repository: AppiumTestDistribution/appium-flutter-server
+          ref: 78ba97a6146091b944335d0db3330f74416f3ac7
+          path: appium-flutter-server
+          sparse-checkout: |
+            demo-app
+            server
+      - name: Build demo-app debug APK wired for the Appium Flutter Integration Server
+        run: |
+          set -euo pipefail
+          cd appium-flutter-server/demo-app
+          dart pub global activate rps --version 0.8.0
+          bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 flutter build apk --debug
+          cd android && bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 ./gradlew app:assembleDebug -Ptarget="$(pwd)/../integration_test/appium.dart"
+      - name: Copy freshly-built APK into FlutterTest path
+        run: |
+          set -euo pipefail
+          APK_PATH="$GITHUB_WORKSPACE/appium-flutter-server/demo-app/build/app/outputs/apk/debug/app-debug.apk"
+          ls -l "$APK_PATH"
+          cp "$APK_PATH" shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk
+      - name: Set up JDK 25 for Maven
+        uses: actions/setup-java@v6
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+      - name: Install engine dependencies for FlutterTest
+        run: >
+          bash scripts/ci/build_retry.sh 2 60
+          mvn -pl shaft-engine -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+      - name: Boot emulator, open Flutter session, run FlutterTest tap/type/text
+        id: flutter_e2e
+        continue-on-error: true
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          working-directory: ${{ github.workspace }}
+          script: |
+            # android-emulator-runner invokes this script with /usr/bin/sh (dash).
+            set -eu
+            cd "$GITHUB_WORKSPACE"
+            APK_PATH="$GITHUB_WORKSPACE/shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk"
+            ls -l "$APK_PATH"
+            adb devices
+
+            appiumLog="$RUNNER_TEMP/appium-server.log"
+            appium --address 127.0.0.1 --port 4723 --log-level info --log "$appiumLog" &
+            APPIUM_PID=$!
+            trap 'kill "$APPIUM_PID" 2>/dev/null || true' EXIT
+
+            ready=false
+            for i in $(seq 1 60); do
+              if curl --max-time 2 -fsS http://127.0.0.1:4723/status >/dev/null 2>&1; then
+                ready=true
+                break
+              fi
+              sleep 1
+            done
+            if [ "$ready" != true ]; then
+              echo "::error::Appium server did not become ready."
+              cat "$appiumLog" || true
+              exit 1
+            fi
+
+            SESSION_PAYLOAD=$(jq -n --arg app "$APK_PATH" '{capabilities: {alwaysMatch: {platformName: "Android", "appium:automationName": "FlutterIntegration", "appium:app": $app, "appium:noReset": true}}}')
+            RESPONSE=$(curl --max-time 120 -fsS -X POST -H "Content-Type: application/json" -d "$SESSION_PAYLOAD" http://127.0.0.1:4723/session)
+            echo "$RESPONSE"
+            SESSION_ID=$(echo "$RESPONSE" | jq -r '.value.sessionId // empty')
+            if [ -z "$SESSION_ID" ]; then
+              echo "::error::Appium session did not open -- no sessionId in response."
+              cat "$appiumLog" || true
+              exit 1
+            fi
+            echo "Appium Flutter session opened: $SESSION_ID"
+            curl --max-time 30 -fsS -X DELETE "http://127.0.0.1:4723/session/$SESSION_ID" || true
+
+            mvn -f "$GITHUB_WORKSPACE/pom.xml" -pl shaft-engine -e test \
+              "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'testPackage.appium.FlutterTest' }}" \
+              "-Dshaft.enableFlutterE2E=true" \
+              "-DexecutionAddress=127.0.0.1:4723" \
+              "-Dmobile_app=src/test/resources/testDataFiles/apps/flutter-demo.apk" \
+              "-Dmobile_automationName=FlutterIntegration" \
+              "-DtargetOperatingSystem=android" \
+              "-DdefaultElementIdentificationTimeout=60" \
+              "-Dallure.automaticallyOpen=false" \
+              "-DheadlessExecution=true" \
+              "-DgenerateAllureReportArchive=true"
+            if [ ! -d "$GITHUB_WORKSPACE/shaft-engine/allure-results" ]; then
+              for d in "$PWD/shaft-engine/allure-results" "$PWD/allure-results" "$GITHUB_WORKSPACE/allure-results"; do
+                if [ -n "$(find "$d" -name '*-result.json' -type f -print -quit 2>/dev/null)" ]; then
+                  mkdir -p "$GITHUB_WORKSPACE/shaft-engine/allure-results"
+                  cp -a "$d"/. "$GITHUB_WORKSPACE/shaft-engine/allure-results/"
+                  break
+                fi
+              done
+            fi
+      - name: Upload Appium server log
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: Ubuntu_Flutter_Emulator_Local_appium_log
+          path: ${{ runner.temp }}/appium-server.log
+          if-no-files-found: ignore
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Ubuntu_Flutter_Emulator_Local
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
   notify_local_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Windows_Edge_Local, MacOSX_Safari_Local_1, MacOSX_Safari_Local_2, Windows_Chrome_Local, Windows_Managed_Lighthouse, Ubuntu_Managed_Android, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local ]
+    needs: [ Windows_Edge_Local, MacOSX_Safari_Local_1, MacOSX_Safari_Local_2, Windows_Chrome_Local, Windows_Managed_Lighthouse, Ubuntu_Managed_Android, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local, Ubuntu_Flutter_Emulator_Local ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -27,19 +27,6 @@ on:
           selector unchanged.
         required: false
         default: ''
-      enableFlutterEmulatorE2E:
-        description: >-
-          Legacy opt-in flag for Android_Flutter_Emulator_E2E on manual
-          workflow_dispatch (issue #4197). Renamed from enableFlutterE2E
-          (issue #4294) to stop colliding with -Dshaft.enableFlutterE2E.
-          The job now also runs on the scheduled nightly (same selector as
-          sibling E2E jobs). On workflow_dispatch, leave jobs=all (or name
-          the job explicitly) to run it; this flag is retained for backward
-          compatibility and is no longer required to gate the nightly.
-          The job builds the Integration-Server demo APK, opens an Appium
-          Flutter session on an emulator, and runs FlutterTest (tap/type/text).
-        required: false
-        default: 'false'
 
 permissions:
   contents: read
@@ -92,6 +79,7 @@ jobs:
       - Ubuntu_Playwright_GalaxyS26Ultra
       - Ubuntu_Playwright_IPhone17ProMax
       - Android_Native_BrowserStack
+      - Android_Flutter_BrowserStack
       - Android_Visual_Ocr_BrowserStack
       - iOS_Visual_Ocr_BrowserStack
       - Android_Recording_BrowserStack
@@ -100,7 +88,6 @@ jobs:
       - iOS_Evidence_BrowserStack
       - iOS_Web_SAFARI_BrowserStack
       - Android_Web_Chrome_BrowserStack
-      - Android_Flutter_Emulator_E2E
       - MacOSX_Safari_BrowserStack
       - Ubuntu_Chrome_Cucumber_Grid
       - MacOSX_Safari_Cucumber_BrowserStack
@@ -643,20 +630,14 @@ jobs:
           job-name: Ubuntu_Playwright_IPhone17ProMax
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-  # Issue #4313: builds the SAME correctly-wired Flutter demo-app that
-  # Android_Flutter_Emulator_E2E builds (identical pinned appium-flutter-server
-  # checkout + flutter build apk --debug + gradlew app:assembleDebug
-  # -Ptarget=.../integration_test/appium.dart pipeline, see that job's own
-  # comment below for the full history), minus the emulator-boot/session-open
-  # steps that job also runs -- this job only needs the APK artifact, not a
-  # live device. Split into its own job (rather than steps inlined into
-  # Android_Native_BrowserStack) so a transient Flutter/Gradle build failure
-  # here can never take down that job's much broader native-Android test run
-  # (its -Dtest selector below also covers %regex[.*ndroid.*] and three
-  # BrowserStack *UnitTest classes, none of which are Flutter-related) --
-  # continue-on-error: true at job level guarantees that isolation.
+  # Issue #4313: builds the correctly-wired Flutter demo-app APK
+  # (pinned appium-flutter-server checkout + flutter build apk --debug +
+  # gradlew app:assembleDebug -Ptarget=.../integration_test/appium.dart).
+  # Split from Android_Native_BrowserStack so a Flutter/Gradle failure
+  # cannot take down native Android coverage. Android_Flutter_BrowserStack
+  # consumes the same artifact for FlutterTest on BrowserStack.
   Flutter_Demo_App_Build:
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Native_BrowserStack,')
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Native_BrowserStack,') || contains(format(',{0},', github.event.inputs.jobs), ',Android_Flutter_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
@@ -679,18 +660,15 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           repository: AppiumTestDistribution/appium-flutter-server
-          # Same pinned commit as Android_Flutter_Emulator_E2E -- never track a
-          # moving branch; there is no permanently-hosted prebuilt APK, the
-          # upstream project's own CI builds fresh from source every run too.
+          # Pinned commit -- never track a moving branch; there is no
+          # permanently-hosted prebuilt APK.
           ref: 78ba97a6146091b944335d0db3330f74416f3ac7
           path: appium-flutter-server
           sparse-checkout: |
             demo-app
             server
       - name: Build demo-app debug APK wired for the Appium Flutter Integration Server
-        # Recipe verbatim from Android_Flutter_Emulator_E2E below (itself taken
-        # from appium-flutter-server's own .github/workflows/main.yml at the
-        # pinned commit).
+        # Recipe from appium-flutter-server .github/workflows/main.yml at the pin.
         run: |
           set -euo pipefail
           cd appium-flutter-server/demo-app
@@ -756,11 +734,8 @@ jobs:
       - name: Run tests
         continue-on-error: true
         timeout-minutes: 40
-        # FlutterTest is not selected here. Nightly 34191282877 failed two
-        # Flutter exists() assertions on BrowserStack while native Android
-        # otherwise passed; Android_Flutter_Emulator_E2E remains the #5638
-        # tap/type/text gate. The Flutter_Demo_App_Build APK overwrite is
-        # retained so a future opt-in dispatch can still feed a wired APK.
+        # FlutterTest is not selected here. Dedicated Android_Flutter_BrowserStack
+        # is the BrowserStack FlutterTest gate (#5638).
         run: mvn -pl shaft-browserstack -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dsurefire.excludedGroups=allure3-visual-demo,mobile-recording-compatible-provider,mobile-evidence-real-provider,visual-ocr-mobile-acceptance" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*ndroid.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
@@ -768,6 +743,45 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Android_Native_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  Android_Flutter_BrowserStack:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Flutter_BrowserStack,')
+    needs: Flutter_Demo_App_Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7.0.1
+      - name: Download freshly-built Flutter demo-app APK
+        uses: actions/download-artifact@v8
+        with:
+          name: flutter-demo-apk
+          path: ${{ runner.temp }}/flutter-demo-apk
+      - name: Wire Flutter demo APK into FlutterTest path
+        run: cp "${{ runner.temp }}/flutter-demo-apk/app-debug.apk" shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '20'
+      - name: Run FlutterTest on BrowserStack
+        continue-on-error: true
+        timeout-minutes: 40
+        run: mvn -pl shaft-browserstack -am -e test "-Dshaft.enableFlutterE2E=true" "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=FlutterIntegration" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*FlutterTest.*]' }}"
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Android_Flutter_BrowserStack
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Visual_Ocr_BrowserStack:
@@ -1116,183 +1130,6 @@ jobs:
           job-name: Android_Web_Chrome_BrowserStack
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-  # Issue #4197: proves a real Appium session can be opened against a Flutter
-  # app built with the driver's own required server wiring, on a real CI
-  # runner. Issue #5638/#5639 extend this job beyond session-open: after building
-  # the Integration-Server demo APK it runs FlutterTest (tap/type/text) via
-  # SHAFT.GUI.Locator.flutter* against the local emulator. Android_Native_BrowserStack
-  # also passes -Dshaft.enableFlutterE2E=true against the same freshly-built APK
-  # (copied from Flutter_Demo_App_Build). Historical caveat (#4303/#4294/#4308
-  # unwired checked-in APK) no longer applies. Runs on the scheduled nightly and
-  # on workflow_dispatch when selected (same if: pattern as sibling jobs).
-  # enableFlutterEmulatorE2E remains as a legacy dispatch input only.
-  # Flutter stays out of GLOBAL_TESTING_SCOPE.
-  Android_Flutter_Emulator_E2E:
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Flutter_Emulator_E2E,')
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    outputs:
-      job: ${{ steps.post_test_report.outputs.job }}
-      total: ${{ steps.post_test_report.outputs.total }}
-      passed: ${{ steps.post_test_report.outputs.passed }}
-      failed: ${{ steps.post_test_report.outputs.failed }}
-      broken: ${{ steps.post_test_report.outputs.broken }}
-      skipped: ${{ steps.post_test_report.outputs.skipped }}
-      duration: ${{ steps.post_test_report.outputs.duration }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7.0.1
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-      - name: Setup Test Environment
-        uses: ./.github/actions/setup-test-env
-        with:
-          java-version: '17'
-          node-version: '20'
-      - name: Setup Flutter 3.22.1
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          flutter-version: 3.22.1
-          channel: stable
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v4.0.1
-      - name: Checkout pinned appium-flutter-server demo-app
-        uses: actions/checkout@v7.0.1
-        with:
-          repository: AppiumTestDistribution/appium-flutter-server
-          # Pinned commit, verified current HEAD of main at ticket time (issue #4197) --
-          # never track a moving branch; there is no permanently-hosted prebuilt APK,
-          # the upstream project's own CI builds fresh from source every run too.
-          ref: 78ba97a6146091b944335d0db3330f74416f3ac7
-          path: appium-flutter-server
-          sparse-checkout: |
-            demo-app
-            server
-      - name: Build demo-app debug APK wired for the Appium Flutter Integration Server
-        # Recipe taken verbatim from appium-flutter-server's own
-        # .github/workflows/main.yml at the pinned commit -- their CI runs this
-        # exact sequence successfully today.
-        run: |
-          set -euo pipefail
-          cd appium-flutter-server/demo-app
-          dart pub global activate rps --version 0.8.0
-          bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 flutter build apk --debug
-          cd android && bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 ./gradlew app:assembleDebug -Ptarget="$(pwd)/../integration_test/appium.dart"
-      - name: Copy freshly-built APK into FlutterTest path
-        run: |
-          set -euo pipefail
-          APK_PATH="$GITHUB_WORKSPACE/appium-flutter-server/demo-app/build/app/outputs/apk/debug/app-debug.apk"
-          ls -l "$APK_PATH"
-          cp "$APK_PATH" shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk
-      - name: Install Appium and the Flutter Integration Driver
-        run: |
-          set -euo pipefail
-          npm install -g appium@3.5.2
-          appium driver install --source npm appium-flutter-integration-driver
-      - name: Set up JDK 25 for Maven
-        uses: actions/setup-java@v6
-        with:
-          java-version: '25'
-          distribution: 'zulu'
-      - name: Install engine dependencies for FlutterTest
-        run: >
-          bash scripts/ci/build_retry.sh 2 60
-          mvn -pl shaft-engine -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
-      - name: Boot emulator, open Flutter session, run FlutterTest tap/type/text
-        id: flutter_e2e
-        continue-on-error: true
-        uses: reactivecircus/android-emulator-runner@v2.38.0
-        with:
-          api-level: 30
-          target: google_apis
-          arch: x86_64
-          working-directory: ${{ github.workspace }}
-          script: |
-            # android-emulator-runner invokes this script with /usr/bin/sh (dash on
-            # ubuntu-latest). dash rejects bash-only -o options and exits 2 before Maven
-            # runs, so Post-Test Report then fails with missing Allure/JaCoCo (#5696).
-            set -eu
-            cd "$GITHUB_WORKSPACE"
-            APK_PATH="$GITHUB_WORKSPACE/shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk"
-            ls -l "$APK_PATH"
-            adb devices
-
-            # Appium server + Maven MUST share this step: a background server from an
-            # earlier step is torn down when that step's shell exits (issue #3806).
-            appiumLog="$RUNNER_TEMP/appium-server.log"
-            appium --address 127.0.0.1 --port 4723 --log-level info --log "$appiumLog" &
-            APPIUM_PID=$!
-            trap 'kill "$APPIUM_PID" 2>/dev/null || true' EXIT
-
-            ready=false
-            for i in $(seq 1 60); do
-              if curl --max-time 2 -fsS http://127.0.0.1:4723/status >/dev/null 2>&1; then
-                ready=true
-                break
-              fi
-              sleep 1
-            done
-            if [ "$ready" != true ]; then
-              echo "::error::Appium server did not become ready."
-              cat "$appiumLog" || true
-              exit 1
-            fi
-
-            # Session-open smoke (keeps the historical #4197 proof) before Maven.
-            SESSION_PAYLOAD=$(jq -n --arg app "$APK_PATH" '{capabilities: {alwaysMatch: {platformName: "Android", "appium:automationName": "FlutterIntegration", "appium:app": $app, "appium:noReset": true}}}')
-            RESPONSE=$(curl --max-time 120 -fsS -X POST -H "Content-Type: application/json" -d "$SESSION_PAYLOAD" http://127.0.0.1:4723/session)
-            echo "$RESPONSE"
-            SESSION_ID=$(echo "$RESPONSE" | jq -r '.value.sessionId // empty')
-            if [ -z "$SESSION_ID" ]; then
-              echo "::error::Appium session did not open -- no sessionId in response."
-              cat "$appiumLog" || true
-              exit 1
-            fi
-            echo "Appium Flutter session opened: $SESSION_ID"
-            curl --max-time 30 -fsS -X DELETE "http://127.0.0.1:4723/session/$SESSION_ID" || true
-
-            # Issue #5638: real tap/type/text via SHAFT.GUI.Locator.flutter*.
-            mvn -f "$GITHUB_WORKSPACE/pom.xml" -pl shaft-engine -e test \
-              "-Dtest=testPackage.appium.FlutterTest" \
-              "-Dshaft.enableFlutterE2E=true" \
-              "-DexecutionAddress=127.0.0.1:4723" \
-              "-Dmobile_app=src/test/resources/testDataFiles/apps/flutter-demo.apk" \
-              "-Dmobile_automationName=FlutterIntegration" \
-              "-DtargetOperatingSystem=android" \
-              "-DdefaultElementIdentificationTimeout=60" \
-              "-Dallure.automaticallyOpen=false" \
-              "-DheadlessExecution=true" \
-              "-DgenerateAllureReportArchive=true"
-            # Post-Test Report only reads shaft-engine/allure-results (#5721).
-            if [ ! -d "$GITHUB_WORKSPACE/shaft-engine/allure-results" ]; then
-              for d in "$PWD/shaft-engine/allure-results" "$PWD/allure-results" "$GITHUB_WORKSPACE/allure-results"; do
-                if [ -n "$(find "$d" -name '*-result.json' -type f -print -quit 2>/dev/null)" ]; then
-                  mkdir -p "$GITHUB_WORKSPACE/shaft-engine/allure-results"
-                  cp -a "$d"/. "$GITHUB_WORKSPACE/shaft-engine/allure-results/"
-                  break
-                fi
-              done
-            fi
-      - name: Upload Appium server log
-        if: always()
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: Android_Flutter_Emulator_E2E_appium_log
-          path: ${{ runner.temp }}/appium-server.log
-          if-no-files-found: ignore
-      - name: Post-Test Report and Check
-        id: post_test_report
-        if: always()
-        uses: ./.github/actions/post-test-report
-        with:
-          job-name: Android_Flutter_Emulator_E2E
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
-
   MacOSX_Safari_BrowserStack:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_BrowserStack,')
     runs-on: ubuntu-latest
@@ -1588,7 +1425,7 @@ jobs:
 
   notify_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, Android_Visual_Ocr_BrowserStack, iOS_Visual_Ocr_BrowserStack, Android_Recording_BrowserStack, iOS_Recording_BrowserStack, Android_Evidence_BrowserStack, iOS_Evidence_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, Android_Flutter_Emulator_E2E, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
+    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, Android_Flutter_BrowserStack, Android_Visual_Ocr_BrowserStack, iOS_Visual_Ocr_BrowserStack, Android_Recording_BrowserStack, iOS_Recording_BrowserStack, Android_Evidence_BrowserStack, iOS_Evidence_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/scripts/ci/flutter_emulator_preflight.sh
+++ b/scripts/ci/flutter_emulator_preflight.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Host checks for Ubuntu_Flutter_Emulator_Local. Must run before emulator-runner.
+# sdkmanager can prompt for the Android XR (extended reality) preview license even
+# when the AVD is a phone image; accept licenses non-interactively or the later
+# emulator-runner sdk step hangs.
+set -eu
+
+if [ ! -e /dev/kvm ]; then
+  echo "::error::KVM device /dev/kvm is missing; Flutter emulator E2E requires hardware virtualization."
+  exit 1
+fi
+if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules >/dev/null
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --name-match=kvm
+  sudo chmod 666 /dev/kvm || true
+fi
+if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+  echo "::error::KVM device /dev/kvm is not read/write for the runner user."
+  exit 1
+fi
+
+if ! command -v sdkmanager >/dev/null 2>&1; then
+  echo "::error::sdkmanager is not on PATH; Android SDK must be provisioned before Flutter emulator E2E."
+  exit 1
+fi
+
+yes | sdkmanager --licenses >/dev/null || true
+# Android XR preview packages ship a distinct license id; refusing it later
+# aborts google_apis system-image downloads used by emulator-runner.
+yes | sdkmanager --licenses >/dev/null || true
+
+if ! command -v adb >/dev/null 2>&1; then
+  echo "::error::adb is not on PATH after Android SDK setup."
+  exit 1
+fi
+adb start-server
+adb version
+
+if ! command -v appium >/dev/null 2>&1; then
+  npm install -g appium@3.5.2
+fi
+appium driver install --source npm appium-flutter-integration-driver
+
+echo "Flutter emulator preflight OK."

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -213,6 +213,7 @@ public class AndroidBasicInteractionsTests extends MobileTest {
     public void visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls() {
         By group1 = By.xpath("//android.widget.TextView[@text='Group 1']");
         By group18 = By.xpath("//android.widget.TextView[@text='Group 18']");
+        By list = By.className("android.widget.ExpandableListView");
         driver.get().touch()
                 .swipeElementIntoView(AppiumBy.accessibilityId("Views"), TouchActions.SwipeDirection.DOWN)
                 .tap(AppiumBy.accessibilityId("Views"))
@@ -220,16 +221,17 @@ public class AndroidBasicInteractionsTests extends MobileTest {
                 .tap(AppiumBy.accessibilityId("Expandable Lists"))
                 .tap(AppiumBy.accessibilityId("3. Simple Adapter"));
 
-        driver.get().touch().swipeElementIntoView(group18, TouchActions.SwipeDirection.DOWN);
+        driver.get().touch().swipeElementIntoView(list, group18, TouchActions.SwipeDirection.DOWN);
         Assert.assertTrue(driver.get().getDriver().findElement(group18).isDisplayed());
         byte[] group18Screenshot = driver.get().getDriver().findElement(group18).getScreenshotAs(OutputType.BYTES);
 
+        // Full-window UP hits the activity boundary before Group 1; scroll the list.
         // Tiny "Group 1" crops match many list rows under AUTO; OCR uniquely names Group 1.
-        driver.get().touch().swipeElementIntoView(OcrTarget.exact("Group 1"), TouchActions.SwipeDirection.UP);
+        driver.get().touch().swipeElementIntoView(list, OcrTarget.exact("Group 1"), TouchActions.SwipeDirection.UP);
         Assert.assertTrue(driver.get().getDriver().findElement(group1).isDisplayed());
 
         // Image proof uses the Group 18 crop captured while that row was visible.
-        driver.get().touch().swipeElementIntoView(
+        driver.get().touch().swipeElementIntoView(list,
                 ImageTarget.fromBytes(group18Screenshot).matchingMode(ImageMatchingMode.AUTO),
                 TouchActions.SwipeDirection.DOWN);
         Assert.assertTrue(driver.get().getDriver().findElement(group18).isDisplayed());
@@ -249,15 +251,12 @@ public class AndroidBasicInteractionsTests extends MobileTest {
                 .swipeElementIntoView(AppiumBy.accessibilityId("5. Scrollable"), TouchActions.SwipeDirection.DOWN)
                 .tap(AppiumBy.accessibilityId("5. Scrollable"));
 
-        byte[] tab1Screenshot = driver.get().getDriver().findElement(tab1).getScreenshotAs(OutputType.BYTES);
         driver.get().touch().swipeElementIntoView(tabs, tab12, TouchActions.SwipeDirection.RIGHT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab12).isDisplayed());
         byte[] tab12Screenshot = driver.get().getDriver().findElement(tab12).getScreenshotAs(OutputType.BYTES);
 
-        // Nightly LEFT image swipe already succeeded under AUTO; keep that proven path.
-        driver.get().touch().swipeElementIntoView(tabs,
-                ImageTarget.fromBytes(tab1Screenshot).matchingMode(ImageMatchingMode.AUTO),
-                TouchActions.SwipeDirection.LEFT);
+        // TAB 1 captured while selected does not match the unselected strip after leaving it.
+        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.exact("TAB 1"), TouchActions.SwipeDirection.LEFT);
         Assert.assertTrue(driver.get().getDriver().findElement(tab1).isDisplayed());
 
         // Exact OCR on short tab labels failed on BrowserStack; return with the selected-state tab12 crop.

--- a/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
@@ -57,6 +57,7 @@ public class IOSBasicInteractionsTest {
 
         driver.get().touch()
                 .tap(ImageTarget.fromBytes(inputScreenshot));
+        waitUntilKeyboardFocus(TEXT_INPUT);
         Assert.assertTrue(isAccessibilityFocused(TEXT_INPUT), "Image tap should focus Text Input");
 
         ((IOSDriver) driver.get().getDriver()).hideKeyboard();
@@ -191,10 +192,30 @@ public class IOSBasicInteractionsTest {
 
     }
 
-    /** XCUITest {@code switchTo().activeElement()} is getActiveElement with null locators. */
+    /** XCUITest keyboard focus is {@code hasKeyboardFocus}; {@code focused} is Android. */
     private boolean isAccessibilityFocused(By locator) {
-        String focused = driver.get().getDriver().findElement(locator).getAttribute("focused");
-        return "true".equalsIgnoreCase(focused) || "1".equals(focused);
+        var element = driver.get().getDriver().findElement(locator);
+        return isTruthyIosFlag(element.getAttribute("hasKeyboardFocus"))
+                || isTruthyIosFlag(element.getAttribute("focused"));
+    }
+
+    private void waitUntilKeyboardFocus(By locator) {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (isAccessibilityFocused(locator)) {
+                return;
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private static boolean isTruthyIosFlag(String value) {
+        return "true".equalsIgnoreCase(value) || "1".equals(value) || "yes".equalsIgnoreCase(value);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -84,9 +84,40 @@ class VisualOcrWorkflowTest(unittest.TestCase):
             self.assertIn('"${reports[@]}" --min-executed 1', verification)
             self.assertNotIn("TEST-testPackage.appium", verification)
 
-    def test_flutter_emulator_keeps_jdk17_for_apk_and_jdk25_for_maven(self):
+    def test_android_flutter_browserstack_is_sibling_not_mixed_into_native(self):
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
-        steps = workflow["jobs"]["Android_Flutter_Emulator_E2E"]["steps"]
+        self.assertNotIn("Android_Flutter_Emulator_E2E", workflow["jobs"])
+        self.assertNotIn("enableFlutterEmulatorE2E", workflow.get("on", {}).get("workflow_dispatch", {}).get("inputs", {}))
+        native = workflow["jobs"]["Android_Native_BrowserStack"]
+        flutter = workflow["jobs"]["Android_Flutter_BrowserStack"]
+        self.assertEqual("Flutter_Demo_App_Build", flutter["needs"])
+        build_if = workflow["jobs"]["Flutter_Demo_App_Build"]["if"]
+        self.assertIn(",Android_Flutter_BrowserStack,", build_if)
+        self.assertIn(",Android_Native_BrowserStack,", build_if)
+        flutter_run = next(step["run"] for step in flutter["steps"] if "-Dtest=" in step.get("run", ""))
+        native_run = next(step["run"] for step in native["steps"] if "-Dtest=" in step.get("run", ""))
+        self.assertIn("-Dshaft.enableFlutterE2E=true", flutter_run)
+        self.assertIn("-DexecutionAddress=browserstack", flutter_run)
+        self.assertIn("-Dmobile_automationName=FlutterIntegration", flutter_run)
+        self.assertIn("Google Pixel 7", flutter_run)
+        self.assertIn("13.0", flutter_run)
+        self.assertIn("-DbrowserStack.appUrl=", flutter_run)
+        self.assertIn("-DdefaultElementIdentificationTimeout=60", flutter_run)
+        self.assertIn("-DretryMaximumNumberOfAttempts=2", flutter_run)
+        self.assertIn("FlutterTest", flutter_run)
+        self.assertIn("github.event.inputs.tests", flutter_run)
+        self.assertNotIn("-Dshaft.enableFlutterE2E=true", native_run)
+        self.assertNotIn("%regex[.*FlutterTest.*]", native_run)
+        self.assertIn("Android_Flutter_BrowserStack", workflow["jobs"]["Workflow_Summary"]["needs"])
+        self.assertIn("Android_Flutter_BrowserStack", workflow["jobs"]["notify_e2e_tests_failure"]["needs"])
+        self.assertNotIn("Android_Flutter_Emulator_E2E", workflow["jobs"]["Workflow_Summary"]["needs"])
+        wire = next(step["run"] for step in flutter["steps"]
+                    if "flutter-demo.apk" in step.get("run", "") and "cp " in step.get("run", ""))
+        self.assertIn("shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk", wire)
+
+    def test_flutter_emulator_keeps_jdk17_for_apk_and_jdk25_for_maven(self):
+        workflow = yaml.safe_load(LOCAL_WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["Ubuntu_Flutter_Emulator_Local"]["steps"]
         env_step = next(step for step in steps if step.get("name") == "Setup Test Environment")
         self.assertEqual("17", env_step["with"]["java-version"])
         maven_jdk = next(step for step in steps if step.get("name") == "Set up JDK 25 for Maven")
@@ -96,10 +127,12 @@ class VisualOcrWorkflowTest(unittest.TestCase):
                         names.index("Set up JDK 25 for Maven"))
         self.assertLess(names.index("Set up JDK 25 for Maven"),
                         names.index("Install engine dependencies for FlutterTest"))
+        self.assertLess(names.index("Flutter emulator preflight"),
+                        names.index("Boot emulator, open Flutter session, run FlutterTest tap/type/text"))
 
     def test_flutter_emulator_script_avoids_pipefail_under_dash(self):
-        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
-        steps = workflow["jobs"]["Android_Flutter_Emulator_E2E"]["steps"]
+        workflow = yaml.safe_load(LOCAL_WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["Ubuntu_Flutter_Emulator_Local"]["steps"]
         emulator = next(step for step in steps if step.get("uses", "").startswith(
             "reactivecircus/android-emulator-runner@"))
         script = emulator["with"]["script"]
@@ -110,6 +143,25 @@ class VisualOcrWorkflowTest(unittest.TestCase):
         self.assertIn("-Dallure.automaticallyOpen=false", script)
         self.assertIn("-DheadlessExecution=true", script)
         self.assertIn("shaft-engine/allure-results", script)
+        self.assertIn("127.0.0.1:4723", script)
+
+    def test_ubuntu_flutter_emulator_local_is_scheduled_like_windows_chrome(self):
+        workflow = yaml.safe_load(LOCAL_WORKFLOW.read_text(encoding="utf-8"))
+        chrome_if = workflow["jobs"]["Windows_Chrome_Local"]["if"]
+        flutter_if = workflow["jobs"]["Ubuntu_Flutter_Emulator_Local"]["if"]
+        self.assertEqual(chrome_if.replace("Windows_Chrome_Local", "JOB"),
+                         flutter_if.replace("Ubuntu_Flutter_Emulator_Local", "JOB"))
+        self.assertIn("Ubuntu_Flutter_Emulator_Local", workflow["jobs"]["Workflow_Summary"]["needs"])
+        self.assertIn("Ubuntu_Flutter_Emulator_Local",
+                      workflow["jobs"]["notify_local_e2e_tests_failure"]["needs"])
+        preflight = (ROOT / "scripts" / "ci" / "flutter_emulator_preflight.sh").read_text(encoding="utf-8")
+        self.assertIn("/dev/kvm", preflight)
+        self.assertIn("sdkmanager", preflight)
+        self.assertIn("Android XR", preflight)
+        self.assertIn("appium-flutter-integration-driver", preflight)
+        self.assertIn("adb", preflight)
+        names = [step.get("name") for step in workflow["jobs"]["Ubuntu_Flutter_Emulator_Local"]["steps"]]
+        self.assertIn("Flutter emulator preflight", names)
 
     def test_ios_visual_ocr_uses_shared_locators_and_opens_text_screen(self):
         ios_tests = IOS_TESTS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Nightly **E2E Tests** run `FlutterTest` on **`Android_Flutter_BrowserStack`** (wired APK from `Flutter_Demo_App_Build`, FlutterIntegration). Local AVD is no longer on that workflow.
- **Local E2E Tests** gain scheduled **`Ubuntu_Flutter_Emulator_Local`** with `scripts/ci/flutter_emulator_preflight.sh` (KVM, SDK licenses including the Android XR trap, Appium flutter-integration-driver).
- Android visual OCR swipes inside `ExpandableListView` / uses OCR for unselected TAB 1. iOS image-tap waits for `hasKeyboardFocus`.

Closes #5741
Closes #5743

## Checks

- `python3 -m unittest tests.scripts.test_visual_ocr_workflow` (10 tests, OK)
- Did not launch scheduled E2E / Local E2E

## Continuation

Watch PR checks to merge. Terminal adversarial review after CI/comment triage.