### PR TITLE
fix(agents): prefer gh; never default GitHub MCP

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,5 +6,5 @@ Follow `AGENTS.md` as the canonical repository policy.
 - Preserve unrelated work and never expose secrets or claim unverified remote
   results.
 <!-- CHAOSENGINE:START -->
-Before every task, follow the canonical [ChaosEngine](../.chaos-engine/skills/chaos-engine/SKILL.md). Use `../.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. No duplicate GitHub MCP. Repair: disable extras in host MCP config.
+Before every task, follow the canonical [ChaosEngine](../.chaos-engine/skills/chaos-engine/SKILL.md). Use `../.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. Leave an existing GitHub MCP config unchanged.
 <!-- CHAOSENGINE:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,5 +45,5 @@ Learning Session skip. Research/explore isolation follows
   `py -3 scripts/ci/validate_agent_setup.py --skip-external` and the smallest
   directly affected tests. Inspect result artifacts rather than banners alone.
 <!-- CHAOSENGINE:START -->
-Before every task, follow the canonical [ChaosEngine](.chaos-engine/skills/chaos-engine/SKILL.md). Use `.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. No duplicate GitHub MCP. Repair: disable extras in host MCP config.
+Before every task, follow the canonical [ChaosEngine](.chaos-engine/skills/chaos-engine/SKILL.md). Use `.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. Leave an existing GitHub MCP config unchanged.
 <!-- CHAOSENGINE:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
 @AGENTS.md
 <!-- CHAOSENGINE:START -->
-Before every task, follow the canonical [ChaosEngine](.chaos-engine/skills/chaos-engine/SKILL.md). Use `.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. No duplicate GitHub MCP. Repair: disable extras in host MCP config.
+Before every task, follow the canonical [ChaosEngine](.chaos-engine/skills/chaos-engine/SKILL.md). Use `.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. Leave an existing GitHub MCP config unchanged.
 <!-- CHAOSENGINE:END -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,3 @@
 <!-- CHAOSENGINE:START -->
-Before every task, follow the canonical [ChaosEngine](.chaos-engine/skills/chaos-engine/SKILL.md). Use `.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. No duplicate GitHub MCP. Repair: disable extras in host MCP config.
+Before every task, follow the canonical [ChaosEngine](.chaos-engine/skills/chaos-engine/SKILL.md). Use `.chaos-engine/tool.py` for the project-local Memory, MemPalace, and Graphify tools. Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. Leave an existing GitHub MCP config unchanged.
 <!-- CHAOSENGINE:END -->

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -191,8 +191,8 @@ MCP alias pairs and non-owned host hook probes (for example Grok trust/loaded
 hooks, or a failed runtime hook probe when owned hook files are present) nest
 under `hostEnvironment` as `sync-advisory` findings with the existing heal
 prompt; they do not flip install-owned `hooks` / `mcps` to `recovery-required`
-and do not cause CE-INSTALL-FAILED. Project-overlay GitHub MCP duplicates still
-fail doctor (#5698). Memory, MemPalace, and Graphify are advisory to ordinary
+and do not cause CE-INSTALL-FAILED. Default MCP catalogs never include GitHub MCP; prefer `gh`. An existing GitHub
+MCP server is left unchanged and does not fail doctor. Memory, MemPalace, and Graphify are advisory to ordinary
 tasks but remain strict in `doctor`; an unhealthy selected store still returns
 `recovery-required`. Maven Tools MCP is auto-installed when the project has a
 root `pom.xml`. On non-Maven projects it stays optional and absent does not make

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -1937,7 +1937,8 @@ def instruction_block(tree: str = INSTALLED_TREE) -> str:
         f"{START}\nBefore every task, follow the canonical "
         f"[ChaosEngine]({skill}). "
         f"Use `{tool}` for the project-local Memory, MemPalace, and Graphify tools. "
-        "No duplicate GitHub MCP. Repair: disable extras in host MCP config.\n"
+        "Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. "
+        "Leave an existing GitHub MCP config unchanged.\n"
         f"{END}\n"
     )
 
@@ -3836,6 +3837,11 @@ def json_content(
         account_commands=account_commands,
         maven_docker=maven_docker,
     )
+    desired = {
+        name: server
+        for name, server in desired.items()
+        if str(name).strip().casefold() not in {"github", "github-gh", "github_gh"}
+    }
     snippet = json.dumps({"mcpServers": desired}, indent=2, sort_keys=True) + "\n"
     try:
         value = json.loads(before.decode("utf-8")) if before is not None else {}
@@ -3857,6 +3863,8 @@ def json_content(
         ):
             del servers[legacy_name]
     for name, server in desired.items():
+        if str(name).strip().casefold() in {"github", "github-gh", "github_gh"}:
+            continue
         if name in servers and not replaceable_owned_server(name, servers[name], server):
             _note_merge_handoff(
                 relative,

--- a/chaos-engine/mcp_policy.py
+++ b/chaos-engine/mcp_policy.py
@@ -9,18 +9,20 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 
-ALIAS_GROUPS: tuple[frozenset[str], ...] = (
-    frozenset({"github", "github-gh", "github_gh"}),
-)
+GITHUB_MCP_IDS = frozenset({"github", "github-gh", "github_gh"})
 
-# When a CLI is the owned client, these MCP server ids must not be enabled.
+# GitHub MCP is never a default catalog entry. Presence of an existing GitHub
+# MCP server is not a uniqueness conflict: leave it unchanged. Graphify MCP
+# still conflicts with the owned Graphify CLI.
+ALIAS_GROUPS: tuple[frozenset[str], ...] = ()
+
 CLI_OWNED_MCP: dict[str, frozenset[str]] = {
-    "github": frozenset({"github", "github-gh", "github_gh"}),
     "graphify": frozenset({"graphify", "graphifyy"}),
 }
 
 HEAL_PROMPT = (
-    "No duplicate GitHub MCP. Repair: disable extras in host MCP config."
+    "Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. "
+    "Leave an existing GitHub MCP config unchanged."
 )
 
 _SERVER_HEADER = re.compile(
@@ -47,6 +49,19 @@ def duplicate_groups(server_ids: Iterable[str]) -> list[tuple[str, ...]]:
     return found
 
 
+def is_github_mcp_id(name: str) -> bool:
+    return str(name).strip().casefold() in GITHUB_MCP_IDS
+
+
+def omit_github_from_defaults(servers: dict[str, object]) -> dict[str, object]:
+    """Default install catalog must never publish GitHub MCP ids."""
+    return {
+        key: value
+        for key, value in servers.items()
+        if not is_github_mcp_id(str(key))
+    }
+
+
 def uniqueness_error(server_ids: Iterable[str]) -> str | None:
     cli_error = cli_owned_conflict_error(server_ids)
     if cli_error:
@@ -59,7 +74,7 @@ def uniqueness_error(server_ids: Iterable[str]) -> str | None:
 
 
 def cli_owned_conflict_error(server_ids: Iterable[str]) -> str | None:
-    """Fail when an MCP duplicates an owned CLI (gh, graphify)."""
+    """Fail when an MCP duplicates an owned CLI (Graphify). GitHub MCP is never defaulted and is left in place if already configured."""
     names = {str(item).strip().casefold() for item in server_ids if str(item).strip()}
     seen: list[str] = []
     for owned, aliases in CLI_OWNED_MCP.items():

--- a/chaos-engine/references/work-github-playbook.md
+++ b/chaos-engine/references/work-github-playbook.md
@@ -3,6 +3,10 @@
 A session-shaped method for taking an issue from filed to merged. Load
 the canonical ChaosEngine entrypoint alongside this playbook. Start with [planning and tracking](work-github-planning.md), then return here for delivery.
 
+GitHub writes use `gh` (`issue create`, `pr create`, comments, labels). Never
+GitHub MCP for those jobs. Default ChaosEngine MCP catalogs never include
+GitHub MCP. If a host already has GitHub MCP, leave it unchanged.
+
 ## 4. Implement, check, review, deliver
 
 Rule every open design choice on the issue before the first implementing commit;

--- a/chaos-engine/references/zero-llm-catalog.md
+++ b/chaos-engine/references/zero-llm-catalog.md
@@ -52,7 +52,7 @@ Prefer training-data CLIs over MCP schema tax when both can do the job:
 
 | Job | Prefer CLI | Avoid when CLI exists |
 | --- | --- | --- |
-| GitHub issues/PRs/checks | `gh` | GitHub MCP for the same call |
+| GitHub issues/PRs/checks | `gh` | GitHub MCP for the same call. Default install never publishes GitHub MCP. If a host already has GitHub MCP, leave it; still prefer `gh`. |
 | Learning queue/metrics | `learning.py` / `learning_session.py` | MCP wrappers around the same files |
 | Install health / repair | `install.py doctor|repair` / `--fix-next-only` | Chat discovery of doctor |
 | Delivery phase ledger | `phase_ledger.py` | MCP phase bookkeeping |

--- a/tests/scripts/test_chaos_engine_host_parity_5698.py
+++ b/tests/scripts/test_chaos_engine_host_parity_5698.py
@@ -146,19 +146,21 @@ class HostParity5698Tests(unittest.TestCase):
             source,
         )
 
-    def test_cli_owned_github_and_graphify_mcp_are_refused(self):
-        for server in ("github", "github-gh", "github_gh", "graphify"):
+    def test_cli_owned_graphify_mcp_is_refused_github_mcp_is_left_in_place(self):
+        for server in ("github", "github-gh", "github_gh"):
             with self.subTest(server=server):
-                error = self.policy.cli_owned_conflict_error([server])
-                self.assertIsNotNone(error)
-                self.assertIn("No duplicate GitHub MCP", error)
+                self.assertIsNone(self.policy.cli_owned_conflict_error([server]))
+        error = self.policy.cli_owned_conflict_error(["graphify"])
+        self.assertIsNotNone(error)
+        self.assertIn("Prefer gh for GitHub", error)
         self.assertIsNone(self.policy.cli_owned_conflict_error(["maven-tools-mcp"]))
         self.assertEqual(
             self.policy.HEAL_PROMPT,
-            "No duplicate GitHub MCP. Repair: disable extras in host MCP config.",
+            "Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. "
+            "Leave an existing GitHub MCP config unchanged.",
         )
 
-    def test_doctor_collects_cli_owned_conflict_from_temp_mcp(self):
+    def test_existing_github_mcp_in_project_overlay_does_not_conflict(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             (project / ".mcp.json").write_text(
@@ -166,9 +168,20 @@ class HostParity5698Tests(unittest.TestCase):
                 encoding="utf-8",
             )
             ids = self.policy.collect_server_ids(project, home=project / "home")
-            error = self.policy.cli_owned_conflict_error(ids)
-            self.assertIsNotNone(error)
-            self.assertIn("github", error.casefold())
+            self.assertIsNone(self.policy.cli_owned_conflict_error(ids))
+            self.assertIsNone(self.policy.project_mcp_policy_error(project))
+
+    def test_default_owned_servers_never_include_github_mcp(self):
+        servers = self.hosts.owned_servers()
+        for name in servers:
+            self.assertFalse(self.policy.is_github_mcp_id(name), name)
+        before = json.dumps(
+            {"mcpServers": {"github": {"command": "npx"}, "keep-me": {"command": "echo"}}}
+        ).encode()
+        after = json.loads(self.hosts.json_content(before).decode("utf-8"))
+        self.assertEqual({"command": "npx"}, after["mcpServers"]["github"])
+        self.assertIn("chaosengine-memory", after["mcpServers"])
+        self.assertNotIn("github-gh", self.hosts.owned_servers())
 
     def test_instruction_block_matches_heal_prompt(self):
         block = self.hosts.instruction_block("chaos-engine")

--- a/tests/scripts/test_chaos_engine_install_verify_5699.py
+++ b/tests/scripts/test_chaos_engine_install_verify_5699.py
@@ -152,15 +152,11 @@ class InstallVerifyHealth5699Tests(unittest.TestCase):
                 "sync-advisory",
                 hooks.get("hostEnvironment", {}).get("status"),
             )
-            self.assertEqual(
-                "sync-advisory",
-                mcps.get("hostEnvironment", {}).get("status"),
-            )
-            self.assertEqual(POLICY.HEAL_PROMPT, mcps["hostEnvironment"]["fixNext"])
+            self.assertNotEqual("recovery-required", mcps.get("status"))
             self.assertFalse(BOOTSTRAP._required_install_unhealthy(doctor))
             rendered = INSTALL.format_health_report(doctor, kind="doctor")
-            self.assertIn("hostEnvironment", rendered)
-            self.assertIn(POLICY.HEAL_PROMPT, rendered)
+            self.assertIn("Prefer gh for GitHub", POLICY.HEAL_PROMPT)
+            self.assertNotIn("recovery-required", rendered.lower() or "healthy")
             self.assertTrue((project / ".chaos-engine/hooks/guard.py").is_file())
             self.assertTrue((project / ".mcp.json").is_file())
 
@@ -190,7 +186,7 @@ class InstallVerifyHealth5699Tests(unittest.TestCase):
         self.assertTrue(BOOTSTRAP._required_install_unhealthy(missing_hook))
         self.assertTrue(BOOTSTRAP._required_install_unhealthy(missing_mcp))
 
-    def test_project_level_github_mcp_still_fails_doctor(self):
+    def test_project_level_github_mcp_is_left_unchanged_and_does_not_fail_doctor(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             (project / ".mcp.json").write_text(
@@ -205,9 +201,7 @@ class InstallVerifyHealth5699Tests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            error = POLICY.project_mcp_policy_error(project)
-            self.assertIsNotNone(error)
-            self.assertIn("github", error.casefold())
+            self.assertIsNone(POLICY.project_mcp_policy_error(project))
 
             doctor = {
                 "status": "healthy",
@@ -217,10 +211,9 @@ class InstallVerifyHealth5699Tests(unittest.TestCase):
             }
             INSTALL.apply_mcp_policy_doctor(doctor, doctor["components"], project, POLICY)
             mcps = doctor["components"]["mcps"]
-            self.assertEqual("recovery-required", mcps["status"])
-            self.assertEqual(POLICY.HEAL_PROMPT, mcps.get("fixNext"))
-            self.assertEqual("recovery-required", doctor["status"])
-            self.assertTrue(BOOTSTRAP._required_install_unhealthy(doctor))
+            self.assertEqual("healthy", mcps["status"])
+            self.assertEqual("healthy", doctor["status"])
+            self.assertFalse(BOOTSTRAP._required_install_unhealthy(doctor))
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_chaos_engine_token_max.py
+++ b/tests/scripts/test_chaos_engine_token_max.py
@@ -111,20 +111,18 @@ class TokenMaxTests(TestCase):
         cls.retrieve = load(ROOT / "chaos-engine/retrieve.py", "ce_retrieve_5689")
         cls.hosts = load(ROOT / "chaos-engine/hosts.py", "ce_hosts_5689")
 
-    def test_github_alias_pair_is_duplicate(self):
-        error = self.policy.uniqueness_error(["github", "github-gh"])
-        self.assertIsNotNone(error)
-        self.assertIn("disable extras", error)
+    def test_github_alias_pair_is_left_in_place(self):
+        self.assertIsNone(self.policy.uniqueness_error(["github", "github-gh"]))
 
-    def test_single_github_or_graphify_mcp_conflicts_with_owned_cli(self):
-        for server in ("github", "graphify"):
-            error = self.policy.cli_owned_conflict_error([server])
-            self.assertIsNotNone(error)
-            self.assertIn("No duplicate GitHub MCP", error)
+    def test_graphify_mcp_conflicts_with_owned_cli_github_does_not(self):
+        self.assertIsNone(self.policy.cli_owned_conflict_error(["github"]))
+        error = self.policy.cli_owned_conflict_error(["graphify"])
+        self.assertIsNotNone(error)
+        self.assertIn("Prefer gh for GitHub", error)
 
     def test_user_and_project_ids_share_one_heal_prompt(self):
         text = (ROOT / "chaos-engine/hosts.py").read_text(encoding="utf-8")
-        self.assertIn("disable extras in host MCP config", text)
+        self.assertIn("Leave an existing GitHub MCP config unchanged", text)
         self.assertIn(".chaos-engine/", self.hosts.instruction_block("chaos-engine"))
         self.assertIn(".chaos-engine/", self.hosts.instruction_block(".chaos-engine"))
         self.assertEqual(
@@ -133,7 +131,8 @@ class TokenMaxTests(TestCase):
         )
         self.assertEqual(
             self.policy.HEAL_PROMPT,
-            "No duplicate GitHub MCP. Repair: disable extras in host MCP config.",
+            "Prefer gh for GitHub. Default MCP catalog never includes GitHub MCP. "
+            "Leave an existing GitHub MCP config unchanged.",
         )
         self.assertIn(self.policy.HEAL_PROMPT, self.hosts.instruction_block(".chaos-engine"))
 


### PR DESCRIPTION
## Summary

- Prefer `gh` for GitHub issues, PRs, comments, and labels.
- Default install MCP catalogs never include GitHub MCP.
- If GitHub MCP is already configured, leave it unchanged (no doctor fail, no disable).

## Checks

- `python3 -m unittest tests.scripts.test_chaos_engine_token_max tests.scripts.test_chaos_engine_host_parity_5698 tests.scripts.test_chaos_engine_install_verify_5699` (25 OK)

## Continuation

Arm merge after PR Gate.